### PR TITLE
Add `args` param to `launchFragmentInNavigationContainer`

### DIFF
--- a/platform/navigation-test/src/androidTest/java/br/com/orcinus/orca/platform/navigation/test/fragment/FragmentScenarioExtensionsTests.kt
+++ b/platform/navigation-test/src/androidTest/java/br/com/orcinus/orca/platform/navigation/test/fragment/FragmentScenarioExtensionsTests.kt
@@ -15,14 +15,25 @@
 
 package br.com.orcinus.orca.platform.navigation.test.fragment
 
+import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
+import assertk.assertThat
+import assertk.assertions.isSameAs
 import br.com.orcinus.orca.platform.navigation.navigator
 import kotlin.test.Test
 
 internal class FragmentScenarioExtensionsTests {
   @Test
+  fun launchesFragmentInNavigationContainerWithArguments() {
+    val args = bundleOf("id" to 0)
+    launchFragmentInNavigationContainer(args, ::Fragment).use { scenario ->
+      scenario.onFragment { fragment -> assertThat(fragment.arguments).isSameAs(args) }
+    }
+  }
+
+  @Test
   fun getsNavigatorFromContainerActivity() {
-    launchFragmentInNavigationContainer(::Fragment).use { scenario ->
+    launchFragmentInNavigationContainer(instantiate = ::Fragment).use { scenario ->
       scenario.onFragment { fragment -> fragment.requireActivity().navigator }
     }
   }

--- a/platform/navigation-test/src/main/java/br/com/orcinus/orca/platform/navigation/test/fragment/FragmentScenario.extensions.kt
+++ b/platform/navigation-test/src/main/java/br/com/orcinus/orca/platform/navigation/test/fragment/FragmentScenario.extensions.kt
@@ -15,6 +15,7 @@
 
 package br.com.orcinus.orca.platform.navigation.test.fragment
 
+import android.os.Bundle
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.FragmentContainerView
@@ -29,13 +30,15 @@ import br.com.orcinus.orca.platform.navigation.test.activity.makeNavigable
  * [FragmentContainerView], which, in turn, allows for its [Navigator] to be obtained.
  *
  * @param T [Fragment] to be launched.
+ * @param args [Bundle] containing the arguments for the [Fragment].
  * @param instantiate Creates an instance of the [Fragment] to be launched.
  * @see navigator
  */
 inline fun <reified T : Fragment> launchFragmentInNavigationContainer(
+  args: Bundle? = null,
   crossinline instantiate: () -> T
 ): FragmentScenario<T> {
-  return launchFragmentInContainer(instantiate = instantiate).onFragment {
+  return launchFragmentInContainer(args, instantiate = instantiate).onFragment {
     it.activity?.makeNavigable()
   }
 }


### PR DESCRIPTION
Allows for arguments to passed into the [`Fragment`](https://developer.android.com/reference/android/app/Fragment) to be launched in a navigation container from [`:platform:navigation-test`](https://github.com/orcinusbr/orca-android/tree/25352e8ab99033513ad4b03c11ee1108d7d6325a/platform/navigation-test).