### PR TITLE
Fix `Replacer` uncached selection referencing on replacement

### DIFF
--- a/std/injector/src/main/java/br/com/orcinus/orca/std/injector/module/replacement/Replacer.kt
+++ b/std/injector/src/main/java/br/com/orcinus/orca/std/injector/module/replacement/Replacer.kt
@@ -218,9 +218,10 @@ abstract class Replacer<E, S, P> : Collection<E> {
   private fun replace(index: Int, element: E, selection: S): Any? {
     for (candidateIndex in indices) {
       val candidate = elementAt(candidateIndex)
-      val isReplaceable = selector(candidate) == selection
+      val isReplaceable = caching.on(candidate) == selection
       if (isReplaceable) {
-        return append(prepareForReplacement(index, candidate), index, element)
+        val preparedForReplacement = prepareForReplacement(index, candidate)
+        return append(preparedForReplacement, index, element)
       }
     }
     return None


### PR DESCRIPTION
Selections of elements over which iteration was performed when deciding whether to append or replace one of them weren't being cached, even if explicitly told to do so by setting [`Replacer.caching`](https://github.com/orcinusbr/orca-android/blob/5bec97ff37da188c8a52f34846ff697b3bb29aa7/std/injector/src/main/java/br/com/orcinus/orca/std/injector/module/replacement/Replacer.kt#L30) to a [`Replacer.Caching.Enabled`](https://github.com/orcinusbr/orca-android/blob/5bec97ff37da188c8a52f34846ff697b3bb29aa7/std/injector/src/main/java/br/com/orcinus/orca/std/injector/module/replacement/Replacer.kt#L67).