### PR TITLE
Add navigation `FragmentActivity` launcher to `:platform:navigation-test`

### DIFF
--- a/platform/navigation-test/build.gradle.kts
+++ b/platform/navigation-test/build.gradle.kts
@@ -26,7 +26,9 @@ android {
 }
 
 dependencies {
+  androidTestImplementation(project(":platform:testing"))
   androidTestImplementation(libs.android.fragment.testing)
+  androidTestImplementation(libs.android.test.junit)
   androidTestImplementation(libs.android.test.runner)
   androidTestImplementation(libs.kotlin.test)
 

--- a/platform/navigation-test/src/androidTest/java/com/jeanbarrossilva/orca/platform/navigation/test/activity/ActivityScenarioExtensionsTests.kt
+++ b/platform/navigation-test/src/androidTest/java/com/jeanbarrossilva/orca/platform/navigation/test/activity/ActivityScenarioExtensionsTests.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2024 Orca
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package com.jeanbarrossilva.orca.platform.navigation.test.activity
+
+import com.jeanbarrossilva.orca.platform.navigation.navigator
+import com.jeanbarrossilva.orca.platform.testing.activity.scenario.activity
+import kotlin.test.Test
+
+internal class ActivityScenarioExtensionsTests {
+  @Test
+  fun getsNavigatorFromNavigationActivity() {
+    launchNavigationActivity().use { it.activity?.navigator }
+  }
+}

--- a/platform/navigation-test/src/androidTest/java/com/jeanbarrossilva/orca/platform/navigation/test/activity/FragmentActivityExtensionsTests.kt
+++ b/platform/navigation-test/src/androidTest/java/com/jeanbarrossilva/orca/platform/navigation/test/activity/FragmentActivityExtensionsTests.kt
@@ -17,7 +17,6 @@ package com.jeanbarrossilva.orca.platform.navigation.test.activity
 
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import com.jeanbarrossilva.orca.platform.navigation.navigator
-import com.jeanbarrossilva.orca.platform.testing.activity.scenario.activity
 import kotlin.test.Test
 import org.junit.Rule
 
@@ -26,8 +25,9 @@ internal class FragmentActivityExtensionsTests {
 
   @Test
   fun getsNavigatorWhenMadeNavigable() {
-    checkNotNull(activityScenarioRule.scenario.activity)
-      .apply(NavigationActivity::makeNavigable)
-      .navigator
+    activityScenarioRule.scenario.onActivity {
+      it.makeNavigable()
+      it.navigator
+    }
   }
 }

--- a/platform/navigation-test/src/androidTest/java/com/jeanbarrossilva/orca/platform/navigation/test/activity/FragmentActivityExtensionsTests.kt
+++ b/platform/navigation-test/src/androidTest/java/com/jeanbarrossilva/orca/platform/navigation/test/activity/FragmentActivityExtensionsTests.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2024 Orca
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package com.jeanbarrossilva.orca.platform.navigation.test.activity
+
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import com.jeanbarrossilva.orca.platform.navigation.navigator
+import com.jeanbarrossilva.orca.platform.testing.activity.scenario.activity
+import kotlin.test.Test
+import org.junit.Rule
+
+internal class FragmentActivityExtensionsTests {
+  @get:Rule val activityScenarioRule = ActivityScenarioRule(NavigationActivity::class.java)
+
+  @Test
+  fun getsNavigatorWhenMadeNavigable() {
+    checkNotNull(activityScenarioRule.scenario.activity)
+      .apply(NavigationActivity::makeNavigable)
+      .navigator
+  }
+}

--- a/platform/navigation-test/src/main/AndroidManifest.xml
+++ b/platform/navigation-test/src/main/AndroidManifest.xml
@@ -14,4 +14,8 @@
   ~ not, see https://www.gnu.org/licenses.
   -->
 
-<manifest />
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application>
+        <activity android:name=".activity.NavigationActivity" />
+    </application>
+</manifest>

--- a/platform/navigation-test/src/main/java/com/jeanbarrossilva/orca/platform/navigation/test/activity/ActivityScenario.extensions.kt
+++ b/platform/navigation-test/src/main/java/com/jeanbarrossilva/orca/platform/navigation/test/activity/ActivityScenario.extensions.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2024 Orca
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package com.jeanbarrossilva.orca.platform.navigation.test.activity
+
+import androidx.fragment.app.FragmentActivity
+import androidx.fragment.app.FragmentContainerView
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.launchActivity
+import com.jeanbarrossilva.orca.platform.navigation.Navigator
+
+/**
+ * Launches a [FragmentActivity] whose content is a [FragmentContainerView], which allows for its
+ * [Navigator] to be obtained.
+ */
+fun launchNavigationActivity(): ActivityScenario<FragmentActivity> {
+  @Suppress("UNCHECKED_CAST")
+  return launchActivity<NavigationActivity>().onActivity(FragmentActivity::makeNavigable)
+    as ActivityScenario<FragmentActivity>
+}

--- a/platform/navigation-test/src/main/java/com/jeanbarrossilva/orca/platform/navigation/test/activity/FragmentActivity.extensions.kt
+++ b/platform/navigation-test/src/main/java/com/jeanbarrossilva/orca/platform/navigation/test/activity/FragmentActivity.extensions.kt
@@ -13,29 +13,21 @@
  * not, see https://www.gnu.org/licenses.
  */
 
-package com.jeanbarrossilva.orca.platform.navigation.test.fragment
+package com.jeanbarrossilva.orca.platform.navigation.test.activity
 
-import androidx.fragment.app.Fragment
+import android.view.View
 import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.FragmentContainerView
-import androidx.fragment.app.testing.FragmentScenario
-import androidx.fragment.app.testing.launchFragmentInContainer
 import com.jeanbarrossilva.orca.platform.navigation.Navigator
 import com.jeanbarrossilva.orca.platform.navigation.navigator
-import com.jeanbarrossilva.orca.platform.navigation.test.activity.makeNavigable
 
 /**
- * Launches the specified [Fragment] in a [FragmentActivity] whose content is a
- * [FragmentContainerView], which, in turn, allows for its [Navigator] to be obtained.
+ * Allows for this [FragmentActivity]'s [Navigator] to be obtained by overriding its content and
+ * setting it as a [FragmentContainerView].
  *
- * @param T [Fragment] to be launched.
- * @param instantiate Creates an instance of the [Fragment] to be launched.
  * @see navigator
  */
-inline fun <reified T : Fragment> launchFragmentInNavigationContainer(
-  crossinline instantiate: () -> T
-): FragmentScenario<T> {
-  return launchFragmentInContainer(instantiate = instantiate).onFragment {
-    it.activity?.makeNavigable()
-  }
+@PublishedApi
+internal fun FragmentActivity.makeNavigable() {
+  FragmentContainerView(this).apply { id = View.generateViewId() }.run(::setContentView)
 }

--- a/platform/navigation-test/src/main/java/com/jeanbarrossilva/orca/platform/navigation/test/activity/NavigationActivity.kt
+++ b/platform/navigation-test/src/main/java/com/jeanbarrossilva/orca/platform/navigation/test/activity/NavigationActivity.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2024 Orca
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package com.jeanbarrossilva.orca.platform.navigation.test.activity
+
+import androidx.fragment.app.FragmentActivity
+
+/** [FragmentActivity] that is launched by [launchNavigationActivity]. */
+internal class NavigationActivity : FragmentActivity()


### PR DESCRIPTION
Adds [`launchNavigationActivity`](https://github.com/orcinusbr/orca-android/blob/6888bcbcc45568c314999a960a859c9e4969acdf/platform/navigation-test/src/main/java/com/jeanbarrossilva/orca/platform/navigation/test/activity/ActivityScenario.extensions.kt#L28).