### PR TITLE
Build `mailto` URI from `URIBuilder`

### DIFF
--- a/composite/timeline/src/test/java/br/com/orcinus/orca/composite/timeline/text/annotated/span/StyleExtractorTests.kt
+++ b/composite/timeline/src/test/java/br/com/orcinus/orca/composite/timeline/text/annotated/span/StyleExtractorTests.kt
@@ -28,7 +28,7 @@ import java.net.URISyntaxException
 import kotlin.test.Test
 
 internal class StyleExtractorTests {
-  private val uri = URIBuilder.scheme("https").host("orca.jeanbarrossilva.com").build()
+  private val uri = URIBuilder.url().scheme("https").host("orca.jeanbarrossilva.com").build()
 
   @Test
   fun boldExtractorDoesNotExtractFromNonBoldSpanStyle() {

--- a/composite/timeline/src/test/java/br/com/orcinus/orca/composite/timeline/text/annotated/span/category/CategorizerTests.kt
+++ b/composite/timeline/src/test/java/br/com/orcinus/orca/composite/timeline/text/annotated/span/category/CategorizerTests.kt
@@ -21,7 +21,7 @@ import br.com.orcinus.orca.std.uri.URIBuilder
 import kotlin.test.Test
 
 internal class CategorizerTests {
-  private val uri = URIBuilder.scheme("https").host("orca.jeanbarrossilva.com").build()
+  private val uri = URIBuilder.url().scheme("https").host("orca.jeanbarrossilva.com").build()
 
   @Test
   fun createsURISpec() {

--- a/composite/timeline/src/test/java/br/com/orcinus/orca/composite/timeline/text/spanned/AnyExtensionsTests.kt
+++ b/composite/timeline/src/test/java/br/com/orcinus/orca/composite/timeline/text/spanned/AnyExtensionsTests.kt
@@ -30,7 +30,7 @@ import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
 internal class AnyExtensionsTests {
-  private val uri = URIBuilder.scheme("https").host("orca.jeanbarrossilva.com").build()
+  private val uri = URIBuilder.url().scheme("https").host("orca.jeanbarrossilva.com").build()
 
   @Test
   fun structurallyComparesEqualStyleSpans() {
@@ -56,7 +56,9 @@ internal class AnyExtensionsTests {
     assertThat(
         URLSpan("$uri")
           .isStructurallyEqualTo(
-            URLSpan("${URIBuilder.scheme("https").host("beluga.jeanbarrossilva.com").build()}")
+            URLSpan(
+              "${URIBuilder.url().scheme("https").host("beluga.jeanbarrossilva.com").build()}"
+            )
           )
       )
       .isFalse()

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/auth/authorization/MastodonAuthorizationActivity.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/auth/authorization/MastodonAuthorizationActivity.kt
@@ -99,7 +99,8 @@ class MastodonAuthorizationActivity internal constructor() :
   companion object {
     /** [URI] that leads to a blog article that explains how Mastodon works. */
     internal val helpURI: URI =
-      URIBuilder.scheme("https")
+      URIBuilder.url()
+        .scheme("https")
         .host("blog.joinmastodon.org")
         .path("2018")
         .path("08")

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/auth/authorization/viewmodel/MastodonAuthorizationViewModel.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/auth/authorization/viewmodel/MastodonAuthorizationViewModel.kt
@@ -29,7 +29,7 @@ import br.com.orcinus.orca.core.mastodon.R
 import br.com.orcinus.orca.core.mastodon.auth.Mastodon
 import br.com.orcinus.orca.core.mastodon.auth.authorization.OnAccessTokenRequestListener
 import br.com.orcinus.orca.core.mastodon.instance.MastodonInstance
-import br.com.orcinus.orca.std.uri.HostedURIBuilder
+import br.com.orcinus.orca.std.uri.url.HostedURLBuilder
 import java.net.URI
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -116,7 +116,7 @@ private constructor(
      */
     internal fun createURI(context: Context, domain: Domain): URI {
       return with(context) {
-        HostedURIBuilder.from(domain.uri)
+        HostedURLBuilder.from(domain.uri)
           .path("oauth")
           .path("authorize")
           .query()

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/instance/registration/MastodonRegistrationWebpageInteractorWithUncertainLoadingFinishing.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/instance/registration/MastodonRegistrationWebpageInteractorWithUncertainLoadingFinishing.kt
@@ -22,7 +22,7 @@ import br.com.orcinus.orca.core.feed.profile.account.Account
 import br.com.orcinus.orca.core.instance.Instance
 import br.com.orcinus.orca.core.instance.domain.Domain
 import br.com.orcinus.orca.core.instance.registration.Credentials
-import br.com.orcinus.orca.std.uri.HostedURIBuilder
+import br.com.orcinus.orca.std.uri.url.HostedURLBuilder
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
 
@@ -54,7 +54,7 @@ internal abstract class MastodonRegistrationWebpageInteractorWithUncertainLoadin
       MastodonRegistrationActivity.start(
         context,
         domain,
-        HostedURIBuilder.from(domain.uri).path("auth").path("sign_up").build()
+        HostedURLBuilder.from(domain.uri).path("auth").path("sign_up").build()
       ) { activity, webView, hasLoadedSuccessfully ->
         onInteraction(activity, webView, hasLoadedSuccessfully, credentials).also {
           runCatching { continuation.resume(it) }

--- a/core/sample/src/main/java/br/com/orcinus/orca/core/sample/feed/profile/post/Author.extensions.kt
+++ b/core/sample/src/main/java/br/com/orcinus/orca/core/sample/feed/profile/post/Author.extensions.kt
@@ -48,7 +48,8 @@ fun Author.Companion.createSample(
     avatarLoaderProvider.provide(AuthorImageSource.Default),
     name = "Jean Silva",
     Account.sample,
-    profileURI = URIBuilder.scheme("https").host("mastodon.social").path("@jeanbarrossilva").build()
+    profileURI =
+      URIBuilder.url().scheme("https").host("mastodon.social").path("@jeanbarrossilva").build()
   )
 }
 
@@ -67,7 +68,8 @@ internal fun Author.Companion.createChristianSample(
     avatarLoaderProvider.provide(AuthorImageSource.Christian),
     name = "Christian Selig",
     account = "christianselig" at "mastodon.social",
-    profileURI = URIBuilder.scheme("https").host("mastodon.social").path("@christianselig").build()
+    profileURI =
+      URIBuilder.url().scheme("https").host("mastodon.social").path("@christianselig").build()
   )
 }
 
@@ -85,6 +87,6 @@ internal fun Author.Companion.createRamboSample(
     avatarLoaderProvider.provide(AuthorImageSource.Rambo),
     name = "Guilherme Rambo",
     account = "_inside" at "mastodon.social",
-    profileURI = URIBuilder.scheme("https").host("mastodon.social").path("@_inside").build()
+    profileURI = URIBuilder.url().scheme("https").host("mastodon.social").path("@_inside").build()
   )
 }

--- a/core/sample/src/main/java/br/com/orcinus/orca/core/sample/feed/profile/post/DeletablePost.extensions.kt
+++ b/core/sample/src/main/java/br/com/orcinus/orca/core/sample/feed/profile/post/DeletablePost.extensions.kt
@@ -52,7 +52,8 @@ fun DeletablePost.Companion.createSample(
       publicationDateTime = ZonedDateTime.of(2_003, 10, 8, 8, 0, 0, 0, ZoneId.of("GMT-3")),
       favorite = createSampleToggleableStat(imageLoaderProvider),
       repost = createSampleToggleableStat(imageLoaderProvider),
-      URIBuilder.scheme("https")
+      URIBuilder.url()
+        .scheme("https")
         .host("mastodon.social")
         .path("@christianselig")
         .path("110492858891694580")

--- a/core/sample/src/main/java/br/com/orcinus/orca/core/sample/feed/profile/post/Post.extensions.kt
+++ b/core/sample/src/main/java/br/com/orcinus/orca/core/sample/feed/profile/post/Post.extensions.kt
@@ -83,7 +83,8 @@ fun Post.Companion.createSamples(
         publicationDateTime = ZonedDateTime.of(2_024, 4, 5, 9, 32, 0, 0, ZoneId.of("GMT-3")),
         favorite = createSampleToggleableStat(imageLoaderProvider),
         repost = createSampleToggleableStat(imageLoaderProvider),
-        URIBuilder.scheme("https")
+        URIBuilder.url()
+          .scheme("https")
           .host("mastodon.social")
           .path("@jeanbarrossilva")
           .path("111665399868682952")
@@ -110,7 +111,8 @@ fun Post.Companion.createSamples(
         ZonedDateTime.of(2_023, 11, 27, 18, 26, 0, 0, ZoneId.of("America/Halifax")),
       favorite = createSampleToggleableStat(imageLoaderProvider),
       repost = createSampleToggleableStat(imageLoaderProvider),
-      URIBuilder.scheme("https")
+      URIBuilder.url()
+        .scheme("https")
         .host("mastodon.social")
         .path("@christianselig")
         .path("111484624066823391")

--- a/core/sample/src/main/java/br/com/orcinus/orca/core/sample/feed/profile/post/content/Attachment.extensions.kt
+++ b/core/sample/src/main/java/br/com/orcinus/orca/core/sample/feed/profile/post/content/Attachment.extensions.kt
@@ -23,21 +23,24 @@ private val sampleAttachments =
   listOf(
     Attachment(
       description = "A very tall window with lots of windows.",
-      URIBuilder.scheme("https")
+      URIBuilder.url()
+        .scheme("https")
         .host("images.unsplash.com")
         .path("photo-1701432925081-9ccb2455c44c")
         .build()
     ),
     Attachment(
       description = "Brown wooden framed yellow padded chair.",
-      URIBuilder.scheme("https")
+      URIBuilder.url()
+        .scheme("https")
         .host("images.unsplash.com")
         .path("photo-1586023492125-27b2c045efd7")
         .build()
     ),
     Attachment(
       description = "Brown wooden seat beside white wooden table.",
-      URIBuilder.scheme("https")
+      URIBuilder.url()
+        .scheme("https")
         .host("images.unsplash.com")
         .path("photo-1600585152220-90363fe7e115")
         .build()
@@ -45,7 +48,8 @@ private val sampleAttachments =
     Attachment(
       description =
         "Black flat widescreen computer monitor with Apple Magic Keyboard and Mouse on desk.",
-      URIBuilder.scheme("https")
+      URIBuilder.url()
+        .scheme("https")
         .host("images.unsplash.com")
         .path("photo-1548611716-3000815a5803")
         .build()

--- a/core/sample/src/main/java/br/com/orcinus/orca/core/sample/feed/profile/post/content/highlight/Highlight.extensions.kt
+++ b/core/sample/src/main/java/br/com/orcinus/orca/core/sample/feed/profile/post/content/highlight/Highlight.extensions.kt
@@ -33,6 +33,6 @@ fun Highlight.Companion.createSample(
 ): Highlight {
   return Highlight(
     Headline.createSample(coverLoaderProvider),
-    URIBuilder.scheme("https").host("pixelpals.app").build()
+    URIBuilder.url().scheme("https").host("pixelpals.app").build()
   )
 }

--- a/core/sample/src/main/java/br/com/orcinus/orca/core/sample/feed/profile/post/repost/Repost.extensions.kt
+++ b/core/sample/src/main/java/br/com/orcinus/orca/core/sample/feed/profile/post/repost/Repost.extensions.kt
@@ -67,7 +67,8 @@ fun Repost.Companion.createSample(
       publicationDateTime = ZonedDateTime.of(2023, 8, 16, 16, 48, 43, 384, ZoneId.of("GMT-3")),
       favorite = createSampleToggleableStat(imageLoaderProvider),
       repost = createSampleToggleableStat(imageLoaderProvider),
-      URIBuilder.scheme("https")
+      URIBuilder.url()
+        .scheme("https")
         .host("mastodon.social")
         .path("@_inside")
         .path("110900315644335855")

--- a/core/shared-preferences/src/test/java/br/com/orcinus/orca/core/sharedpreferences/actor/mirror/MirroredActorTests.kt
+++ b/core/shared-preferences/src/test/java/br/com/orcinus/orca/core/sharedpreferences/actor/mirror/MirroredActorTests.kt
@@ -45,7 +45,8 @@ internal class MirroredActorTests {
     val encoder = createJsonTreeEncoder()
     val delegate = Actor.Authenticated.sample
     val avatarURI =
-      URIBuilder.scheme("https")
+      URIBuilder.url()
+        .scheme("https")
         .host("app.orca.jeanbarrossilva.com")
         .path("profile")
         .path("@jeanbarrossilva")
@@ -75,7 +76,8 @@ internal class MirroredActorTests {
   fun isDeserializableWhenAuthenticatedWithAvatarURI() {
     val delegate = Actor.Authenticated.sample
     val avatarURI =
-      URIBuilder.scheme("https")
+      URIBuilder.url()
+        .scheme("https")
         .host("app.orca.jeanbarrossilva.com")
         .path("profile")
         .path("@jeanbarrossilva")

--- a/core/shared-preferences/src/test/java/br/com/orcinus/orca/core/sharedpreferences/actor/mirror/image/ImageLoaderProviderFactoryTests.kt
+++ b/core/shared-preferences/src/test/java/br/com/orcinus/orca/core/sharedpreferences/actor/mirror/image/ImageLoaderProviderFactoryTests.kt
@@ -40,7 +40,8 @@ internal class ImageLoaderProviderFactoryTests {
   fun runsURICallbackWhenSourceIsURI() {
     assertThat(
         ImageLoaderProviderFactory.fold<SampleImageSource, _>(
-          URIBuilder.scheme("https")
+          URIBuilder.url()
+            .scheme("https")
             .host("app.orca.jeanbarrossilva.com")
             .path("profile")
             .path("@jeanbarrossilva")

--- a/core/src/main/java/br/com/orcinus/orca/core/instance/domain/Domain.kt
+++ b/core/src/main/java/br/com/orcinus/orca/core/instance/domain/Domain.kt
@@ -28,7 +28,7 @@ import java.net.URI
 value class Domain(private val value: String) : Serializable {
   /** [URI] that leads to this [Domain]. */
   val uri
-    get() = URIBuilder.scheme("https").host(value).build()
+    get() = URIBuilder.url().scheme("https").host(value).build()
 
   /** [IllegalArgumentException] thrown if the [value] is blank. */
   class BlankValueException internal constructor() :

--- a/core/src/test/java/br/com/orcinus/orca/core/feed/profile/post/content/ContentTests.kt
+++ b/core/src/test/java/br/com/orcinus/orca/core/feed/profile/post/content/ContentTests.kt
@@ -22,7 +22,7 @@ import br.com.orcinus.orca.core.sample.instance.domain.sample
 import br.com.orcinus.orca.core.sample.test.feed.profile.post.content.highlight.sample
 import br.com.orcinus.orca.std.markdown.Markdown
 import br.com.orcinus.orca.std.markdown.buildMarkdown
-import br.com.orcinus.orca.std.uri.HostedURIBuilder
+import br.com.orcinus.orca.std.uri.url.HostedURLBuilder
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -83,7 +83,7 @@ internal class ContentTests {
     Content.from(
       Domain.sample,
       buildMarkdown {
-        link(HostedURIBuilder.from(Domain.sample.uri).path("resource").build()) { +"Here" }
+        link(HostedURLBuilder.from(Domain.sample.uri).path("resource").build()) { +"Here" }
         +'!'
       }
     ) {

--- a/core/src/test/java/br/com/orcinus/orca/core/instance/domain/URIExtensionsTests.kt
+++ b/core/src/test/java/br/com/orcinus/orca/core/instance/domain/URIExtensionsTests.kt
@@ -19,15 +19,15 @@ import assertk.assertThat
 import assertk.assertions.isFalse
 import assertk.assertions.isTrue
 import br.com.orcinus.orca.core.sample.instance.domain.sample
-import br.com.orcinus.orca.std.uri.HostedURIBuilder
 import br.com.orcinus.orca.std.uri.URIBuilder
+import br.com.orcinus.orca.std.uri.url.HostedURLBuilder
 import kotlin.test.Test
 
 internal class URIExtensionsTests {
   @Test
   fun isInternalResourceURI() {
     assertThat(
-        HostedURIBuilder.from(Domain.sample.uri)
+        HostedURLBuilder.from(Domain.sample.uri)
           .path("path")
           .build()
           .isOfResourceFrom(Domain.sample)
@@ -38,7 +38,7 @@ internal class URIExtensionsTests {
   @Test
   fun isExternalResourceURI() {
     assertThat(
-        URIBuilder.scheme("https").host("google.com").build().isOfResourceFrom(Domain.sample)
+        URIBuilder.url().scheme("https").host("google.com").build().isOfResourceFrom(Domain.sample)
       )
       .isFalse()
   }

--- a/platform/intents-test/src/test/java/br/com/orcinus/orca/platform/intents/test/IntentsExtensionsTests.kt
+++ b/platform/intents-test/src/test/java/br/com/orcinus/orca/platform/intents/test/IntentsExtensionsTests.kt
@@ -59,12 +59,12 @@ internal class IntentsExtensionsTests {
 
   @Test(expected = AssertionFailedError::class)
   fun throwsWhenBrowsingIsIntendedButNotRequested() {
-    intendBrowsingTo(URIBuilder.scheme("https").host("orca.jeanbarrossilva.com").build()) {}
+    intendBrowsingTo(URIBuilder.url().scheme("https").host("orca.jeanbarrossilva.com").build()) {}
   }
 
   @Test
   fun intendsBrowsing() {
-    val uri = URIBuilder.scheme("https").host("orca.jeanbarrossilva.com").build()
+    val uri = URIBuilder.url().scheme("https").host("orca.jeanbarrossilva.com").build()
     intendBrowsingTo(uri) { browseTo(uri) }
   }
 

--- a/std/uri/src/main/java/br/com/orcinus/orca/std/uri/URIBuilder.kt
+++ b/std/uri/src/main/java/br/com/orcinus/orca/std/uri/URIBuilder.kt
@@ -15,21 +15,36 @@
 
 package br.com.orcinus.orca.std.uri
 
+import br.com.orcinus.orca.std.uri.url.URLBuilder
 import java.net.URI
 
 /**
  * Entrypoint that introduces an API for building [URI]s without having to rely on the unnamed and
  * error-prone parameters that the Java class' constructor requires.
  *
- * @see scheme
+ * @see url
+ * @see mailto
  */
 object URIBuilder {
   /**
-   * Defines the scheme of the [URI] to be built.
+   * Scheme of a `mailto` [URI].
    *
-   * @param scheme Specification about the type of application addressed by the [URI].
+   * @see mailto
    */
-  fun scheme(scheme: String): SchemedURIBuilder {
-    return SchemedURIBuilder(scheme)
+  internal const val MAILTO = "mailto"
+
+  /** Indicates that the [URI] to be built is a Universal Resource Locator (URL). */
+  fun url(): URLBuilder {
+    return URLBuilder()
+  }
+
+  /**
+   * Builds a `mailto` [URI].
+   *
+   * @param email E-mail box address for which the [URI] is.
+   */
+  fun mailto(email: String): URI {
+    val fragment = null
+    return URI(MAILTO, email, fragment)
   }
 }

--- a/std/uri/src/main/java/br/com/orcinus/orca/std/uri/url/HostedURLBuilder.kt
+++ b/std/uri/src/main/java/br/com/orcinus/orca/std/uri/url/HostedURLBuilder.kt
@@ -13,13 +13,13 @@
  * not, see https://www.gnu.org/licenses.
  */
 
-package br.com.orcinus.orca.std.uri
+package br.com.orcinus.orca.std.uri.url
 
 import java.net.URI
 import java.util.Objects
 
 /**
- * [URI] builder to which both a scheme and a host have been provided, from which paths can be
+ * URL [URI] builder to which both a scheme and a host have been provided, from which paths can be
  * appended, a query can be constructed and a [URI] can be finally built.
  *
  * @param scheme Specification about the type of application addressed by the [URI].
@@ -29,7 +29,7 @@ import java.util.Objects
  * @see query
  * @see build
  */
-class HostedURIBuilder internal constructor(private val scheme: String, private val host: String) {
+class HostedURLBuilder internal constructor(private val scheme: String, private val host: String) {
   /**
    * Segments that have been appended to the [URI] to be built.
    *
@@ -45,7 +45,7 @@ class HostedURIBuilder internal constructor(private val scheme: String, private 
     get() = '/' + segments.joinToString(separator = "/")
 
   override fun equals(other: Any?): Boolean {
-    return other is HostedURIBuilder &&
+    return other is HostedURLBuilder &&
       scheme == other.scheme &&
       host == other.host &&
       segments == other.segments
@@ -56,22 +56,22 @@ class HostedURIBuilder internal constructor(private val scheme: String, private 
   }
 
   /**
-   * Appends a segment to the path of the [URI] to be built.
+   * Appends a segment to the path of the URL [URI] to be built.
    *
    * @param path Segment that may resemble or map exactly to a file system path but does not always
    *   imply a relation to one.
    */
-  fun path(path: String): HostedURIBuilder {
+  fun path(path: String): HostedURLBuilder {
     segments += path
     return this
   }
 
-  /** Allows for query parameters to be appended from a [SegmentedURIBuilder]. */
-  fun query(): SegmentedURIBuilder {
-    return SegmentedURIBuilder(scheme, host, path)
+  /** Allows for query parameters to be appended from a [SegmentedURLBuilder]. */
+  fun query(): SegmentedURLBuilder {
+    return SegmentedURLBuilder(scheme, host, path)
   }
 
-  /** Builds a [URI] with the specified components. */
+  /** Builds a URL [URI] with the specified components. */
   fun build(): URI {
     val fragment = null
     return URI(scheme, host, path, fragment)
@@ -79,13 +79,13 @@ class HostedURIBuilder internal constructor(private val scheme: String, private 
 
   companion object {
     /**
-     * Creates a [HostedURIBuilder] from which path segments can be appended to the given existing
-     * [URI], allowing for a new one with the specified modifications to be built.
+     * Creates a [HostedURLBuilder] from which path segments can be appended to the given existing
+     * URL [URI], allowing for a new one with the specified modifications to be built.
      *
      * @param uri [URI] based on which another one can be built.
      */
-    fun from(uri: URI): HostedURIBuilder {
-      return HostedURIBuilder(uri.scheme, uri.host)
+    fun from(uri: URI): HostedURLBuilder {
+      return HostedURLBuilder(uri.scheme, uri.host)
     }
   }
 }

--- a/std/uri/src/main/java/br/com/orcinus/orca/std/uri/url/SchemedURLBuilder.kt
+++ b/std/uri/src/main/java/br/com/orcinus/orca/std/uri/url/SchemedURLBuilder.kt
@@ -13,25 +13,25 @@
  * not, see https://www.gnu.org/licenses.
  */
 
-package br.com.orcinus.orca.std.uri
+package br.com.orcinus.orca.std.uri.url
 
 import java.net.URI
 
 /**
- * [URI] builder to which a scheme has been provided, from which the host can be defined.
+ * URL [URI] builder to which a scheme has been provided, from which the host can be defined.
  *
  * @param scheme Specification about the type of application addressed by the [URI].
  * @see host
  */
 @JvmInline
-value class SchemedURIBuilder internal constructor(private val scheme: String) {
+value class SchemedURLBuilder internal constructor(private val scheme: String) {
   /**
-   * Defines the host of the [URI] to be built.
+   * Defines the host of the URL [URI] to be built.
    *
    * @param host Subcomponent consisting of either a registered name (including but not limited to a
    *   hostname) or an IP address.
    */
-  fun host(host: String): HostedURIBuilder {
-    return HostedURIBuilder(scheme, host)
+  fun host(host: String): HostedURLBuilder {
+    return HostedURLBuilder(scheme, host)
   }
 }

--- a/std/uri/src/main/java/br/com/orcinus/orca/std/uri/url/SegmentedURLBuilder.kt
+++ b/std/uri/src/main/java/br/com/orcinus/orca/std/uri/url/SegmentedURLBuilder.kt
@@ -13,13 +13,13 @@
  * not, see https://www.gnu.org/licenses.
  */
 
-package br.com.orcinus.orca.std.uri
+package br.com.orcinus.orca.std.uri.url
 
 import java.net.URI
 import java.util.Objects
 
 /**
- * [URI] builder to which a scheme, a host and a path have been provided, from which query
+ * URL [URI] builder to which a scheme, a host and a path have been provided, from which query
  * parameters can be appended and a [URI] can be finally built.
  *
  * @param scheme Specification about the type of application addressed by the [URI].
@@ -30,21 +30,21 @@ import java.util.Objects
  * @see parameter
  * @see build
  */
-class SegmentedURIBuilder
+class SegmentedURLBuilder
 internal constructor(
   private val scheme: String,
   private val host: String,
   private val path: String
 ) {
   /**
-   * Parameters that have been appended to the query of the [URI] to be built.
+   * Parameters that have been appended to the query of the URL [URI] to be built.
    *
    * @see parameter
    */
   private val query = hashMapOf<String, String>()
 
   override fun equals(other: Any?): Boolean {
-    return other is SegmentedURIBuilder &&
+    return other is SegmentedURLBuilder &&
       scheme == other.scheme &&
       host == other.host &&
       path == other.path
@@ -55,17 +55,17 @@ internal constructor(
   }
 
   /**
-   * Appends a query parameter to the [URI] to be built.
+   * Appends a query parameter to the URL [URI] to be built.
    *
    * @param key Identifier of the [value].
    * @param value Information to be associated to the [key] in the query.
    */
-  fun parameter(key: String, value: String): SegmentedURIBuilder {
+  fun parameter(key: String, value: String): SegmentedURLBuilder {
     query[key] = value
     return this
   }
 
-  /** Builds a [URI] with the specified components. */
+  /** Builds a URL [URI] with the specified components. */
   fun build(): URI {
     val query = query.map { (key, value) -> "$key=$value" }.joinToString(separator = "&")
     val fragment = null

--- a/std/uri/src/main/java/br/com/orcinus/orca/std/uri/url/URLBuilder.kt
+++ b/std/uri/src/main/java/br/com/orcinus/orca/std/uri/url/URLBuilder.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023–2024 Orcinus
+ * Copyright © 2024 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -13,26 +13,22 @@
  * not, see https://www.gnu.org/licenses.
  */
 
-package br.com.orcinus.orca.std.markdown.style
+package br.com.orcinus.orca.std.uri.url
 
-import br.com.orcinus.orca.std.markdown.Markdown
-import br.com.orcinus.orca.std.uri.URIBuilder
 import java.net.URI
 
 /**
- * Sample [URI] to create mentions with.
+ * Builder from which a [SchemedURLBuilder] can be obtained.
  *
- * @see Markdown.Builder.mention
- * @see Style.Mention
+ * @see scheme
  */
-internal val Style.Mention.Companion.uri
-  get() = URIBuilder.url().scheme("https").host("mastodon.social").path("@jeanbarrossilva").build()
-
-/**
- * Sample username to mention.
- *
- * @see Markdown.Builder.mention
- * @see Style.Mention
- */
-internal val Style.Mention.Companion.username
-  get() = "jeanbarrossilva"
+class URLBuilder internal constructor() {
+  /**
+   * Defines the scheme of the URL [URI] to be built.
+   *
+   * @param scheme Specification about the type of application addressed by the [URI].
+   */
+  fun scheme(scheme: String): SchemedURLBuilder {
+    return SchemedURLBuilder(scheme)
+  }
+}

--- a/std/uri/src/test/java/br/com/orcinus/orca/std/uri/URIBuilderTests.kt
+++ b/std/uri/src/test/java/br/com/orcinus/orca/std/uri/URIBuilderTests.kt
@@ -17,11 +17,19 @@ package br.com.orcinus.orca.std.uri
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import br.com.orcinus.orca.std.uri.url.SchemedURLBuilder
+import java.net.URI
 import kotlin.test.Test
 
 class URIBuilderTests {
   @Test
   fun createsSchemedURIBuilder() {
-    assertThat(URIBuilder.scheme("https")).isEqualTo(SchemedURIBuilder("https"))
+    assertThat(URIBuilder.url().scheme("https")).isEqualTo(SchemedURLBuilder("https"))
+  }
+
+  @Test
+  fun buildsMailtoURI() {
+    assertThat(URIBuilder.mailto("jean@orcinus.com.br"))
+      .isEqualTo(URI("${URIBuilder.MAILTO}:jean@orcinus.com.br"))
   }
 }

--- a/std/uri/src/test/java/br/com/orcinus/orca/std/uri/url/HostedURLBuilderTests.kt
+++ b/std/uri/src/test/java/br/com/orcinus/orca/std/uri/url/HostedURLBuilderTests.kt
@@ -13,24 +13,28 @@
  * not, see https://www.gnu.org/licenses.
  */
 
-package br.com.orcinus.orca.std.uri
+package br.com.orcinus.orca.std.uri.url
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import br.com.orcinus.orca.std.uri.URIBuilder
 import java.net.URI
 import kotlin.test.Test
 
-internal class HostedURIBuilderTests {
+internal class HostedURLBuilderTests {
   @Test
-  fun createsHostedURIBuilder() {
-    assertThat(HostedURIBuilder.from(URIBuilder.scheme("https").host("mastodon.social").build()))
-      .isEqualTo(HostedURIBuilder("https", "mastodon.social"))
+  fun createsHostedURLBuilder() {
+    assertThat(
+        HostedURLBuilder.from(URIBuilder.url().scheme("https").host("mastodon.social").build())
+      )
+      .isEqualTo(HostedURLBuilder("https", "mastodon.social"))
   }
 
   @Test
   fun appendsPaths() {
     assertThat(
-        URIBuilder.scheme("https")
+        URIBuilder.url()
+          .scheme("https")
           .host("mastodon.social")
           .path("@jeanbarrossilva")
           .path("following")
@@ -40,14 +44,15 @@ internal class HostedURIBuilderTests {
   }
 
   @Test
-  fun createsSegmentedURIBuilder() {
+  fun createsSegmentedURLBuilder() {
     assertThat(
-        URIBuilder.scheme("https")
+        URIBuilder.url()
+          .scheme("https")
           .host("mastodon.social")
           .path("@jeanbarrossilva")
           .path("followers")
           .query()
       )
-      .isEqualTo(SegmentedURIBuilder("https", "mastodon.social", "/@jeanbarrossilva/followers"))
+      .isEqualTo(SegmentedURLBuilder("https", "mastodon.social", "/@jeanbarrossilva/followers"))
   }
 }

--- a/std/uri/src/test/java/br/com/orcinus/orca/std/uri/url/SchemedURLBuilderTests.kt
+++ b/std/uri/src/test/java/br/com/orcinus/orca/std/uri/url/SchemedURLBuilderTests.kt
@@ -13,34 +13,17 @@
  * not, see https://www.gnu.org/licenses.
  */
 
-package br.com.orcinus.orca.std.uri
+package br.com.orcinus.orca.std.uri.url
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
-import java.net.URI
+import br.com.orcinus.orca.std.uri.URIBuilder
 import kotlin.test.Test
 
-internal class SegmentedURIBuilderTests {
+internal class SchemedURLBuilderTests {
   @Test
-  fun appendsParameters() {
-    assertThat(
-        URIBuilder.scheme("https")
-          .host("mastodon.social")
-          .path("api")
-          .path("v1")
-          .path("statuses")
-          .path("112276588128366269")
-          .path("reblogged_by")
-          .query()
-          .parameter("limit", "2")
-          .parameter("since_id", "112276666465473478")
-          .build()
-      )
-      .isEqualTo(
-        URI(
-          "https://mastodon.social/api/v1/statuses/112276588128366269/reblogged_by?limit=2&since_" +
-            "id=112276666465473478"
-        )
-      )
+  fun createsHostedURLBuilder() {
+    assertThat(URIBuilder.url().scheme("https").host("mastodon.social"))
+      .isEqualTo(HostedURLBuilder("https", "mastodon.social"))
   }
 }

--- a/std/uri/src/test/java/br/com/orcinus/orca/std/uri/url/SegmentedURLBuilderTests.kt
+++ b/std/uri/src/test/java/br/com/orcinus/orca/std/uri/url/SegmentedURLBuilderTests.kt
@@ -13,16 +13,36 @@
  * not, see https://www.gnu.org/licenses.
  */
 
-package br.com.orcinus.orca.std.uri
+package br.com.orcinus.orca.std.uri.url
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import br.com.orcinus.orca.std.uri.URIBuilder
+import java.net.URI
 import kotlin.test.Test
 
-internal class SchemedURIBuilderTests {
+internal class SegmentedURLBuilderTests {
   @Test
-  fun createsHostedURIBuilder() {
-    assertThat(URIBuilder.scheme("https").host("mastodon.social"))
-      .isEqualTo(HostedURIBuilder("https", "mastodon.social"))
+  fun appendsParameters() {
+    assertThat(
+        URIBuilder.url()
+          .scheme("https")
+          .host("mastodon.social")
+          .path("api")
+          .path("v1")
+          .path("statuses")
+          .path("112276588128366269")
+          .path("reblogged_by")
+          .query()
+          .parameter("limit", "2")
+          .parameter("since_id", "112276666465473478")
+          .build()
+      )
+      .isEqualTo(
+        URI(
+          "https://mastodon.social/api/v1/statuses/112276588128366269/reblogged_by?limit=2&since_" +
+            "id=112276666465473478"
+        )
+      )
   }
 }


### PR DESCRIPTION
For better distinction between the types of URIs that the [`URIBuilder`](https://github.com/orcinusbr/orca-android/blob/5693a86138ea49108df8e65beefc68b7ad1ddcb0/std/uri/src/main/java/br/com/orcinus/orca/std/uri/URIBuilder.kt#L37) can build, URL-specific builders have been made accessible through [`url(): URLBuilder`](https://github.com/orcinusbr/orca-android/blob/5693a86138ea49108df8e65beefc68b7ad1ddcb0/std/uri/src/main/java/br/com/orcinus/orca/std/uri/URIBuilder.kt#L37).