### PR TITLE
Remove `:std:visibility` from `:std:visibility-check`

### DIFF
--- a/build-src/setup/lint/src/main/java/br/com/orcinus/orca/setup/lint/LintSetupPlugin.kt
+++ b/build-src/setup/lint/src/main/java/br/com/orcinus/orca/setup/lint/LintSetupPlugin.kt
@@ -25,11 +25,8 @@ class LintSetupPlugin : Plugin<Project> {
       subProject.afterEvaluate { evaluatedSubproject ->
         with(evaluatedSubproject) {
           extensions.findByType(CommonExtension::class.java)?.let { _ ->
-            arrayOf(":std:visibility").forEach { modulePath ->
-              with(dependencies) {
-                add("compileOnly", project(mapOf("path" to modulePath)))
-                add("lintChecks", project(mapOf("path" to "$modulePath-check")))
-              }
+            arrayOf(":std:visibility-check").forEach { modulePath ->
+              with(dependencies) { add("lintChecks", project(mapOf("path" to modulePath))) }
             }
           }
         }

--- a/std/visibility-check/build.gradle.kts
+++ b/std/visibility-check/build.gradle.kts
@@ -21,10 +21,8 @@ plugins {
 }
 
 dependencies {
-  compileOnly(project(":std:visibility"))
   compileOnly(libs.lint.api)
 
-  testImplementation(project(":std:visibility"))
   testImplementation(libs.assertk)
   testImplementation(libs.kotlin.test)
   testImplementation(libs.lint.api)

--- a/std/visibility-check/src/main/java/br/com/orcinus/orca/std/visibility/check/PackageProtectedIssueRegistry.kt
+++ b/std/visibility-check/src/main/java/br/com/orcinus/orca/std/visibility/check/PackageProtectedIssueRegistry.kt
@@ -22,7 +22,7 @@ import com.android.tools.lint.detector.api.CURRENT_API
 
 /**
  * [IssueRegistry] containing the [PackageProtectedDetector.issue], which characterizes problems of
- * accesses to structures that have been marked as package-protected from outside of the module in
+ * references to structures that have been marked as package-protected from outside of the module in
  * which they have been declared or any of its children.
  */
 @Suppress("unused")

--- a/std/visibility-check/src/main/java/br/com/orcinus/orca/std/visibility/check/detection/Iterable.extensions.kt
+++ b/std/visibility-check/src/main/java/br/com/orcinus/orca/std/visibility/check/detection/Iterable.extensions.kt
@@ -15,10 +15,10 @@
 
 package br.com.orcinus.orca.std.visibility.check.detection
 
-import br.com.orcinus.orca.std.visibility.PackageProtected
 import com.android.tools.lint.detector.api.UastLintUtils.Companion.tryResolveUDeclaration
 import com.android.utils.associateWithNotNull
 import com.android.utils.mapValuesNotNull
+import org.jetbrains.uast.UAnnotation
 import org.jetbrains.uast.UDeclaration
 import org.jetbrains.uast.UExpression
 import org.jetbrains.uast.getContainingDeclaration
@@ -30,8 +30,9 @@ import org.jetbrains.uast.getContainingDeclaration
  *
  * @param action Operation to be run on the [UExpression]s that both contain references to
  *   package-protected structures and are from packages that are unrelated to those of the
- *   structures, alongside the custom message that has been specified by the [PackageProtected]
- *   annotation with which these structures' [UDeclaration]s have been annotated.
+ *   structures, alongside the custom message that has been specified by the [UAnnotation] that
+ *   changes the visibility to package-protected with which these structures' [UDeclaration]s have
+ *   been annotated.
  * @see tryResolveUDeclaration
  * @see UDeclaration.findPackageProtectedAnnotation
  */
@@ -45,7 +46,7 @@ internal fun Iterable<UExpression>
         if (expression.isFromPackageOutsideOfThatOf(declaration)) {
           declaration
             .findPackageProtectedAnnotation()
-            ?.findAttributeValue(PackageProtected::message.name)
+            ?.findAttributeValue("message")
             ?.evaluate()
             ?.toString()
         } else {

--- a/std/visibility-check/src/main/java/br/com/orcinus/orca/std/visibility/check/detection/PackageProtectedDetector.kt
+++ b/std/visibility-check/src/main/java/br/com/orcinus/orca/std/visibility/check/detection/PackageProtectedDetector.kt
@@ -15,7 +15,6 @@
 
 package br.com.orcinus.orca.std.visibility.check.detection
 
-import br.com.orcinus.orca.std.visibility.PackageProtected
 import com.android.tools.lint.detector.api.AnnotationInfo
 import com.android.tools.lint.detector.api.AnnotationUsageInfo
 import com.android.tools.lint.detector.api.Category
@@ -37,9 +36,6 @@ import org.jetbrains.uast.getQualifiedChain
  * (i. e., a class marked as package-protected declared at `br.com.orcinus.orca.core` can be
  * accessed from `br.com.orcinus.orca.core` and `br.com.orcinus.orca.core.sample`, but shouldn't be
  * accessed from `br.com.orcinus.orca.app`).
- *
- * A structure is considered to have package-protected visibility if it's annotated with
- * [PackageProtected].
  */
 internal class PackageProtectedDetector : Detector(), SourceCodeScanner {
   override fun visitAnnotationUsage(
@@ -55,7 +51,7 @@ internal class PackageProtectedDetector : Detector(), SourceCodeScanner {
   }
 
   override fun applicableAnnotations(): List<String> {
-    return listOfNotNull(PackageProtected::class.qualifiedName)
+    return listOfNotNull(PACKAGE_PROTECTED_ANNOTATION_NAME)
   }
 
   override fun getApplicableUastTypes(): List<Class<UExpression>> {
@@ -67,7 +63,7 @@ internal class PackageProtectedDetector : Detector(), SourceCodeScanner {
    * been declared or its children in each of the qualified [UExpression]s within the [expression].
    *
    * @param context [JavaContext] through which qualified [UExpression]s that refer to
-   *   package-private structures from outside packages will be obtained from the [expression].
+   *   package-protected structures from outside packages will be obtained from the [expression].
    * @param expression [UExpression] to be checked.
    * @see Iterable.withResolvedToDeclarationMarkedAsPackageProtectedReferencedFromOutsidePackage
    */

--- a/std/visibility-check/src/main/java/br/com/orcinus/orca/std/visibility/check/detection/UDeclaration.extensions.kt
+++ b/std/visibility-check/src/main/java/br/com/orcinus/orca/std/visibility/check/detection/UDeclaration.extensions.kt
@@ -15,20 +15,25 @@
 
 package br.com.orcinus.orca.std.visibility.check.detection
 
-import br.com.orcinus.orca.std.visibility.PackageProtected
 import com.android.tools.lint.detector.api.UastLintUtils.Companion.tryResolveUDeclaration
 import org.jetbrains.uast.UAnnotation
 import org.jetbrains.uast.UDeclaration
 
 /**
- * Obtains the [UAnnotation] of [PackageProtected] if this [UDeclaration] is of a structure that has
- * been annotated with it or with a [UAnnotation] that extends [PackageProtected], denoting that
- * references from a package that isn't the one in which this [UDeclaration] is should be reported.
+ * Qualified name of the annotation for changing the visibility of a structure to package-protected.
+ */
+internal const val PACKAGE_PROTECTED_ANNOTATION_NAME =
+  "br.com.orcinus.orca.std.visibility.PackageProtected"
+
+/**
+ * Obtains the [UAnnotation] that makes a structure be package-protected if this [UDeclaration] is
+ * of a structure that has been annotated with it or with another [UAnnotation] that extends that
+ * one, denoting that references from a package that isn't the one in which this [UDeclaration] is
+ * should be reported.
  */
 internal fun UDeclaration.findPackageProtectedAnnotation(): UAnnotation? {
-  val annotationName = PackageProtected::class.qualifiedName ?: return null
-  return findAnnotation(annotationName)
+  return findAnnotation(PACKAGE_PROTECTED_ANNOTATION_NAME)
     ?: uAnnotations
       .mapNotNull { it.tryResolveUDeclaration() }
-      .firstNotNullOfOrNull { it.findAnnotation(annotationName) }
+      .firstNotNullOfOrNull { it.findAnnotation(PACKAGE_PROTECTED_ANNOTATION_NAME) }
 }

--- a/std/visibility-check/src/test/java/br/com/orcinus/orca/std/visibility/check/detection/PackageProtectedDetectorTests.kt
+++ b/std/visibility-check/src/test/java/br/com/orcinus/orca/std/visibility/check/detection/PackageProtectedDetectorTests.kt
@@ -15,7 +15,6 @@
 
 package br.com.orcinus.orca.std.visibility.check.detection
 
-import br.com.orcinus.orca.std.visibility.PackageProtected
 import com.android.tools.lint.checks.infrastructure.TestFiles
 import com.android.tools.lint.checks.infrastructure.TestLintTask
 import kotlin.test.Test
@@ -57,7 +56,7 @@ internal class PackageProtectedDetectorTests {
       .run()
       .expect(
         """
-          src/br/com/orcinus/orca/app/Consumer.kt:7: Error: ${PackageProtected.DEFAULT_MESSAGE} [${PackageProtectedDetector.issue.id}]
+          src/br/com/orcinus/orca/app/Consumer.kt:7: Error: $DEFAULT_MESSAGE [${PackageProtectedDetector.issue.id}]
               Api()
               ~~~~~
           1 errors, 0 warnings
@@ -140,7 +139,7 @@ internal class PackageProtectedDetectorTests {
       .run()
       .expect(
         """
-          src/br/com/orcinus/orca/app/Consumer.kt:7: Error: ${PackageProtected.DEFAULT_MESSAGE} [${PackageProtectedDetector.issue.id}]
+          src/br/com/orcinus/orca/app/Consumer.kt:7: Error: $DEFAULT_MESSAGE [${PackageProtectedDetector.issue.id}]
               Api()
               ~~~~~
           1 errors, 0 warnings
@@ -362,7 +361,7 @@ internal class PackageProtectedDetectorTests {
       .run()
       .expect(
         """
-          src/br/com/orcinus/orca/app/Consumer.kt:7: Error: ${PackageProtected.DEFAULT_MESSAGE} [${PackageProtectedDetector.issue.id}]
+          src/br/com/orcinus/orca/app/Consumer.kt:7: Error: $DEFAULT_MESSAGE [${PackageProtectedDetector.issue.id}]
               Api()
               ~~~~~
           1 errors, 0 warnings
@@ -443,7 +442,7 @@ internal class PackageProtectedDetectorTests {
       .run()
       .expect(
         """
-          src/br/com/orcinus/orca/app/Consumer.kt:7: Error: ${PackageProtected.DEFAULT_MESSAGE} [${PackageProtectedDetector.issue.id}]
+          src/br/com/orcinus/orca/app/Consumer.kt:7: Error: $DEFAULT_MESSAGE [${PackageProtectedDetector.issue.id}]
               Api()
               ~~~~~
           1 errors, 0 warnings
@@ -595,7 +594,7 @@ internal class PackageProtectedDetectorTests {
       .run()
       .expect(
         """
-          src/br/com/orcinus/orca/app/Consumer.kt:7: Error: ${PackageProtected.DEFAULT_MESSAGE} [${PackageProtectedDetector.issue.id}]
+          src/br/com/orcinus/orca/app/Consumer.kt:7: Error: $DEFAULT_MESSAGE [${PackageProtectedDetector.issue.id}]
               Api().call()
               ~~~~~~~~~~~~
           1 errors, 0 warnings
@@ -684,7 +683,7 @@ internal class PackageProtectedDetectorTests {
       .run()
       .expect(
         """
-          src/br/com/orcinus/orca/app/Consumer.kt:7: Error: ${PackageProtected.DEFAULT_MESSAGE} [${PackageProtectedDetector.issue.id}]
+          src/br/com/orcinus/orca/app/Consumer.kt:7: Error: $DEFAULT_MESSAGE [${PackageProtectedDetector.issue.id}]
               Api().call()
               ~~~~~~~~~~~~
           1 errors, 0 warnings

--- a/std/visibility-check/src/test/java/br/com/orcinus/orca/std/visibility/check/detection/TestFiles.extensions.kt
+++ b/std/visibility-check/src/test/java/br/com/orcinus/orca/std/visibility/check/detection/TestFiles.extensions.kt
@@ -15,25 +15,28 @@
 
 package br.com.orcinus.orca.std.visibility.check.detection
 
-import br.com.orcinus.orca.std.visibility.PackageProtected
 import com.android.tools.lint.checks.infrastructure.TestFile
 import com.android.tools.lint.checks.infrastructure.TestFiles
 
-/** [TestFile] in which a [PackageProtected]-like [Annotation] is declared. */
+internal const val DEFAULT_MESSAGE =
+  "This structure is package-protected and is not intended to be referenced by outside " +
+    "packages."
+
+/** [TestFile] in which an [Annotation] for marking a structure as package-protected is declared. */
 internal val TestFiles.packageProtectedAnnotation
   get() =
     kotlin(
         """
           package br.com.orcinus.orca.std.visibility
 
-          annotation class PackageProtected(val message: String = "${PackageProtected.DEFAULT_MESSAGE}")
+          annotation class PackageProtected(val message: String = "$DEFAULT_MESSAGE")
         """
       )
       .indented()
 
 /**
- * [TestFile] in which an [Annotation] that is annotated with the [PackageProtected]-like one from
- * [TestFiles.packageProtectedAnnotation] is declared.
+ * [TestFile] in which an [Annotation] that is annotated with the [Annotation] for marking a
+ * structure as package-protected from [TestFiles.packageProtectedAnnotation] is declared.
  */
 internal val TestFiles.packageProtectedAnnotatedAnnotation
   get() =


### PR DESCRIPTION
Was occasionally causing a `NoClassDefFoundError` to be thrown when lint analysis was performed.