### PR TITLE
Add immediately delayed timing to `:platform:animator`

### DIFF
--- a/platform/animator/src/main/java/br/com/orcinus/orca/platform/animator/Animator.kt
+++ b/platform/animator/src/main/java/br/com/orcinus/orca/platform/animator/Animator.kt
@@ -59,6 +59,17 @@ import br.com.orcinus.orca.platform.animator.animation.timing.immediately
  * }
  * ```
  *
+ * There might also be cases in which [Composable]s should simply be shown [after] a certain amount
+ * of time on their own, unbound from any other animations. Such behavior could be achieved with the
+ * following:
+ * ```kotlin
+ * Animator { (greeting) ->
+ *   emoji.Animate(fadeIn(), after(2.seconds)) {
+ *     Text("Hello, world!")
+ *   }
+ * }
+ * ```
+ *
  * Note that this [Composable], [Animator], serves merely as an entrypoint to the overall API and
  * doesn't have any intrinsic behavior other than just showing the [content] and providing a
  * remembered instance of [Animatables] to it.

--- a/platform/animator/src/main/java/br/com/orcinus/orca/platform/animator/animation/timing/Timing.extensions.kt
+++ b/platform/animator/src/main/java/br/com/orcinus/orca/platform/animator/animation/timing/Timing.extensions.kt
@@ -16,10 +16,20 @@
 package br.com.orcinus.orca.platform.animator.animation.timing
 
 import br.com.orcinus.orca.platform.animator.animation.animatable.Animatable
+import kotlin.time.Duration
 
 /** [Timing] that indicates that an animation should be run immediately. */
 fun immediately(): Timing {
   return Timing.Immediate()
+}
+
+/**
+ * [Timing] that indicates that an animation should be run after the given amount of time.
+ *
+ * @param delay [Duration] to wait for before animating.
+ */
+fun after(delay: Duration): Timing {
+  return Timing.Immediate(delay)
 }
 
 /**

--- a/platform/animator/src/main/java/br/com/orcinus/orca/platform/animator/animation/timing/Timing.extensions.kt
+++ b/platform/animator/src/main/java/br/com/orcinus/orca/platform/animator/animation/timing/Timing.extensions.kt
@@ -26,7 +26,7 @@ fun immediately(): Timing {
 /**
  * [Timing] that indicates that an animation should be run after the given amount of time.
  *
- * @param delay [Duration] to wait for before animating.
+ * @param delay [Duration] to wait for before the animation runs.
  */
 fun after(delay: Duration): Timing {
   return Timing.Immediate(delay)

--- a/platform/animator/src/main/java/br/com/orcinus/orca/platform/animator/animation/timing/Timing.kt
+++ b/platform/animator/src/main/java/br/com/orcinus/orca/platform/animator/animation/timing/Timing.kt
@@ -26,7 +26,11 @@ sealed class Timing {
   internal abstract val delay: Duration
 
   /** Indicates that an animation should be run immediately. */
-  internal data class Immediate(override val delay: Duration = Duration.ZERO) : Timing()
+  internal data class Immediate(override val delay: Duration = Duration.ZERO) : Timing() {
+    override fun plus(delay: Duration): Timing {
+      return Immediate(delay)
+    }
+  }
 
   /**
    * Indicates that an animation should be run after the given [animatable] has finished animating.
@@ -38,12 +42,7 @@ sealed class Timing {
     private val animatable: Animatable,
     override val delay: Duration = Duration.ZERO
   ) : Timing() {
-    /**
-     * Indicates that the animation should only be run after the given amount of time.
-     *
-     * @param delay [Duration] to be waited for before the animation runs.
-     */
-    operator fun plus(delay: Duration): Timing {
+    override fun plus(delay: Duration): Timing {
       return Sequential(animatable, delay)
     }
 
@@ -52,6 +51,9 @@ sealed class Timing {
       super.time()
     }
   }
+
+  /** Indicates that the animation should only be run after the given amount of time. */
+  abstract operator fun plus(delay: Duration): Timing
 
   /**
    * Suspends until the condition specified by this [Timing] for the animation to be run is

--- a/platform/animator/src/main/java/br/com/orcinus/orca/platform/animator/animation/timing/Timing.kt
+++ b/platform/animator/src/main/java/br/com/orcinus/orca/platform/animator/animation/timing/Timing.kt
@@ -26,11 +26,7 @@ sealed class Timing {
   internal abstract val delay: Duration
 
   /** Indicates that an animation should be run immediately. */
-  internal data class Immediate(override val delay: Duration = Duration.ZERO) : Timing() {
-    override fun plus(delay: Duration): Timing {
-      return Immediate(delay)
-    }
-  }
+  internal data class Immediate(override val delay: Duration = Duration.ZERO) : Timing()
 
   /**
    * Indicates that an animation should be run after the given [animatable] has finished animating.
@@ -42,7 +38,12 @@ sealed class Timing {
     private val animatable: Animatable,
     override val delay: Duration = Duration.ZERO
   ) : Timing() {
-    override fun plus(delay: Duration): Timing {
+    /**
+     * Indicates that the animation should only be run after the given amount of time.
+     *
+     * @param delay [Duration] to be waited for before the animation runs.
+     */
+    operator fun plus(delay: Duration): Timing {
       return Sequential(animatable, delay)
     }
 
@@ -51,9 +52,6 @@ sealed class Timing {
       super.time()
     }
   }
-
-  /** Indicates that the animation should only be run after the given amount of time. */
-  abstract operator fun plus(delay: Duration): Timing
 
   /**
    * Suspends until the condition specified by this [Timing] for the animation to be run is

--- a/platform/animator/src/main/java/br/com/orcinus/orca/platform/animator/animation/timing/Timing.kt
+++ b/platform/animator/src/main/java/br/com/orcinus/orca/platform/animator/animation/timing/Timing.kt
@@ -52,7 +52,11 @@ sealed class Timing {
     }
   }
 
-  /** Indicates that the animation should only be run after the given amount of time. */
+  /**
+   * Indicates that the animation should only be run after the given amount of time.
+   *
+   * @param delay [Duration] to wait for before the animation runs.
+   */
   abstract operator fun plus(delay: Duration): Timing
 
   /**

--- a/platform/animator/src/test/java/br/com/orcinus/orca/platform/animator/animation/timing/TimingExtensionsTests.kt
+++ b/platform/animator/src/test/java/br/com/orcinus/orca/platform/animator/animation/timing/TimingExtensionsTests.kt
@@ -19,11 +19,17 @@ import assertk.assertThat
 import assertk.assertions.isEqualTo
 import br.com.orcinus.orca.platform.animator.animation.animatable.Animatable
 import kotlin.test.Test
+import kotlin.time.Duration.Companion.seconds
 
-internal class AnimatableScopeExtensionsTests {
+internal class TimingExtensionsTests {
   @Test
   fun createsImmediateTiming() {
     assertThat(immediately()).isEqualTo(Timing.Immediate())
+  }
+
+  @Test
+  fun createsDelayedTiming() {
+    assertThat(after(2.seconds)).isEqualTo(Timing.Immediate(delay = 2.seconds))
   }
 
   @Test


### PR DESCRIPTION
Adds [`after(Duration): Timing`](https://github.com/orcinusbr/orca-android/blob/1824d2b9d9da40027bd8d2c61cc4d397d78486fc/platform/animator/src/main/java/br/com/orcinus/orca/platform/animator/animation/timing/Timing.extensions.kt#L31), which defines that an animation should be run independently, but after a given delay.