### PR TITLE
Add account registration to `:core`

### DIFF
--- a/core/sample/src/main/java/br/com/orcinus/orca/core/sample/instance/SampleInstance.kt
+++ b/core/sample/src/main/java/br/com/orcinus/orca/core/sample/instance/SampleInstance.kt
@@ -41,7 +41,7 @@ import br.com.orcinus.orca.std.image.SomeImageLoaderProvider
  *
  * @param imageLoaderProvider [ImageLoader.Provider] that provides the [ImageLoader] by which images
  *   will be loaded from a [SampleImageSource].
- * @param posts [Post]s that are provided by default by the [postProvider].
+ * @param defaultPosts [Post]s that are provided by default by the [postProvider].
  */
 class SampleInstance
 internal constructor(

--- a/core/sample/src/main/java/br/com/orcinus/orca/core/sample/instance/registration/Credentials.extensions.kt
+++ b/core/sample/src/main/java/br/com/orcinus/orca/core/sample/instance/registration/Credentials.extensions.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2024 Orcinus
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package br.com.orcinus.orca.core.sample.instance.registration
+
+import br.com.orcinus.orca.core.instance.registration.Credentials
+
+/** [Credentials] returned by [Credentials.Companion.sample]. */
+private val sampleCredentials = Credentials("jean@orcinus.com.br", "password123")
+
+/** Sample [Credentials]. */
+val Credentials.Companion.sample
+  get() = sampleCredentials

--- a/core/sample/src/main/java/br/com/orcinus/orca/core/sample/instance/registration/SampleRegistrar.kt
+++ b/core/sample/src/main/java/br/com/orcinus/orca/core/sample/instance/registration/SampleRegistrar.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2024 Orcinus
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package br.com.orcinus.orca.core.sample.instance.registration
+
+import br.com.orcinus.orca.core.instance.Instance
+import br.com.orcinus.orca.core.instance.domain.Domain
+import br.com.orcinus.orca.core.instance.registration.Credentials
+import br.com.orcinus.orca.core.instance.registration.Registrar
+import br.com.orcinus.orca.core.instance.registration.Registration
+import br.com.orcinus.orca.core.sample.instance.domain.sample
+import br.com.orcinus.orca.core.sample.instance.domain.samples
+
+/**
+ * [Registrar] that emits a successful [Registration] for the sample [Instance]'s [Domain].
+ *
+ * @see Instance.Companion.createSample
+ * @see Instance.domain
+ */
+internal object SampleRegistrar : Registrar() {
+  override val domains = Domain.samples
+
+  override suspend fun register(credentials: Credentials, domain: Domain): Boolean {
+    return domain == Domain.sample
+  }
+}

--- a/core/sample/src/test/java/br/com/orcinus/orca/core/sample/instance/registration/SampleRegistrarTests.kt
+++ b/core/sample/src/test/java/br/com/orcinus/orca/core/sample/instance/registration/SampleRegistrarTests.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2024 Orcinus
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package br.com.orcinus.orca.core.sample.instance.registration
+
+import assertk.assertThat
+import assertk.assertions.isTrue
+import br.com.orcinus.orca.core.instance.domain.Domain
+import br.com.orcinus.orca.core.instance.registration.Credentials
+import br.com.orcinus.orca.core.sample.instance.domain.sample
+import kotlin.test.Test
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.single
+import kotlinx.coroutines.test.runTest
+
+internal class SampleRegistrarTests {
+  @Test
+  fun registrationSucceedsInSampleInstance() {
+    runTest {
+      assertThat(
+          SampleRegistrar.register(Credentials.sample.email, Credentials.sample.password)
+            .filter { it.domain == Domain.sample }
+            .single()
+            .hasSucceeded
+        )
+        .isTrue()
+    }
+  }
+}

--- a/core/src/main/java/br/com/orcinus/orca/core/instance/registration/Credentials.kt
+++ b/core/src/main/java/br/com/orcinus/orca/core/instance/registration/Credentials.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2024 Orcinus
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package br.com.orcinus.orca.core.instance.registration
+
+import br.com.orcinus.orca.core.feed.profile.account.Account
+import br.com.orcinus.orca.core.instance.Instance
+import br.com.orcinus.orca.std.styledstring.style.type.Email
+
+/**
+ * Information with which an [Account] can be registered or logged into.
+ *
+ * @param email E-mail address. When registering an [Account], ideally would be one that hasn't yet
+ *   been used by anyone else in the [Instance].
+ * @param password Private key that provides access to the [Account] alongside the [email].
+ * @throws BlankPasswordException If the [password] is blank.
+ * @throws InvalidEmailException If the [email] is invalid.
+ * @see Registrar.register
+ */
+data class Credentials
+@Throws(BlankPasswordException::class, InvalidEmailException::class)
+constructor(val email: String, val password: String) {
+  /** [IllegalArgumentException] thrown if the [email] is not a valid one. */
+  inner class InvalidEmailException internal constructor() :
+    IllegalArgumentException("\"$email\" isn't a valid e-mail.")
+
+  /** [IllegalArgumentException] thrown if the [password] is blank. */
+  inner class BlankPasswordException internal constructor() :
+    IllegalArgumentException("Password cannot be blank.")
+
+  init {
+    ensureEmailValidity()
+    ensurePasswordNonBlankness()
+  }
+
+  /**
+   * Ensures that the [email] is a valid one, matching it against the [Email.regex].
+   *
+   * @throws InvalidEmailException If the [email] is invalid.
+   */
+  @Throws(InvalidEmailException::class)
+  private fun ensureEmailValidity() {
+    val isEmailInvalid = !Email.regex.matches(email)
+    if (isEmailInvalid) {
+      throw InvalidEmailException()
+    }
+  }
+
+  /**
+   * Ensures that the [password] isn't blank.
+   *
+   * @throws BlankPasswordException If the [password] is blank.
+   */
+  @Throws(BlankPasswordException::class)
+  private fun ensurePasswordNonBlankness() {
+    val isPasswordBlank = password.isBlank()
+    if (isPasswordBlank) {
+      throw BlankPasswordException()
+    }
+  }
+}

--- a/core/src/main/java/br/com/orcinus/orca/core/instance/registration/Credentials.kt
+++ b/core/src/main/java/br/com/orcinus/orca/core/instance/registration/Credentials.kt
@@ -23,7 +23,8 @@ import br.com.orcinus.orca.std.styledstring.style.type.Email
  * Information with which an [Account] can be registered or logged into.
  *
  * @param email E-mail address. When registering an [Account], ideally would be one that hasn't yet
- *   been used by anyone else in the [Instance].
+ *   been used by anyone else in the [Instance] when registering, and an existing one when logging
+ *   in.
  * @param password Private key that provides access to the [Account] alongside the [email].
  * @throws BlankPasswordException If the [password] is blank.
  * @throws InvalidEmailException If the [email] is invalid.
@@ -70,4 +71,6 @@ constructor(val email: String, val password: String) {
       throw BlankPasswordException()
     }
   }
+
+  companion object
 }

--- a/core/src/main/java/br/com/orcinus/orca/core/instance/registration/Credentials.kt
+++ b/core/src/main/java/br/com/orcinus/orca/core/instance/registration/Credentials.kt
@@ -42,7 +42,7 @@ constructor(val email: String, val password: String) {
     IllegalArgumentException("\"$email\" isn't a valid e-mail.")
 
   /** [IllegalArgumentException] thrown if the [password] is blank. */
-  inner class BlankPasswordException internal constructor() :
+  class BlankPasswordException internal constructor() :
     IllegalArgumentException("Password cannot be blank.")
 
   init {

--- a/core/src/main/java/br/com/orcinus/orca/core/instance/registration/Credentials.kt
+++ b/core/src/main/java/br/com/orcinus/orca/core/instance/registration/Credentials.kt
@@ -33,8 +33,12 @@ import br.com.orcinus.orca.std.styledstring.style.type.Email
 data class Credentials
 @Throws(BlankPasswordException::class, InvalidEmailException::class)
 constructor(val email: String, val password: String) {
-  /** [IllegalArgumentException] thrown if the [email] is not a valid one. */
-  inner class InvalidEmailException internal constructor() :
+  /**
+   * [IllegalArgumentException] thrown if the [email] is not a valid one.
+   *
+   * @param email E-mail that is invalid.
+   */
+  class InvalidEmailException internal constructor(email: String) :
     IllegalArgumentException("\"$email\" isn't a valid e-mail.")
 
   /** [IllegalArgumentException] thrown if the [password] is blank. */
@@ -55,7 +59,7 @@ constructor(val email: String, val password: String) {
   private fun ensureEmailValidity() {
     val isEmailInvalid = !Email.regex.matches(email)
     if (isEmailInvalid) {
-      throw InvalidEmailException()
+      throw InvalidEmailException(email)
     }
   }
 

--- a/core/src/main/java/br/com/orcinus/orca/core/instance/registration/Registrar.kt
+++ b/core/src/main/java/br/com/orcinus/orca/core/instance/registration/Registrar.kt
@@ -47,7 +47,7 @@ abstract class Registrar {
    * @see FlowCollector.emit
    */
   @Throws(Credentials.BlankPasswordException::class, Credentials.InvalidEmailException::class)
-  suspend fun register(email: String, password: String): Flow<Registration> {
+  fun register(email: String, password: String): Flow<Registration> {
     return flow {
       val domainIterator = domains.iterator()
       val credentials = Credentials(email, password)

--- a/core/src/main/java/br/com/orcinus/orca/core/instance/registration/Registrar.kt
+++ b/core/src/main/java/br/com/orcinus/orca/core/instance/registration/Registrar.kt
@@ -36,17 +36,19 @@ abstract class Registrar {
    * Iterates through each of the [Instance]s' [Domain]s that are known by this [Registrar] and
    * tries to register an [Account] in one that is available.
    *
+   * **NOTE**: Collecting the resulting [Flow] with an invalid [email] will cause a
+   * [Credentials.InvalidEmailException] to be thrown. Conversely, if the [password] is blank, a
+   * [Credentials.BlankPasswordException] will be thrown.
+   *
    * @param email E-mail address. Ideally would be one that hasn't yet been used by anyone else in
    *   the [Instance].
    * @param password Private key that provides access to the [Account] alongside the [email].
    * @return [Flow] to which the results of registration attempts are emitted. By design, if any of
    *   them is successful, no subsequent [Registration]s are emitted to the returned [Flow].
-   * @throws Credentials.BlankPasswordException If the [password] is blank.
-   * @throws Credentials.InvalidEmailException If the [email] is invalid.
    * @see Instance.domain
    * @see FlowCollector.emit
+   * @see Flow.collect
    */
-  @Throws(Credentials.BlankPasswordException::class, Credentials.InvalidEmailException::class)
   fun register(email: String, password: String): Flow<Registration> {
     return flow {
       val domainIterator = domains.iterator()

--- a/core/src/main/java/br/com/orcinus/orca/core/instance/registration/Registrar.kt
+++ b/core/src/main/java/br/com/orcinus/orca/core/instance/registration/Registrar.kt
@@ -41,13 +41,16 @@ abstract class Registrar {
    * @param password Private key that provides access to the [Account] alongside the [email].
    * @return [Flow] to which the results of registration attempts are emitted. By design, if any of
    *   them is successful, no subsequent [Registration]s are emitted to the returned [Flow].
+   * @throws Credentials.BlankPasswordException If the [password] is blank.
+   * @throws Credentials.InvalidEmailException If the [email] is invalid.
    * @see Instance.domain
    * @see FlowCollector.emit
    */
+  @Throws(Credentials.BlankPasswordException::class, Credentials.InvalidEmailException::class)
   suspend fun register(email: String, password: String): Flow<Registration> {
     return flow {
-      val credentials = Credentials(email, password)
       val domainIterator = domains.iterator()
+      val credentials = Credentials(email, password)
       var hasSucceeded = false
       while (!hasSucceeded && domainIterator.hasNext()) {
         val domain = domainIterator.next()

--- a/core/src/main/java/br/com/orcinus/orca/core/instance/registration/Registrar.kt
+++ b/core/src/main/java/br/com/orcinus/orca/core/instance/registration/Registrar.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2024 Orcinus
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package br.com.orcinus.orca.core.instance.registration
+
+import br.com.orcinus.orca.core.feed.profile.account.Account
+import br.com.orcinus.orca.core.instance.Instance
+import br.com.orcinus.orca.core.instance.domain.Domain
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.flow
+
+/**
+ * Attempts to register an [Account] in an [Instance] that is both known by the implementation and
+ * available.
+ *
+ * @see register
+ */
+abstract class Registrar {
+  /** [Domain]s of the [Instance]s in which registration can be attempted to be performed. */
+  protected abstract val domains: List<Domain>
+
+  /**
+   * Iterates through each of the [Instance]s' [Domain]s that are known by this [Registrar] and
+   * tries to register an [Account] in one that is available.
+   *
+   * @param email E-mail address. Ideally would be one that hasn't yet been used by anyone else in
+   *   the [Instance].
+   * @param password Private key that provides access to the [Account] alongside the [email].
+   * @return [Flow] to which the results of registration attempts are emitted. By design, if any of
+   *   them is successful, no subsequent [Registration]s are emitted to the returned [Flow].
+   * @see Instance.domain
+   * @see FlowCollector.emit
+   */
+  suspend fun register(email: String, password: String): Flow<Registration> {
+    return flow {
+      val credentials = Credentials(email, password)
+      val domainIterator = domains.iterator()
+      var hasSucceeded = false
+      while (!hasSucceeded && domainIterator.hasNext()) {
+        val domain = domainIterator.next()
+        hasSucceeded = register(credentials, domain)
+        emit(Registration(domain, hasSucceeded))
+      }
+    }
+  }
+
+  /**
+   * Attempts to register an [Account] in the [Instance] that has the specified [domain].
+   *
+   * @param credentials [Credentials] for accessing the [Account].
+   * @param domain [Domain] of the [Instance] in which registration is being tried.
+   * @return `true` if the [Account] has been registered in the [Instance]; otherwise, `false`.
+   * @see Instance.domain
+   */
+  protected abstract suspend fun register(credentials: Credentials, domain: Domain): Boolean
+}

--- a/core/src/main/java/br/com/orcinus/orca/core/instance/registration/Registration.kt
+++ b/core/src/main/java/br/com/orcinus/orca/core/instance/registration/Registration.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2024 Orcinus
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package br.com.orcinus.orca.core.instance.registration
+
+import br.com.orcinus.orca.core.feed.profile.account.Account
+import br.com.orcinus.orca.core.instance.Instance
+import br.com.orcinus.orca.core.instance.domain.Domain
+
+/**
+ * Result of an attempt to register an [Account].
+ *
+ * @param domain [Domain] of the [Instance] at which registration was tried.
+ * @param hasSucceeded Whether registration has been performed successfully.
+ */
+data class Registration internal constructor(val domain: Domain, val hasSucceeded: Boolean)

--- a/core/src/test/java/br/com/orcinus/orca/core/instance/registration/CredentialsTests.kt
+++ b/core/src/test/java/br/com/orcinus/orca/core/instance/registration/CredentialsTests.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2024 Orcinus
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package br.com.orcinus.orca.core.instance.registration
+
+import kotlin.test.Test
+
+internal class CredentialsTests {
+  @Test(expected = Credentials.InvalidEmailException::class)
+  fun throwsWhenEmailIsInvalid() {
+    Credentials("alo@@ola.com", "password123")
+  }
+
+  @Test(expected = Credentials.BlankPasswordException::class)
+  fun throwsWhenPasswordIsEmpty() {
+    Credentials("jean@orcinus.com.br", " ")
+  }
+
+  @Test
+  fun doesNotThrowsWhenEmailIsValidAndPasswordIsNotBlank() {
+    Credentials("jean@orcinus.com.br", "password123")
+  }
+}

--- a/core/src/test/java/br/com/orcinus/orca/core/instance/registration/CredentialsTests.kt
+++ b/core/src/test/java/br/com/orcinus/orca/core/instance/registration/CredentialsTests.kt
@@ -29,7 +29,7 @@ internal class CredentialsTests {
   }
 
   @Test
-  fun doesNotThrowsWhenEmailIsValidAndPasswordIsNotBlank() {
+  fun doesNotThrowWhenEmailIsValidAndPasswordIsNotBlank() {
     Credentials("jean@orcinus.com.br", "password123")
   }
 }

--- a/core/src/test/java/br/com/orcinus/orca/core/instance/registration/RegistrarTests.kt
+++ b/core/src/test/java/br/com/orcinus/orca/core/instance/registration/RegistrarTests.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright © 2024 Orcinus
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package br.com.orcinus.orca.core.instance.registration
+
+import app.cash.turbine.test
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
+import br.com.orcinus.orca.core.instance.domain.Domain
+import br.com.orcinus.orca.core.sample.instance.domain.sample
+import br.com.orcinus.orca.core.sample.instance.domain.samples
+import br.com.orcinus.orca.core.sample.instance.registration.sample
+import kotlin.test.Test
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.test.runTest
+
+internal class RegistrarTests {
+  @Test
+  fun emitsFailedRegistrationWhenInstancesAreUnavailable() {
+    runTest {
+      object : Registrar() {
+          override val domains = listOf(Domain.sample)
+
+          override suspend fun register(credentials: Credentials, domain: Domain): Boolean {
+            return false
+          }
+        }
+        .register(Credentials.sample.email, Credentials.sample.password)
+        .test {
+          assertThat(awaitItem().hasSucceeded).isFalse()
+          awaitComplete()
+        }
+    }
+  }
+
+  @Test
+  fun emitsSuccessfulRegistrationWhenAnInstanceIsAvailable() {
+    runTest {
+      object : Registrar() {
+          override val domains = Domain.samples.take(2)
+
+          override suspend fun register(credentials: Credentials, domain: Domain): Boolean {
+            return domain == domains.last()
+          }
+        }
+        .register(Credentials.sample.email, Credentials.sample.password)
+        .test {
+          assertThat(awaitItem().hasSucceeded).isFalse()
+          assertThat(awaitItem().hasSucceeded).isTrue()
+          awaitComplete()
+        }
+    }
+  }
+
+  @Test
+  fun attemptsToRegisterAtEachInstanceWhenNoneIsAvailable() {
+    runTest {
+      object : Registrar() {
+          override val domains = Domain.samples
+
+          override suspend fun register(credentials: Credentials, domain: Domain): Boolean {
+            return false
+          }
+        }
+        .register(Credentials.sample.email, Credentials.sample.password)
+        .test {
+          Domain.samples.forEach { assertThat(awaitItem().domain).isEqualTo(it) }
+          awaitComplete()
+        }
+    }
+  }
+
+  @Test
+  fun doesNotPerformRegistrationAttemptsAfterSuccessfulOne() {
+    var attemptCount = 0
+    runTest {
+      object : Registrar() {
+          override val domains = Domain.samples.take(2)
+
+          override suspend fun register(credentials: Credentials, domain: Domain): Boolean {
+            attemptCount++
+            return domain == domains.first()
+          }
+        }
+        .register(Credentials.sample.email, Credentials.sample.password)
+        .collect()
+    }
+    assertThat(attemptCount).isEqualTo(1)
+  }
+}

--- a/std/styled-string/src/main/java/br/com/orcinus/orca/std/styledstring/style/type/Email.kt
+++ b/std/styled-string/src/main/java/br/com/orcinus/orca/std/styledstring/style/type/Email.kt
@@ -25,7 +25,7 @@ data class Email(override val indices: IntRange) : Style {
 
   companion object {
     /** [Regex] that matches an [Email]. */
-    internal val regex =
+    val regex =
       Regex(
         "(?:[a-z0-9!#\$%&'*+/=?^_`{|}~-]+(?:\\.[a-z0-9!#\$%&'*+/=?^_`{|}~-]+)*|\"(?:[\\x01-\\x08" +
           "\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-" +


### PR DESCRIPTION
Adds [`Registrar`](https://github.com/orcinusbr/orca-android/blob/a08b792e5d5ae827eb9039d7082a07045beb06eb/core/src/main/java/br/com/orcinus/orca/core/instance/registration/Registrar.kt), which is responsible for registrating an account in one of its known instances that is available.