### PR TITLE
Make routing return a `URI`

### DIFF
--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/network/requester/Requester.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/network/requester/Requester.kt
@@ -78,7 +78,7 @@ constructor(
    *
    * @param route Builds the route from the [baseURI] to which the request will be sent.
    */
-  suspend fun delete(route: HostedURLBuilder.() -> HostedURLBuilder): HttpResponse {
+  suspend fun delete(route: HostedURLBuilder.() -> URI): HttpResponse {
     return delete(route, noOpRequestBuild)
   }
 
@@ -90,7 +90,7 @@ constructor(
    */
   suspend fun get(
     parameters: Parameters = Parameters.Empty,
-    route: HostedURLBuilder.() -> HostedURLBuilder
+    route: HostedURLBuilder.() -> URI
   ): HttpResponse {
     return get(parameters, route, noOpRequestBuild)
   }
@@ -103,7 +103,7 @@ constructor(
    */
   suspend fun post(
     parameters: Parameters = Parameters.Empty,
-    route: HostedURLBuilder.() -> HostedURLBuilder
+    route: HostedURLBuilder.() -> URI
   ): HttpResponse {
     return post(parameters, route, noOpRequestBuild)
   }
@@ -114,10 +114,7 @@ constructor(
    * @param form `multipart/form-data`-encoded parts to be added as headers.
    * @param route Builds the route from the [baseURI] to which the request will be sent.
    */
-  suspend fun post(
-    form: List<PartData>,
-    route: HostedURLBuilder.() -> HostedURLBuilder
-  ): HttpResponse {
+  suspend fun post(form: List<PartData>, route: HostedURLBuilder.() -> URI): HttpResponse {
     return post(form, route, noOpRequestBuild)
   }
 
@@ -129,7 +126,7 @@ constructor(
    */
   @InternalNetworkApi
   internal open suspend fun delete(
-    route: HostedURLBuilder.() -> HostedURLBuilder,
+    route: HostedURLBuilder.() -> URI,
     build: HttpRequestBuilder.() -> Unit
   ): HttpResponse {
     return client.delete(absolute(route), build)
@@ -145,7 +142,7 @@ constructor(
   @InternalNetworkApi
   internal open suspend fun get(
     parameters: Parameters = Parameters.Empty,
-    route: HostedURLBuilder.() -> HostedURLBuilder,
+    route: HostedURLBuilder.() -> URI,
     build: HttpRequestBuilder.() -> Unit
   ): HttpResponse {
     return client.get(absolute(route)) {
@@ -164,7 +161,7 @@ constructor(
   @InternalNetworkApi
   internal open suspend fun post(
     parameters: Parameters = Parameters.Empty,
-    route: HostedURLBuilder.() -> HostedURLBuilder,
+    route: HostedURLBuilder.() -> URI,
     build: HttpRequestBuilder.() -> Unit
   ): HttpResponse {
     return if (parameters.isEmpty()) {
@@ -184,7 +181,7 @@ constructor(
   @InternalNetworkApi
   internal open suspend fun post(
     form: List<PartData>,
-    route: HostedURLBuilder.() -> HostedURLBuilder,
+    route: HostedURLBuilder.() -> URI,
     build: HttpRequestBuilder.() -> Unit
   ): HttpResponse {
     return if (form.isEmpty()) {
@@ -201,8 +198,8 @@ constructor(
    */
   @InternalNetworkApi
   @VisibleForTesting(otherwise = VisibleForTesting.PROTECTED)
-  internal fun absolute(route: HostedURLBuilder.() -> HostedURLBuilder): String {
-    return HostedURLBuilder.from(baseURI).route().build().toString()
+  internal fun absolute(route: HostedURLBuilder.() -> URI): String {
+    return HostedURLBuilder.from(baseURI).route().toString()
   }
 
   /** Configures retrying behavior on requests that fail due to server errors. */

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/network/requester/authentication/AuthenticatedRequester.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/network/requester/authentication/AuthenticatedRequester.kt
@@ -54,7 +54,7 @@ constructor(
   @get:InternalNetworkApi @get:VisibleForTesting internal val lock: SomeAuthenticationLock
 ) : Requester(logger, baseURI, clientEngineFactory) {
   override suspend fun delete(
-    route: HostedURLBuilder.() -> HostedURLBuilder,
+    route: HostedURLBuilder.() -> URI,
     build: HttpRequestBuilder.() -> Unit
   ): HttpResponse {
     return lock.scheduleUnlock {
@@ -67,7 +67,7 @@ constructor(
 
   override suspend fun get(
     parameters: Parameters,
-    route: HostedURLBuilder.() -> HostedURLBuilder,
+    route: HostedURLBuilder.() -> URI,
     build: HttpRequestBuilder.() -> Unit
   ): HttpResponse {
     return lock.scheduleUnlock {
@@ -80,7 +80,7 @@ constructor(
 
   override suspend fun post(
     parameters: Parameters,
-    route: HostedURLBuilder.() -> HostedURLBuilder,
+    route: HostedURLBuilder.() -> URI,
     build: HttpRequestBuilder.() -> Unit
   ): HttpResponse {
     return lock.scheduleUnlock {
@@ -93,7 +93,7 @@ constructor(
 
   override suspend fun post(
     form: List<PartData>,
-    route: HostedURLBuilder.() -> HostedURLBuilder,
+    route: HostedURLBuilder.() -> URI,
     build: HttpRequestBuilder.() -> Unit
   ): HttpResponse {
     return lock.scheduleUnlock {

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/network/requester/resumption/ResumableRequester.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/network/requester/resumption/ResumableRequester.kt
@@ -104,7 +104,7 @@ constructor(
     CancellationException("$request has been interrupted by its requester.")
 
   override suspend fun delete(
-    route: HostedURLBuilder.() -> HostedURLBuilder,
+    route: HostedURLBuilder.() -> URI,
     build: HttpRequestBuilder.() -> Unit
   ): HttpResponse {
     return prepareForResumption(Request.MethodName.DELETE, Parameterization.empty, route) {
@@ -114,7 +114,7 @@ constructor(
 
   override suspend fun get(
     parameters: Parameters,
-    route: HostedURLBuilder.() -> HostedURLBuilder,
+    route: HostedURLBuilder.() -> URI,
     build: HttpRequestBuilder.() -> Unit
   ): HttpResponse {
     return prepareForResumption(Request.MethodName.GET, Parameterization.Body(parameters), route) {
@@ -124,7 +124,7 @@ constructor(
 
   override suspend fun post(
     parameters: Parameters,
-    route: HostedURLBuilder.() -> HostedURLBuilder,
+    route: HostedURLBuilder.() -> URI,
     build: HttpRequestBuilder.() -> Unit
   ): HttpResponse {
     return prepareForResumption(Request.MethodName.POST, Parameterization.Body(parameters), route) {
@@ -134,7 +134,7 @@ constructor(
 
   override suspend fun post(
     form: List<PartData>,
-    route: HostedURLBuilder.() -> HostedURLBuilder,
+    route: HostedURLBuilder.() -> URI,
     build: HttpRequestBuilder.() -> Unit
   ): HttpResponse {
     return prepareForResumption(Request.MethodName.POST, Parameterization.Headers(form), route) {
@@ -151,7 +151,7 @@ constructor(
    */
   suspend fun resume() {
     requestDao.selectAll().forEach {
-      val route = { _: HostedURLBuilder -> HostedURLBuilder.from(URI(it.route)) }
+      val route = { _: HostedURLBuilder -> URI(it.route) }
       it.fold(
         onDelete = { delete(route) },
         onGet = {
@@ -202,7 +202,7 @@ constructor(
   private suspend inline fun prepareForResumption(
     @Request.MethodName methodName: String,
     parameterization: Parameterization<*>,
-    noinline route: HostedURLBuilder.() -> HostedURLBuilder,
+    noinline route: HostedURLBuilder.() -> URI,
     crossinline request: suspend () -> HttpResponse
   ): HttpResponse {
     contract { callsInPlace(request, InvocationKind.AT_MOST_ONCE) }

--- a/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/network/requester/RequesterTestScope.kt
+++ b/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/network/requester/RequesterTestScope.kt
@@ -41,14 +41,14 @@ import kotlinx.coroutines.CoroutineScope
  * @property delegate [MastodonClientTestScope] to which [CoroutineScope]-like functionality will be
  *   delegated.
  * @property requester [Requester] that's been created.
- * @property route Produces a default route from the [requester]'s base [URI] to which the
- *   [requester]'s requests can be sent.
+ * @property route Produces a default route from the [requester]'s base [URI] to which the requests
+ *   can be sent.
  */
 @InternalNetworkApi
 internal class RequesterTestScope<T : Requester>(
   val delegate: MastodonClientTestScope<*>,
   val requester: T,
-  val route: HostedURLBuilder.() -> HostedURLBuilder
+  val route: HostedURLBuilder.() -> URI
 ) : CoroutineScope by delegate
 
 /**
@@ -88,6 +88,6 @@ internal inline fun runRequesterTest(
     val baseURI = URIBuilder.url().scheme("https").host("orca.orcinus.com.br").path("app").build()
     val clientEngineFactory = createHttpClientEngineFactory<MockEngineConfig>(client::engine)
     val requester = Requester(NoOpLogger, baseURI, clientEngineFactory)
-    RequesterTestScope(this, requester) { path("api").path("v1").path("resource") }.body()
+    RequesterTestScope(this, requester) { path("api").path("v1").path("resource").build() }.body()
   }
 }

--- a/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/network/requester/RequesterTests.kt
+++ b/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/network/requester/RequesterTests.kt
@@ -26,7 +26,7 @@ internal class RequesterTests {
   fun makesRouteAbsolute() {
     runRequesterTest {
       assertThat(requester.absolute(route))
-        .isEqualTo("${HostedURLBuilder.from(requester.baseURI).route().build()}")
+        .isEqualTo("${HostedURLBuilder.from(requester.baseURI).route()}")
     }
   }
 


### PR DESCRIPTION
[`Requester`](https://github.com/orcinusbr/orca-android/blob/0d72a6e5e0fe0e26a0edc4a9599171a70cb3ca85/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/network/requester/Requester.kt)'s requests' routing now provide a [`URI`](https://docs.oracle.com/en%2Fjava%2Fjavase%2F22%2Fdocs%2Fapi%2F%2F/java.base/java/net/URI.html) instead of a [`HostedURLBuilder`](https://github.com/orcinusbr/orca-android/blob/0d72a6e5e0fe0e26a0edc4a9599171a70cb3ca85/std/uri/src/main/java/br/com/orcinus/orca/std/uri/url/HostedURLBuilder.kt), which limited modifications that would be able to be done the resulting [`URI`](https://docs.oracle.com/en%2Fjava%2Fjavase%2F22%2Fdocs%2Fapi%2F%2F/java.base/java/net/URI.html) otherwise, such as including query parameters. Doing the following would result in a compilation error, given that the returned value is a [`SegmentedURLBuilder`](https://github.com/orcinusbr/orca-android/blob/0d72a6e5e0fe0e26a0edc4a9599171a70cb3ca85/std/uri/src/main/java/br/com/orcinus/orca/std/uri/url/SegmentedURLBuilder.kt) instead of the expected [`HostedURLBuilder`](https://github.com/orcinusbr/orca-android/blob/0d72a6e5e0fe0e26a0edc4a9599171a70cb3ca85/std/uri/src/main/java/br/com/orcinus/orca/std/uri/url/HostedURLBuilder.kt):

```kotlin
requester.get { path("api").path("v1").path("resource").query().parameter("key", "value") }
```

With the changes contained in this PR, the lambda now returns a [`URI`](https://docs.oracle.com/en%2Fjava%2Fjavase%2F22%2Fdocs%2Fapi%2F%2F/java.base/java/net/URI.html):

```kotlin
requester.get { path("api").path("v1").path("resource").query().parameter("key", "value").build() }
```