### PR TITLE
Add `plus` and `minus` operators to `ReplacementList`

### DIFF
--- a/ext/coroutines/src/main/java/br/com/orcinus/orca/ext/coroutines/replacement/ReplacementList.kt
+++ b/ext/coroutines/src/main/java/br/com/orcinus/orca/ext/coroutines/replacement/ReplacementList.kt
@@ -94,6 +94,14 @@ private class DelegatorReplacementList<E, S>(
     delegate.clear()
   }
 
+  override fun plus(element: E): ReplacementList<E, S> {
+    return DelegatorReplacementList(delegate, caching, selector).apply { add(element) }
+  }
+
+  override fun minus(element: E): ReplacementList<E, S> {
+    return DelegatorReplacementList(delegate, caching, selector).apply { remove(element) }
+  }
+
   override fun append(index: Int, element: E) {
     delegate.add(index, element)
   }
@@ -335,6 +343,22 @@ abstract class ReplacementList<E, S> internal constructor() : MutableList<E> {
   operator fun contains(selection: S): Boolean {
     return any { caching.on(it) == selection }
   }
+
+  /**
+   * Creates a [ReplacementList] to which the [element] is added, either by replacing an existing
+   * one depending on the equality of their selections or appending it.
+   *
+   * @param element Element to be added.
+   */
+  abstract operator fun plus(element: E): ReplacementList<E, S>
+
+  /**
+   * Creates a [ReplacementList] from which the [element] whose selector matches that of an existing
+   * one is removed.
+   *
+   * @param element Element to be removed.
+   */
+  abstract operator fun minus(element: E): ReplacementList<E, S>
 
   /**
    * Callback that gets called when the [element] is requested to be appended.

--- a/ext/coroutines/src/test/java/br/com/orcinus/orca/ext/coroutines/replacement/ReplacementListTests.kt
+++ b/ext/coroutines/src/test/java/br/com/orcinus/orca/ext/coroutines/replacement/ReplacementListTests.kt
@@ -58,11 +58,22 @@ internal class ReplacementListTests {
 
   @Test
   fun appends() {
+    assertThat(replacementListOf<Int>() + 0).containsExactly(0)
+  }
+
+  @Test
+  fun appendsByMutation() {
     assertThat(replacementListOf<Int>().apply { add(0) }).containsExactly(0)
   }
 
   @Test
   fun replaces() {
+    assertThat(replacementListOf("Hey,", "world!", selector = String::first) + "Hello,")
+      .containsExactly("Hello,", "world!")
+  }
+
+  @Test
+  fun replacesByMutation() {
     assertThat(
         replacementListOf("Hey,", "world!", selector = String::first).apply { add("Hello,") }
       )


### PR DESCRIPTION
Adds operators that produce new [`ReplacementList`](https://github.com/orcinusbr/orca-android/blob/0ab396bff15806377dec19e827a6f44a7dd6facc/ext/coroutines/src/main/java/br/com/orcinus/orca/ext/coroutines/replacement/ReplacementList.kt#L119)s with the newly added or without the removed element instead of mutating it.