### PR TITLE
Package-protect core APIs

### DIFF
--- a/core-module/src/main/java/br/com/orcinus/orca/core/module/CoreModule.kt
+++ b/core-module/src/main/java/br/com/orcinus/orca/core/module/CoreModule.kt
@@ -15,6 +15,7 @@
 
 package br.com.orcinus.orca.core.module
 
+import br.com.orcinus.orca.core.InternalCoreApi
 import br.com.orcinus.orca.core.auth.AuthenticationLock
 import br.com.orcinus.orca.core.auth.SomeAuthenticationLock
 import br.com.orcinus.orca.core.auth.actor.Actor
@@ -34,7 +35,9 @@ import br.com.orcinus.orca.std.injector.module.injection.Injection
  *   functionality behind a "wall".
  * @param termMuter [TermMuter] by which terms will be muted.
  */
-open class CoreModule(
+open class CoreModule
+@InternalCoreApi
+constructor(
   @Inject internal val instanceProvider: Injection<InstanceProvider>,
   @Inject internal val authenticationLock: Injection<SomeAuthenticationLock>,
   @Inject internal val termMuter: Injection<TermMuter>

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023-2024 Orcinus
+ * Copyright © 2023–2024 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -27,6 +27,7 @@ dependencies {
 
   implementation(project(":ext:coroutines"))
   implementation(project(":std:buildable"))
+  implementation(project(":std:visibility"))
 
   ksp(project(":std:buildable-processor"))
 

--- a/core/src/main/java/br/com/orcinus/orca/core/InternalCoreApi.kt
+++ b/core/src/main/java/br/com/orcinus/orca/core/InternalCoreApi.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023–2024 Orcinus
+ * Copyright © 2024 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -13,13 +13,13 @@
  * not, see https://www.gnu.org/licenses.
  */
 
-package br.com.orcinus.orca.core.feed.profile.search
+package br.com.orcinus.orca.core
 
-import br.com.orcinus.orca.core.InternalCoreApi
-import br.com.orcinus.orca.core.feed.profile.Profile
+import br.com.orcinus.orca.std.visibility.PackageProtected
 
-/** Converts this [Profile] into a [ProfileSearchResult]. */
-@InternalCoreApi
-fun Profile.toProfileSearchResult(): ProfileSearchResult {
-  return ProfileSearchResult(id, account, avatarLoader, name, url)
-}
+/**
+ * Denotes that an API is a part of the internal structure of the main functionality of Orca and
+ * should only be referenced from one of the core variants.
+ */
+@PackageProtected(message = "This API should only be referenced from a core variant.")
+annotation class InternalCoreApi

--- a/core/src/main/java/br/com/orcinus/orca/core/auth/AuthenticationLock.kt
+++ b/core/src/main/java/br/com/orcinus/orca/core/auth/AuthenticationLock.kt
@@ -15,6 +15,7 @@
 
 package br.com.orcinus.orca.core.auth
 
+import br.com.orcinus.orca.core.InternalCoreApi
 import br.com.orcinus.orca.core.auth.actor.Actor
 import br.com.orcinus.orca.core.auth.actor.ActorProvider
 import kotlin.coroutines.Continuation
@@ -39,10 +40,9 @@ typealias SomeAuthenticationLock = AuthenticationLock<*>
  * @see scheduleUnlock
  * @see scheduleUnlock
  */
-class AuthenticationLock<A : Authenticator>(
-  private val authenticator: A,
-  private val actorProvider: ActorProvider
-) {
+class AuthenticationLock<A : Authenticator>
+@InternalCoreApi
+constructor(private val authenticator: A, private val actorProvider: ActorProvider) {
   /**
    * [MutableStateFlow] to which [Boolean]s that indicate whether this [AuthenticationLock] has
    * ongoing unlocks are emitted.

--- a/core/src/main/java/br/com/orcinus/orca/core/auth/Authenticator.kt
+++ b/core/src/main/java/br/com/orcinus/orca/core/auth/Authenticator.kt
@@ -15,11 +15,12 @@
 
 package br.com.orcinus.orca.core.auth
 
+import br.com.orcinus.orca.core.InternalCoreApi
 import br.com.orcinus.orca.core.auth.actor.Actor
 import br.com.orcinus.orca.core.auth.actor.ActorProvider
 
 /** Authenticates a user through [authenticate]. */
-abstract class Authenticator {
+abstract class Authenticator @InternalCoreApi constructor() {
   /** [Authorizer] with which the user will be authorized. */
   protected abstract val authorizer: Authorizer
 

--- a/core/src/main/java/br/com/orcinus/orca/core/auth/Authorizer.kt
+++ b/core/src/main/java/br/com/orcinus/orca/core/auth/Authorizer.kt
@@ -15,8 +15,10 @@
 
 package br.com.orcinus.orca.core.auth
 
+import br.com.orcinus.orca.core.InternalCoreApi
+
 /** Authorizes the user through [authorize]. */
-abstract class Authorizer {
+abstract class Authorizer @InternalCoreApi constructor() {
   /**
    * Authorizes the user, allowing the application to perform operations on their behalf.
    *

--- a/core/src/main/java/br/com/orcinus/orca/core/auth/actor/Actor.kt
+++ b/core/src/main/java/br/com/orcinus/orca/core/auth/actor/Actor.kt
@@ -15,6 +15,7 @@
 
 package br.com.orcinus.orca.core.auth.actor
 
+import br.com.orcinus.orca.core.InternalCoreApi
 import br.com.orcinus.orca.std.image.ImageLoader
 import br.com.orcinus.orca.std.image.SomeImageLoader
 
@@ -30,11 +31,9 @@ sealed interface Actor {
    * @param accessToken Access token resulted from the authentication.
    * @param avatarLoader [ImageLoader] by which the avatar will be loaded.
    */
-  data class Authenticated(
-    val id: String,
-    val accessToken: String,
-    val avatarLoader: SomeImageLoader
-  ) : Actor {
+  data class Authenticated
+  @InternalCoreApi
+  constructor(val id: String, val accessToken: String, val avatarLoader: SomeImageLoader) : Actor {
     companion object
   }
 }

--- a/core/src/main/java/br/com/orcinus/orca/core/auth/actor/ActorProvider.kt
+++ b/core/src/main/java/br/com/orcinus/orca/core/auth/actor/ActorProvider.kt
@@ -15,8 +15,10 @@
 
 package br.com.orcinus.orca.core.auth.actor
 
+import br.com.orcinus.orca.core.InternalCoreApi
+
 /** Provides an [Actor] through [provide]. */
-abstract class ActorProvider {
+abstract class ActorProvider @InternalCoreApi constructor() {
   /** Provides an [Actor]. */
   suspend fun provide(): Actor {
     return retrieve()

--- a/core/src/main/java/br/com/orcinus/orca/core/feed/FeedProvider.kt
+++ b/core/src/main/java/br/com/orcinus/orca/core/feed/FeedProvider.kt
@@ -15,6 +15,7 @@
 
 package br.com.orcinus.orca.core.feed
 
+import br.com.orcinus.orca.core.InternalCoreApi
 import br.com.orcinus.orca.core.feed.profile.post.Post
 import br.com.orcinus.orca.core.feed.profile.post.content.TermMuter
 import kotlinx.coroutines.flow.Flow
@@ -22,7 +23,7 @@ import kotlinx.coroutines.flow.Flow
 /**
  * Provides a user's feed (the [Post]s shown to them based on who they follow) through [onProvide].
  */
-abstract class FeedProvider {
+abstract class FeedProvider @InternalCoreApi constructor() {
   /** [TermMuter] by which [Post]s with muted terms will be filtered out. */
   protected abstract val termMuter: TermMuter
 

--- a/core/src/main/java/br/com/orcinus/orca/core/feed/profile/ProfileProvider.kt
+++ b/core/src/main/java/br/com/orcinus/orca/core/feed/profile/ProfileProvider.kt
@@ -15,17 +15,18 @@
 
 package br.com.orcinus.orca.core.feed.profile
 
+import br.com.orcinus.orca.core.InternalCoreApi
 import kotlinx.coroutines.flow.Flow
 
 /** Provides a [Profile] through [onProvide]. */
-abstract class ProfileProvider {
+abstract class ProfileProvider @InternalCoreApi constructor() {
   /**
    * [IllegalArgumentException] thrown when a [Profile] that doesn't exist is requested to be
    * provided.
    *
    * @param id ID of the [Profile] requested to be provided.
    */
-  class NonexistentProfileException(id: String) :
+  class NonexistentProfileException @InternalCoreApi constructor(id: String) :
     IllegalArgumentException("Profile identified as \"$id\" doesn't exist.")
 
   /**

--- a/core/src/main/java/br/com/orcinus/orca/core/feed/profile/account/Account.kt
+++ b/core/src/main/java/br/com/orcinus/orca/core/feed/profile/account/Account.kt
@@ -15,6 +15,7 @@
 
 package br.com.orcinus.orca.core.feed.profile.account
 
+import br.com.orcinus.orca.core.InternalCoreApi
 import br.com.orcinus.orca.core.feed.profile.account.Account.Companion.of
 import br.com.orcinus.orca.core.instance.domain.Domain
 import java.io.Serializable
@@ -68,6 +69,7 @@ data class Account internal constructor(val username: Username, val domain: Doma
      * @throws Domain.ValueWithoutTopLevelDomainException If the domain doesn't have a top-level
      *   domain.
      */
+    @InternalCoreApi
     @Throws(
       BlankStringException::class,
       Username.BlankValueException::class,

--- a/core/src/main/java/br/com/orcinus/orca/core/feed/profile/account/String.extensions.kt
+++ b/core/src/main/java/br/com/orcinus/orca/core/feed/profile/account/String.extensions.kt
@@ -15,6 +15,7 @@
 
 package br.com.orcinus.orca.core.feed.profile.account
 
+import br.com.orcinus.orca.core.InternalCoreApi
 import br.com.orcinus.orca.core.instance.domain.Domain
 
 /**
@@ -23,6 +24,7 @@ import br.com.orcinus.orca.core.instance.domain.Domain
  *
  * @param domain Mastodon instance from which the user is.
  */
+@InternalCoreApi
 infix fun String.at(domain: String): Account {
   return Account(Username(this), Domain(domain))
 }

--- a/core/src/main/java/br/com/orcinus/orca/core/feed/profile/post/Author.kt
+++ b/core/src/main/java/br/com/orcinus/orca/core/feed/profile/post/Author.kt
@@ -15,6 +15,7 @@
 
 package br.com.orcinus.orca.core.feed.profile.post
 
+import br.com.orcinus.orca.core.InternalCoreApi
 import br.com.orcinus.orca.core.feed.profile.account.Account
 import br.com.orcinus.orca.std.image.ImageLoader
 import br.com.orcinus.orca.std.image.SomeImageLoader
@@ -30,7 +31,9 @@ import java.net.URL
  * @param account Unique identifier within an instance.
  * @param profileURL [URL] that leads to this [Author]'s profile.
  */
-data class Author(
+data class Author
+@InternalCoreApi
+constructor(
   val id: String,
   val avatarLoader: SomeImageLoader,
   val name: String,

--- a/core/src/main/java/br/com/orcinus/orca/core/feed/profile/post/DeletablePost.kt
+++ b/core/src/main/java/br/com/orcinus/orca/core/feed/profile/post/DeletablePost.kt
@@ -15,6 +15,8 @@
 
 package br.com.orcinus.orca.core.feed.profile.post
 
+import br.com.orcinus.orca.core.InternalCoreApi
+
 /**
  * [Post] that can be deleted.
  *
@@ -22,7 +24,7 @@ package br.com.orcinus.orca.core.feed.profile.post
  *   will be delegated.
  * @see delete
  */
-abstract class DeletablePost(private val delegate: Post) : Post {
+abstract class DeletablePost @InternalCoreApi constructor(private val delegate: Post) : Post {
   override val id = delegate.id
   override val author = delegate.author
   override val content = delegate.content

--- a/core/src/main/java/br/com/orcinus/orca/core/feed/profile/post/content/Attachment.kt
+++ b/core/src/main/java/br/com/orcinus/orca/core/feed/profile/post/content/Attachment.kt
@@ -15,6 +15,7 @@
 
 package br.com.orcinus.orca.core.feed.profile.post.content
 
+import br.com.orcinus.orca.core.InternalCoreApi
 import java.io.Serializable
 import java.net.URL
 
@@ -24,6 +25,7 @@ import java.net.URL
  * @param description Description of what's displayed.
  * @param url [URL] that leads to the media.
  */
-data class Attachment(val description: String?, val url: URL) : Serializable {
+data class Attachment @InternalCoreApi constructor(val description: String?, val url: URL) :
+  Serializable {
   companion object
 }

--- a/core/src/main/java/br/com/orcinus/orca/core/feed/profile/post/content/Content.kt
+++ b/core/src/main/java/br/com/orcinus/orca/core/feed/profile/post/content/Content.kt
@@ -15,6 +15,7 @@
 
 package br.com.orcinus.orca.core.feed.profile.post.content
 
+import br.com.orcinus.orca.core.InternalCoreApi
 import br.com.orcinus.orca.core.feed.profile.post.content.highlight.Headline
 import br.com.orcinus.orca.core.feed.profile.post.content.highlight.HeadlineProvider
 import br.com.orcinus.orca.core.feed.profile.post.content.highlight.Highlight
@@ -62,6 +63,7 @@ private constructor(
      * @param attachments [Attachment]s containing the attached media.
      * @param headlineProvider [HeadlineProvider] that provides the [Headline].
      */
+    @InternalCoreApi
     fun from(
       domain: Domain,
       text: StyledString,

--- a/core/src/main/java/br/com/orcinus/orca/core/feed/profile/post/content/highlight/Headline.kt
+++ b/core/src/main/java/br/com/orcinus/orca/core/feed/profile/post/content/highlight/Headline.kt
@@ -15,6 +15,7 @@
 
 package br.com.orcinus.orca.core.feed.profile.post.content.highlight
 
+import br.com.orcinus.orca.core.InternalCoreApi
 import br.com.orcinus.orca.std.image.ImageLoader
 import br.com.orcinus.orca.std.image.SomeImageLoader
 
@@ -25,6 +26,8 @@ import br.com.orcinus.orca.std.image.SomeImageLoader
  * @param subtitle Brief description of the content in the external site.
  * @param coverLoader [ImageLoader] that loads the image that represents the content.
  */
-data class Headline(val title: String, val subtitle: String?, val coverLoader: SomeImageLoader?) {
+data class Headline
+@InternalCoreApi
+constructor(val title: String, val subtitle: String?, val coverLoader: SomeImageLoader?) {
   companion object
 }

--- a/core/src/main/java/br/com/orcinus/orca/core/feed/profile/post/content/highlight/HeadlineProvider.kt
+++ b/core/src/main/java/br/com/orcinus/orca/core/feed/profile/post/content/highlight/HeadlineProvider.kt
@@ -15,9 +15,11 @@
 
 package br.com.orcinus.orca.core.feed.profile.post.content.highlight
 
+import br.com.orcinus.orca.core.InternalCoreApi
 import java.net.URL
 
 /** Provides a [Headline] through [provide]. */
+@InternalCoreApi
 fun interface HeadlineProvider {
   /**
    * Provides a [Headline] based on the [url].

--- a/core/src/main/java/br/com/orcinus/orca/core/feed/profile/post/content/highlight/Highlight.kt
+++ b/core/src/main/java/br/com/orcinus/orca/core/feed/profile/post/content/highlight/Highlight.kt
@@ -15,6 +15,7 @@
 
 package br.com.orcinus.orca.core.feed.profile.post.content.highlight
 
+import br.com.orcinus.orca.core.InternalCoreApi
 import br.com.orcinus.orca.core.feed.profile.post.content.Content
 import java.net.URL
 
@@ -24,6 +25,6 @@ import java.net.URL
  * @param headline [Headline] with the main information.
  * @param url [URL] that leads to the external site.
  */
-data class Highlight(val headline: Headline, val url: URL) {
+data class Highlight @InternalCoreApi constructor(val headline: Headline, val url: URL) {
   companion object
 }

--- a/core/src/main/java/br/com/orcinus/orca/core/feed/profile/post/provider/PostProvider.kt
+++ b/core/src/main/java/br/com/orcinus/orca/core/feed/profile/post/provider/PostProvider.kt
@@ -15,6 +15,7 @@
 
 package br.com.orcinus.orca.core.feed.profile.post.provider
 
+import br.com.orcinus.orca.core.InternalCoreApi
 import br.com.orcinus.orca.core.auth.AuthenticationLock
 import br.com.orcinus.orca.core.auth.SomeAuthenticationLock
 import br.com.orcinus.orca.core.feed.profile.post.Post
@@ -22,7 +23,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
 /** Provides [Post]s. */
-abstract class PostProvider {
+abstract class PostProvider @InternalCoreApi constructor() {
   /**
    * [AuthenticationLock] for distinguishing standard [Post]s from those that can be deleted when
    * providing them.

--- a/core/src/main/java/br/com/orcinus/orca/core/feed/profile/search/ProfileSearchResult.kt
+++ b/core/src/main/java/br/com/orcinus/orca/core/feed/profile/search/ProfileSearchResult.kt
@@ -15,6 +15,7 @@
 
 package br.com.orcinus.orca.core.feed.profile.search
 
+import br.com.orcinus.orca.core.InternalCoreApi
 import br.com.orcinus.orca.core.feed.profile.account.Account
 import br.com.orcinus.orca.std.image.SomeImageLoader
 import java.io.Serializable
@@ -29,7 +30,9 @@ import java.net.URL
  * @param name Name to be displayed.
  * @param url [URL] that leads to the profile.
  */
-data class ProfileSearchResult(
+data class ProfileSearchResult
+@InternalCoreApi
+constructor(
   val id: String,
   val account: Account,
   val avatarLoader: SomeImageLoader,

--- a/core/src/main/java/br/com/orcinus/orca/core/feed/profile/search/ProfileSearcher.kt
+++ b/core/src/main/java/br/com/orcinus/orca/core/feed/profile/search/ProfileSearcher.kt
@@ -15,6 +15,7 @@
 
 package br.com.orcinus.orca.core.feed.profile.search
 
+import br.com.orcinus.orca.core.InternalCoreApi
 import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
@@ -25,7 +26,7 @@ import kotlinx.coroutines.flow.flatMapMerge
 import kotlinx.coroutines.flow.flowOf
 
 /** Searches for profiles through [search]. */
-abstract class ProfileSearcher {
+abstract class ProfileSearcher @InternalCoreApi constructor() {
   /** [MutableStateFlow] to which the query is emitted. */
   private val queryFlow = MutableStateFlow("")
 

--- a/core/src/main/java/br/com/orcinus/orca/core/feed/profile/type/editable/EditableProfile.kt
+++ b/core/src/main/java/br/com/orcinus/orca/core/feed/profile/type/editable/EditableProfile.kt
@@ -15,10 +15,11 @@
 
 package br.com.orcinus.orca.core.feed.profile.type.editable
 
+import br.com.orcinus.orca.core.InternalCoreApi
 import br.com.orcinus.orca.core.feed.profile.Profile
 
 /** [Profile] that can be edited through its [editor]. */
-abstract class EditableProfile : Profile {
+abstract class EditableProfile @InternalCoreApi constructor() : Profile {
   /** [Editor] through which this [EditableProfile] can be edited. */
   abstract val editor: Editor
 

--- a/core/src/main/java/br/com/orcinus/orca/core/feed/profile/type/editable/Editor.kt
+++ b/core/src/main/java/br/com/orcinus/orca/core/feed/profile/type/editable/Editor.kt
@@ -15,6 +15,7 @@
 
 package br.com.orcinus.orca.core.feed.profile.type.editable
 
+import br.com.orcinus.orca.core.InternalCoreApi
 import br.com.orcinus.orca.std.image.ImageLoader
 import br.com.orcinus.orca.std.image.SomeImageLoader
 import br.com.orcinus.orca.std.styledstring.StyledString
@@ -44,6 +45,7 @@ interface Editor {
 
   companion object {
     /** No-op, empty [Editor]. */
+    @InternalCoreApi
     val empty =
       object : Editor {
         override suspend fun setAvatarLoader(avatarLoader: SomeImageLoader) {}

--- a/core/src/main/java/br/com/orcinus/orca/core/feed/profile/type/followable/Follow.kt
+++ b/core/src/main/java/br/com/orcinus/orca/core/feed/profile/type/followable/Follow.kt
@@ -15,6 +15,7 @@
 
 package br.com.orcinus.orca.core.feed.profile.type.followable
 
+import br.com.orcinus.orca.core.InternalCoreApi
 import java.io.Serializable
 
 /** Status that indicates in which "following" state a user is related to another. */
@@ -31,6 +32,7 @@ abstract class Follow private constructor() : Serializable {
        * [Follow] status in which a user doesn't receive any updates related to the other's
        * activity.
        */
+      @InternalCoreApi
       fun unfollowed(): Public {
         return object : Public() {
           override fun toString(): String {
@@ -48,6 +50,7 @@ abstract class Follow private constructor() : Serializable {
       }
 
       /** [Follow] status in which a user has subscribed to receive updates from another. */
+      @InternalCoreApi
       fun following(): Public {
         return object : Public() {
           override fun toString(): String {
@@ -75,6 +78,7 @@ abstract class Follow private constructor() : Serializable {
        * [Follow] status in which a user doesn't receive any updates related to the other's
        * activity.
        */
+      @InternalCoreApi
       fun unfollowed(): Private {
         return object : Private() {
           override fun toString(): String {
@@ -95,6 +99,7 @@ abstract class Follow private constructor() : Serializable {
        * [Follow] status in which a user has requested to follow another and is waiting for it to be
        * accepted or denied.
        */
+      @InternalCoreApi
       fun requested(): Private {
         return object : Private() {
           override fun toString(): String {
@@ -112,6 +117,7 @@ abstract class Follow private constructor() : Serializable {
       }
 
       /** [Follow] status in which a user has subscribed to receive updates from another. */
+      @InternalCoreApi
       fun following(): Private {
         return object : Private() {
           override fun toString(): String {
@@ -178,6 +184,7 @@ abstract class Follow private constructor() : Serializable {
      * @throws BlankStringException If the [string] is blank.
      * @throws InvalidFollowString If the [string] is not a valid [Follow] representation.
      */
+    @InternalCoreApi
     fun of(string: String): Follow {
       val formattedString = string.trim()
       formattedString.ifBlank { throw BlankStringException() }
@@ -201,6 +208,7 @@ abstract class Follow private constructor() : Serializable {
      * @throws IllegalArgumentException If [expected] and [actual] have different visibilities.
      * @see visibilityName
      */
+    @InternalCoreApi
     fun <T : Follow> requireVisibilityMatch(expected: T, actual: Follow): T {
       val isCohesive = actual.visibilityName == expected.visibilityName
       return if (isCohesive) {

--- a/core/src/main/java/br/com/orcinus/orca/core/feed/profile/type/followable/FollowableProfile.kt
+++ b/core/src/main/java/br/com/orcinus/orca/core/feed/profile/type/followable/FollowableProfile.kt
@@ -15,10 +15,11 @@
 
 package br.com.orcinus.orca.core.feed.profile.type.followable
 
+import br.com.orcinus.orca.core.InternalCoreApi
 import br.com.orcinus.orca.core.feed.profile.Profile
 
 /** [Profile] whose [follow] status can be toggled. */
-abstract class FollowableProfile<T : Follow> : Profile {
+abstract class FollowableProfile<T : Follow> @InternalCoreApi constructor() : Profile {
   /** Current [Follow] status. */
   abstract val follow: T
 

--- a/core/src/main/java/br/com/orcinus/orca/core/instance/Instance.kt
+++ b/core/src/main/java/br/com/orcinus/orca/core/instance/Instance.kt
@@ -15,6 +15,7 @@
 
 package br.com.orcinus.orca.core.instance
 
+import br.com.orcinus.orca.core.InternalCoreApi
 import br.com.orcinus.orca.core.auth.AuthenticationLock
 import br.com.orcinus.orca.core.auth.Authenticator
 import br.com.orcinus.orca.core.feed.FeedProvider
@@ -33,7 +34,7 @@ typealias SomeInstance = Instance<*>
  *
  * @param T [Authenticator] to authenticate the user with.
  */
-abstract class Instance<T : Authenticator> {
+abstract class Instance<T : Authenticator> @InternalCoreApi constructor() {
   /** Unique identifier of the server. */
   abstract val domain: Domain
 

--- a/core/src/main/java/br/com/orcinus/orca/core/instance/registration/Credentials.kt
+++ b/core/src/main/java/br/com/orcinus/orca/core/instance/registration/Credentials.kt
@@ -15,6 +15,7 @@
 
 package br.com.orcinus.orca.core.instance.registration
 
+import br.com.orcinus.orca.core.InternalCoreApi
 import br.com.orcinus.orca.core.feed.profile.account.Account
 import br.com.orcinus.orca.core.instance.Instance
 import br.com.orcinus.orca.std.styledstring.style.type.Email
@@ -30,6 +31,7 @@ import br.com.orcinus.orca.std.styledstring.style.type.Email
  * @see Registrar.register
  */
 data class Credentials
+@InternalCoreApi
 @Throws(BlankPasswordException::class, InvalidEmailException::class)
 constructor(val email: String, val password: String) {
   /**

--- a/core/src/main/java/br/com/orcinus/orca/core/instance/registration/Registrar.kt
+++ b/core/src/main/java/br/com/orcinus/orca/core/instance/registration/Registrar.kt
@@ -15,6 +15,7 @@
 
 package br.com.orcinus.orca.core.instance.registration
 
+import br.com.orcinus.orca.core.InternalCoreApi
 import br.com.orcinus.orca.core.feed.profile.account.Account
 import br.com.orcinus.orca.core.instance.Instance
 import br.com.orcinus.orca.core.instance.domain.Domain
@@ -28,7 +29,7 @@ import kotlinx.coroutines.flow.flow
  *
  * @see register
  */
-abstract class Registrar {
+abstract class Registrar @InternalCoreApi constructor() {
   /** [Domain]s of the [Instance]s in which registration can be attempted to be performed. */
   protected abstract val domains: List<Domain>
 


### PR DESCRIPTION
Annotates APIs that should only be accessed from a core variant with [`InternalCoreApi`](https://github.com/orcinusbr/orca-android/blob/9016409aa9658bfa179eb9b084760229e469e491/core/src/main/java/br/com/orcinus/orca/core/InternalCoreApi.kt).