### PR TITLE
Internalize `StackScope.contents(): List<@Composable () -> Unit>`

### DIFF
--- a/platform/stack/src/main/java/br/com/orcinus/orca/platform/stack/StackScope.kt
+++ b/platform/stack/src/main/java/br/com/orcinus/orca/platform/stack/StackScope.kt
@@ -23,11 +23,6 @@ class StackScope internal constructor() {
   /** Contents that have been added onto the [Stack]. */
   private val contents = mutableStateListOf<@Composable () -> Unit>()
 
-  /** Gets an immutable [List] containing the contents that have been added onto the [Stack]. */
-  fun contents(): List<@Composable () -> Unit> {
-    return contents.toList()
-  }
-
   /**
    * Adds an item onto the [Stack].
    *
@@ -35,5 +30,10 @@ class StackScope internal constructor() {
    */
   fun item(content: @Composable () -> Unit) {
     contents.add(content)
+  }
+
+  /** Gets an immutable [List] containing the contents that have been added onto the [Stack]. */
+  internal fun contents(): List<@Composable () -> Unit> {
+    return contents.toList()
   }
 }


### PR DESCRIPTION
Makes [`StackScope.contents(): List<@Composable () -> Unit>`](https://github.com/orcinusbr/orca-android/blob/f0ed32f75b6efa8bc6b7e1e8bd16a4949b69252e/platform/stack/src/main/java/br/com/orcinus/orca/platform/stack/StackScope.kt#L36) internal, as it shouldn't be accessed from outside the module.