### PR TITLE
Create markdown through factory methods

### DIFF
--- a/composite/timeline/src/main/java/br/com/orcinus/orca/composite/timeline/text/annotated/AnnotatedString.extensions.kt
+++ b/composite/timeline/src/main/java/br/com/orcinus/orca/composite/timeline/text/annotated/AnnotatedString.extensions.kt
@@ -22,5 +22,5 @@ import br.com.orcinus.orca.std.markdown.Markdown
 /** Converts this [AnnotatedString] into [Markdown]. */
 fun AnnotatedString.toMarkdown(): Markdown {
   val styles = spanStyles.flatMap { StyleExtractor.extractAll(it.item, it.start..it.end.dec()) }
-  return Markdown(text, styles)
+  return Markdown.styled(text, styles)
 }

--- a/composite/timeline/src/main/java/br/com/orcinus/orca/composite/timeline/text/spanned/Spanned.extensions.kt
+++ b/composite/timeline/src/main/java/br/com/orcinus/orca/composite/timeline/text/spanned/Spanned.extensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023-2024 Orcinus
+ * Copyright © 2023–2024 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -36,5 +36,5 @@ import br.com.orcinus.orca.std.markdown.style.Style
 fun Spanned.toMarkdown(context: Context): Markdown {
   val text = toString()
   val styles = getIndexedSpans(context).flatMap(IndexedSpans::toStyles)
-  return Markdown(text, styles)
+  return Markdown.styled(text, styles)
 }

--- a/composite/timeline/src/test/java/br/com/orcinus/orca/composite/timeline/post/figure/FigureTests.kt
+++ b/composite/timeline/src/test/java/br/com/orcinus/orca/composite/timeline/post/figure/FigureTests.kt
@@ -51,7 +51,7 @@ internal class FigureTests {
         Figure.of(
           Posts.withSample.single().id,
           Author.sample.name,
-          Content.from(Domain.sample, text = Markdown(""), Attachment.samples) { null },
+          Content.from(Domain.sample, text = Markdown.empty, Attachment.samples) { null },
           onLinkClick = {}
         )
       )

--- a/composite/timeline/src/test/java/br/com/orcinus/orca/composite/timeline/text/MarkdownExtensionsTests.kt
+++ b/composite/timeline/src/test/java/br/com/orcinus/orca/composite/timeline/text/MarkdownExtensionsTests.kt
@@ -28,6 +28,7 @@ import org.robolectric.RobolectricTestRunner
 internal class MarkdownExtensionsTests {
   @Test
   fun breaksLineTwiceBetweenParagraphsWhenConvertingHtmlToMarkdown() {
-    assertThat(Markdown.fromHtml(context, "<p>👔</p><p>🥾</p>")).isEqualTo(Markdown("👔\n\n🥾"))
+    assertThat(Markdown.fromHtml(context, "<p>👔</p><p>🥾</p>"))
+      .isEqualTo(Markdown.unstyled("👔\n\n🥾"))
   }
 }

--- a/composite/timeline/src/test/java/br/com/orcinus/orca/composite/timeline/text/annotated/span/AnnotatedStringExtensionsTests.kt
+++ b/composite/timeline/src/test/java/br/com/orcinus/orca/composite/timeline/text/annotated/span/AnnotatedStringExtensionsTests.kt
@@ -28,7 +28,8 @@ import kotlin.test.Test
 internal class AnnotatedStringExtensionsTests {
   @Test
   fun convertsAnnotatedStringWithoutAnnotationsIntoMarkdown() {
-    assertThat(AnnotatedString("Hello, world!").toMarkdown()).isEqualTo(Markdown("Hello, world!"))
+    assertThat(AnnotatedString("Hello, world!").toMarkdown())
+      .isEqualTo(Markdown.unstyled("Hello, world!"))
   }
 
   @Test

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/cache/storage/MastodonProfileEntity.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/cache/storage/MastodonProfileEntity.kt
@@ -172,7 +172,7 @@ internal constructor(
    */
   private suspend fun getBioAsMarkdown(dao: MastodonProfileEntityDao): Markdown {
     val styles = dao.selectWithBioStylesByID(id).styles.map(MastodonStyleEntity::toStyle)
-    return Markdown(bio, styles)
+    return Markdown.styled(bio, styles)
   }
 
   companion object {

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/cache/storage/MastodonPostEntity.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/cache/storage/MastodonPostEntity.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023-2024 Orcinus
+ * Copyright © 2023–2024 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -99,7 +99,7 @@ internal data class MastodonPostEntity(
     val author = profileCache.get(authorID).toAuthor()
     val domain = Injector.from<CoreModule>().instanceProvider().provide().domain
     val styles = dao.selectWithStylesByID(id).styles.map(MastodonStyleEntity::toStyle)
-    val text = Markdown(text, styles)
+    val text = Markdown.styled(text, styles)
     val coverLoader = headlineCoverURI?.let { imageLoaderProvider.provide(URI(it)) }
     val content =
       Content.from(domain, text) {

--- a/core/sample/src/main/java/br/com/orcinus/orca/core/sample/feed/profile/Profile.extensions.kt
+++ b/core/sample/src/main/java/br/com/orcinus/orca/core/sample/feed/profile/Profile.extensions.kt
@@ -43,7 +43,7 @@ fun Profile.Companion.createSample(
     override val avatarLoader = author.avatarLoader
     override val name = author.name
     override val bio =
-      Markdown(
+      Markdown.unstyled(
         "Co-founder @ Grupo Estoa, software engineer, author, writer and content creator; " +
           "neuroscience, quantum physics and philosophy enthusiast."
       )

--- a/core/sample/src/main/java/br/com/orcinus/orca/core/sample/feed/profile/post/repost/Repost.extensions.kt
+++ b/core/sample/src/main/java/br/com/orcinus/orca/core/sample/feed/profile/post/repost/Repost.extensions.kt
@@ -54,7 +54,7 @@ fun Repost.Companion.createSample(
       Author.createRamboSample(imageLoaderProvider),
       Content.from(
         Domain.sample,
-        Markdown(
+        Markdown.unstyled(
           "Programming life hack. Looking for real-world examples of how an API is used? Search " +
             "for code on GitHub like so: “APINameHere path:*.extension”. Practical example for a " +
             "MusicKit API in Swift: “MusicCatalogResourceRequest extension:*.swift”. I can " +

--- a/core/src/test/java/br/com/orcinus/orca/core/feed/profile/post/content/ContentTests.kt
+++ b/core/src/test/java/br/com/orcinus/orca/core/feed/profile/post/content/ContentTests.kt
@@ -30,7 +30,7 @@ internal class ContentTests {
   @Test
   fun `GIVEN a text with a trailing link and a headline WHEN creating content from them THEN the link is removed`() {
     assertEquals(
-      Markdown("😗"),
+      Markdown.unstyled("😗"),
       Content.from(
           Domain.sample,
           buildMarkdown {

--- a/platform/markdown/src/main/java/br/com/orcinus/orca/platform/markdown/MarkdownTextField.kt
+++ b/platform/markdown/src/main/java/br/com/orcinus/orca/platform/markdown/MarkdownTextField.kt
@@ -86,7 +86,7 @@ fun MarkdownTextField(
   val context = LocalContext.current
   val editText = remember(context) { EditText(context) }
   var styles by remember(state) { mutableStateOf(emptyList<Style>()) }
-  val markDown: (String) -> Markdown by rememberUpdatedState { Markdown(it, styles) }
+  val markDown: (String) -> Markdown by rememberUpdatedState { Markdown.styled(it, styles) }
   val onStylizationListener =
     remember(state) {
       MarkdownTextFieldState.OnStylizationListener {

--- a/platform/markdown/src/test/java/br/com/orcinus/orca/platform/markdown/MarkdownTextFieldTests.kt
+++ b/platform/markdown/src/test/java/br/com/orcinus/orca/platform/markdown/MarkdownTextFieldTests.kt
@@ -17,7 +17,6 @@ package br.com.orcinus.orca.platform.markdown
 
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.createComposeRule
@@ -43,9 +42,7 @@ internal class MarkdownTextFieldTests {
   fun doesNotChangeText() {
     composeRule
       .apply {
-        setContent {
-          MarkdownTextField(stateRule.state, remember { Markdown("") }, onTextChange = {})
-        }
+        setContent { MarkdownTextField(stateRule.state, Markdown.empty, onTextChange = {}) }
       }
       .onMarkdownTextField()
       .apply { performTextInput(":c") }
@@ -54,7 +51,7 @@ internal class MarkdownTextFieldTests {
 
   @Test
   fun notifiesChangesToText() {
-    var text by mutableStateOf(Markdown(""))
+    var text by mutableStateOf(Markdown.empty)
     composeRule
       .apply {
         setContent { MarkdownTextField(stateRule.state, text, onTextChange = { text = it }) }
@@ -66,7 +63,7 @@ internal class MarkdownTextFieldTests {
 
   @Test
   fun notifiesChangeToTextWhenStyleIsApplied() {
-    var text by mutableStateOf(Markdown("君の名は。"))
+    var text by mutableStateOf(Markdown.unstyled("君の名は。"))
     composeRule.setContent {
       MarkdownTextField(stateRule.state, text, onTextChange = { text = it })
     }

--- a/std/markdown/src/test/java/br/com/orcinus/orca/std/markdown/MarkdownTests.kt
+++ b/std/markdown/src/test/java/br/com/orcinus/orca/std/markdown/MarkdownTests.kt
@@ -18,12 +18,35 @@ package br.com.orcinus.orca.std.markdown
 import assertk.assertThat
 import assertk.assertions.containsExactly
 import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import assertk.assertions.isSameAs
 import br.com.orcinus.orca.std.markdown.style.Style
 import java.net.URI
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 
 internal class MarkdownTests {
+  @Test
+  fun createsUnstyledMarkdown() {
+    assertThat(Markdown.unstyled("💍").styles).isEmpty()
+  }
+
+  @Test
+  fun returnsEmptyMarkdownWhenCreatingStyledOneWithBothTextAndStylesBeingEmpty() {
+    assertThat(Markdown.styled("", styles = emptyList())).isSameAs(Markdown.empty)
+  }
+
+  @Test
+  fun createsMarkdownWithSpecifiedTextWhenTextIsNotEmptyAndIsUnstyled() {
+    assertThat("${Markdown.styled("☕️", styles = emptyList())}").isEqualTo("☕️")
+  }
+
+  @Test
+  fun createsMarkdownWithSpecifiedStylesWhenTextIsEmptyAndUnstyled() {
+    assertThat(Markdown.styled("", styles = listOf(Style.Bold(0..0))).styles)
+      .containsExactly(Style.Bold(0..0))
+  }
+
   @Test
   fun doesNotStylizeMalformattedEmailWhenItIsAppended() {
     assertThat(buildMarkdown { +"john@@appleseed.com" }.styles).isEmpty()


### PR DESCRIPTION
Delegates instantiation of [`Markdown`](https://github.com/orcinusbr/orca-android/blob/118d7ce61f6329ae4a54e5bcd211cbb5e257054e/std/markdown/src/main/java/br/com/orcinus/orca/std/markdown/Markdown.kt) objects to two factory methods: [`Markdown.Companion.unstyled(String): Markdown`](https://github.com/orcinusbr/orca-android/blob/118d7ce61f6329ae4a54e5bcd211cbb5e257054e/std/markdown/src/main/java/br/com/orcinus/orca/std/markdown/Markdown.kt#L190) and [`Markdown.Companion.styled(String, List<Style>): Markdown`](https://github.com/orcinusbr/orca-android/blob/118d7ce61f6329ae4a54e5bcd211cbb5e257054e/std/markdown/src/main/java/br/com/orcinus/orca/std/markdown/Markdown.kt#L200).