### PR TITLE
Add `ReplacementList` by-selection element obtainance method

### DIFF
--- a/ext/coroutines/src/main/java/br/com/orcinus/orca/ext/coroutines/replacement/ReplacementList.kt
+++ b/ext/coroutines/src/main/java/br/com/orcinus/orca/ext/coroutines/replacement/ReplacementList.kt
@@ -364,6 +364,16 @@ abstract class ReplacementList<E, S> internal constructor() : MutableList<E> {
   }
 
   /**
+   * Obtains the element whose selection equals to the given one or `null` when no element's equals
+   * to it.
+   *
+   * @param selection Result of invoking the [selector] on the element to be obtained.
+   */
+  fun getOrNull(selection: S): E? {
+    return find { caching.on(it) == selection }
+  }
+
+  /**
    * Creates a [ReplacementList] to which the [element] is added, either by replacing an existing
    * one depending on the equality of their selections or appending it.
    *

--- a/ext/coroutines/src/test/java/br/com/orcinus/orca/ext/coroutines/replacement/ReplacementListTests.kt
+++ b/ext/coroutines/src/test/java/br/com/orcinus/orca/ext/coroutines/replacement/ReplacementListTests.kt
@@ -20,7 +20,9 @@ import assertk.assertions.contains
 import assertk.assertions.containsAll
 import assertk.assertions.containsExactly
 import assertk.assertions.doesNotContain
+import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
+import assertk.assertions.isNull
 import assertk.assertions.isTrue
 import kotlin.test.Test
 import org.opentest4j.AssertionFailedError
@@ -78,6 +80,16 @@ internal class ReplacementListTests {
         replacementListOf("Hey,", "world!", selector = String::first).apply { add("Hello,") }
       )
       .containsExactly("Hello,", "world!")
+  }
+
+  @Test
+  fun getsBySelection() {
+    assertThat(replacementListOf(0, 1) { it % 2 == 0 }.getOrNull(true)).isEqualTo(0)
+  }
+
+  @Test
+  fun returnsNullWhenGettingBySelectionAndNoneIsFound() {
+    assertThat(replacementListOf(0, 2) { it % 2 == 0 }.getOrNull(false)).isNull()
   }
 
   @Test


### PR DESCRIPTION
Adds an method for obtaining an element by its selection from a [`ReplacementList`](https://github.com/orcinusbr/orca-android/blob/188e594c1657e19ac1f4677815bf7096424afa21/ext/coroutines/src/main/java/br/com/orcinus/orca/ext/coroutines/replacement/ReplacementList.kt#L138).