### PR TITLE
Simplify request routing

### DIFF
--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/network/requester/authentication/AuthenticatedRequester.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/network/requester/authentication/AuthenticatedRequester.kt
@@ -26,6 +26,7 @@ import br.com.orcinus.orca.core.module.CoreModule
 import br.com.orcinus.orca.core.module.authenticationLock
 import br.com.orcinus.orca.std.injector.Injector
 import br.com.orcinus.orca.std.injector.module.Module
+import br.com.orcinus.orca.std.uri.url.HostedURLBuilder
 import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.engine.HttpClientEngineFactory
 import io.ktor.client.request.HttpRequestBuilder
@@ -53,7 +54,7 @@ constructor(
   @get:InternalNetworkApi @get:VisibleForTesting internal val lock: SomeAuthenticationLock
 ) : Requester(logger, baseURI, clientEngineFactory) {
   override suspend fun delete(
-    route: URI.() -> URI,
+    route: HostedURLBuilder.() -> HostedURLBuilder,
     build: HttpRequestBuilder.() -> Unit
   ): HttpResponse {
     return lock.scheduleUnlock {
@@ -66,7 +67,7 @@ constructor(
 
   override suspend fun get(
     parameters: Parameters,
-    route: URI.() -> URI,
+    route: HostedURLBuilder.() -> HostedURLBuilder,
     build: HttpRequestBuilder.() -> Unit
   ): HttpResponse {
     return lock.scheduleUnlock {
@@ -79,7 +80,7 @@ constructor(
 
   override suspend fun post(
     parameters: Parameters,
-    route: URI.() -> URI,
+    route: HostedURLBuilder.() -> HostedURLBuilder,
     build: HttpRequestBuilder.() -> Unit
   ): HttpResponse {
     return lock.scheduleUnlock {
@@ -92,7 +93,7 @@ constructor(
 
   override suspend fun post(
     form: List<PartData>,
-    route: URI.() -> URI,
+    route: HostedURLBuilder.() -> HostedURLBuilder,
     build: HttpRequestBuilder.() -> Unit
   ): HttpResponse {
     return lock.scheduleUnlock {

--- a/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/network/requester/RequesterTestScope.kt
+++ b/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/network/requester/RequesterTestScope.kt
@@ -48,7 +48,7 @@ import kotlinx.coroutines.CoroutineScope
 internal class RequesterTestScope<T : Requester>(
   val delegate: MastodonClientTestScope<*>,
   val requester: T,
-  val route: URI.() -> URI
+  val route: HostedURLBuilder.() -> HostedURLBuilder
 ) : CoroutineScope by delegate
 
 /**
@@ -88,9 +88,6 @@ internal inline fun runRequesterTest(
     val baseURI = URIBuilder.url().scheme("https").host("orca.orcinus.com.br").path("app").build()
     val clientEngineFactory = createHttpClientEngineFactory<MockEngineConfig>(client::engine)
     val requester = Requester(NoOpLogger, baseURI, clientEngineFactory)
-    RequesterTestScope(this, requester) {
-        HostedURLBuilder.from(this).path("api").path("v1").path("resource").build()
-      }
-      .body()
+    RequesterTestScope(this, requester) { path("api").path("v1").path("resource") }.body()
   }
 }

--- a/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/network/requester/RequesterTests.kt
+++ b/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/network/requester/RequesterTests.kt
@@ -17,6 +17,7 @@ package br.com.orcinus.orca.core.mastodon.network.requester
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import br.com.orcinus.orca.std.uri.url.HostedURLBuilder
 import io.ktor.client.call.body
 import kotlin.test.Test
 
@@ -24,7 +25,8 @@ internal class RequesterTests {
   @Test
   fun makesRouteAbsolute() {
     runRequesterTest {
-      assertThat(requester.absolute(route)).isEqualTo("${requester.baseURI.route()}")
+      assertThat(requester.absolute(route))
+        .isEqualTo("${HostedURLBuilder.from(requester.baseURI).route().build()}")
     }
   }
 


### PR DESCRIPTION
Requests that would be performed as

```kotlin
requester.get { HostedURIBuilder.from(this).path("api").path("v1").path("resource").build() }
```

are now done so as

```kotlin
requester.get { path("api").path("v1").path("resource") }
```