### PR TITLE
Remove `Replacer` placement result

### DIFF
--- a/std/injector/src/main/java/br/com/orcinus/orca/std/injector/module/replacement/MutableReplacementList.kt
+++ b/std/injector/src/main/java/br/com/orcinus/orca/std/injector/module/replacement/MutableReplacementList.kt
@@ -26,7 +26,7 @@ package br.com.orcinus.orca.std.injector.module.replacement
  * @see replace
  */
 abstract class MutableReplacementList<E, S> internal constructor() :
-  Replacer<E, S, Unit>(), MutableList<E> {
+  Replacer<E, S>(), MutableList<E> {
   /**
    * Either adds the given [element] to the end of this [MutableReplacementList] or replaces the
    * existing one that matches it based on its [selector], placing it at the same index at which the

--- a/std/injector/src/test/java/br/com/orcinus/orca/std/injector/module/replacement/EmptyReplacer.kt
+++ b/std/injector/src/test/java/br/com/orcinus/orca/std/injector/module/replacement/EmptyReplacer.kt
@@ -18,7 +18,7 @@ package br.com.orcinus.orca.std.injector.module.replacement
 internal class EmptyReplacer<E, S>(
   override val caching: Caching<E, S>,
   override val selector: (E) -> S
-) : Replacer<E, S, Unit>() {
+) : Replacer<E, S>() {
   override val size = 0
 
   override fun iterator(): Iterator<E> {


### PR DESCRIPTION
Useless since [`MutableReplacerList`](https://github.com/orcinusbr/orca-android/blob/a4811a7c6016130a908455cdd74f492eef180323/std/injector/src/main/java/br/com/orcinus/orca/std/injector/module/replacement/MutableReplacementList.kt) is the only direct subclass.