### PR TITLE
Add onboarding template to `:platform:autos`

### DIFF
--- a/platform/autos/src/main/java/com/jeanbarrossilva/orca/platform/autos/template/onboarding/Onboarding.kt
+++ b/platform/autos/src/main/java/com/jeanbarrossilva/orca/platform/autos/template/onboarding/Onboarding.kt
@@ -1,0 +1,148 @@
+/*
+ * Copyright © 2024 Orca
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package com.jeanbarrossilva.orca.platform.autos.template.onboarding
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ProvideTextStyle
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.jeanbarrossilva.orca.platform.autos.colors.asColor
+import com.jeanbarrossilva.orca.platform.autos.iconography.asImageVector
+import com.jeanbarrossilva.orca.platform.autos.kit.action.button.PrimaryButton
+import com.jeanbarrossilva.orca.platform.autos.kit.action.button.SecondaryButton
+import com.jeanbarrossilva.orca.platform.autos.kit.scaffold.Scaffold
+import com.jeanbarrossilva.orca.platform.autos.kit.scaffold.bar.button.ButtonBar
+import com.jeanbarrossilva.orca.platform.autos.kit.scaffold.plus
+import com.jeanbarrossilva.orca.platform.autos.theme.AutosTheme
+import com.jeanbarrossilva.orca.platform.autos.theme.MultiThemePreview
+
+/** Type of content contained by an [Onboarding]. */
+@Immutable
+private enum class OnboardingContentType {
+  /** Type of an [Onboarding] illustration. */
+  Illustration,
+
+  /** Type of an [Onboarding] headline. */
+  Headline,
+
+  /**
+   * Type of the empty content of an [Onboarding] used to separate the illustration from the
+   * headline.
+   *
+   * @see Illustration
+   * @see Headline
+   */
+  Spacer
+}
+
+/**
+ * Template for introducing a feature.
+ *
+ * @param illustration Visual representation that facilitates the understanding of what the [title]
+ *   and the [description] explain.
+ * @param title Exposes the overall idea, generally by resuming what the feature does or the outcome
+ *   of using it for the user.
+ * @param description Provides more details on the subject being presented, expanding on what the
+ *   [title] says.
+ * @param modifier [Modifier] for the underlying [LazyColumn].
+ * @param contentPadding Padding to be applied to the shown content.
+ */
+@Composable
+fun Onboarding(
+  illustration: @Composable () -> Unit,
+  title: @Composable () -> Unit,
+  description: @Composable () -> Unit,
+  modifier: Modifier = Modifier,
+  contentPadding: PaddingValues = PaddingValues(0.dp)
+) {
+  val spacing = AutosTheme.spacings.large.dp
+
+  LazyColumn(
+    modifier.fillMaxHeight(),
+    verticalArrangement = Arrangement.SpaceBetween,
+    horizontalAlignment = Alignment.CenterHorizontally,
+    contentPadding = contentPadding + PaddingValues(spacing)
+  ) {
+    item(contentType = OnboardingContentType.Spacer) {}
+    item(contentType = OnboardingContentType.Illustration) { illustration() }
+    item(contentType = OnboardingContentType.Spacer) {}
+
+    item(contentType = OnboardingContentType.Headline) {
+      Column(verticalArrangement = Arrangement.spacedBy(spacing)) {
+        ProvideTextStyle(AutosTheme.typography.headlineLarge, title)
+        ProvideTextStyle(AutosTheme.typography.headlineSmall, description)
+      }
+    }
+  }
+}
+
+/** Preview of an [Onboarding]. */
+@Composable
+@MultiThemePreview
+private fun OnboardingPreview() {
+  AutosTheme {
+    val leadingBackdropColor = AutosTheme.colors.activation.favorite.asColor
+    val trailingBackdropColor = AutosTheme.colors.activation.reposted.asColor
+
+    Scaffold(
+      bottom = {
+        ButtonBar {
+          PrimaryButton(onClick = {}) { Text("Continue") }
+          SecondaryButton(onClick = {}) { Text("Go back") }
+        }
+      }
+    ) {
+      expanded {
+        Onboarding(
+          illustration = {
+            Box(contentAlignment = Alignment.Center) {
+              Canvas(Modifier.matchParentSize()) {
+                drawCircle(leadingBackdropColor, center = center / 2f)
+                drawCircle(trailingBackdropColor, center = center * 1.5f)
+              }
+
+              Icon(
+                AutosTheme.iconography.home.filled.asImageVector,
+                contentDescription = "Illustration",
+                Modifier.size(128.dp)
+              )
+            }
+          },
+          title = { Text("Greatest feature of all") },
+          description = {
+            Text(
+              "And then here goes a very detailed description of it: what it is, what and who it " +
+                "is for, what it does..."
+            )
+          },
+          contentPadding = it
+        )
+      }
+    }
+  }
+}

--- a/platform/autos/src/main/res/values/themes.xml
+++ b/platform/autos/src/main/res/values/themes.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright © 2023 Orca
+  ~ Copyright © 2023-2024 Orca
   ~
   ~ This program is free software: you can redistribute it and/or modify it under the terms of the
   ~ GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -68,6 +68,7 @@
         <item name="textAppearanceBodySmall">@style/Theme.Orca.Typography.BodySmall</item>
         <item name="textAppearanceHeadlineLarge">@style/Theme.Orca.Typography.HeadlineLarge</item>
         <item name="textAppearanceHeadlineMedium">@style/Theme.Orca.Typography.HeadlineMedium</item>
+        <item name="textAppearanceHeadlineSmall">@style/Theme.Orca.Typography.HeadlineSmall</item>
         <item name="textAppearanceLabelLarge">@style/Theme.Orca.Typography.LabelLarge</item>
         <item name="textAppearanceLabelMedium">@style/Theme.Orca.Typography.LabelMedium</item>
         <item name="textAppearanceTitleLarge">@style/Theme.Orca.Typography.TitleLarge</item>

--- a/platform/autos/src/main/res/values/typography.xml
+++ b/platform/autos/src/main/res/values/typography.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright © 2023 Orca
+  ~ Copyright © 2023-2024 Orca
   ~
   ~ This program is free software: you can redistribute it and/or modify it under the terms of the
   ~ GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -36,6 +36,14 @@
         <item name="android:textColor">@color/secondary</item>
         <item name="android:textFontWeight">@integer/font_weight_medium</item>
         <item name="android:textSize">20sp</item>
+    </style>
+
+    <style
+        name="Theme.Orca.Typography.HeadlineSmall"
+        parent="TextAppearance.Material3.HeadlineSmall">
+        <item name="android:textColor">@color/secondary</item>
+        <item name="android:textSize">18sp</item>
+        <item name="lineHeight">26sp</item>
     </style>
 
     <style


### PR DESCRIPTION
Adds a template for explaining how features work.

<img src="https://github.com/orcinusbr/orca-android/assets/38408390/a7729c1c-0d06-4a29-9f0c-1a528eae0a61" width="256" />
<img src="https://github.com/orcinusbr/orca-android/assets/38408390/3e7bc275-9adb-4aac-a201-90746c150cfc" width="256" />
