### PR TITLE
Pass requester by argument

### DIFF
--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/auth/authentication/MastodonAuthenticationToken.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/auth/authentication/MastodonAuthenticationToken.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023-2024 Orcinus
+ * Copyright © 2023–2024 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -16,14 +16,10 @@
 package br.com.orcinus.orca.core.mastodon.auth.authentication
 
 import br.com.orcinus.orca.core.auth.actor.Actor
-import br.com.orcinus.orca.core.mastodon.instance.SomeMastodonInstance
-import br.com.orcinus.orca.core.module.CoreModule
-import br.com.orcinus.orca.core.module.instanceProvider
+import br.com.orcinus.orca.core.mastodon.instance.requester.Requester
 import br.com.orcinus.orca.std.image.ImageLoader
 import br.com.orcinus.orca.std.image.SomeImageLoaderProvider
-import br.com.orcinus.orca.std.injector.Injector
 import io.ktor.client.call.body
-import io.ktor.client.request.get
 import io.ktor.http.HttpHeaders
 import java.net.URI
 import kotlinx.serialization.Serializable
@@ -40,14 +36,17 @@ internal data class MastodonAuthenticationToken(val accessToken: String) {
    * Converts this [MastodonAuthenticationToken] into an [authenticated][Actor.Authenticated]
    * [Actor].
    *
+   * @param requester [Requester] by which a request to verify the credentials will be performed.
    * @param avatarLoaderProvider [ImageLoader.Provider] that provides the [ImageLoader] by which the
    *   avatar will be loaded from a [URI].
    */
-  suspend fun toActor(avatarLoaderProvider: SomeImageLoaderProvider<URI>): Actor.Authenticated {
+  suspend fun toActor(
+    requester: Requester,
+    avatarLoaderProvider: SomeImageLoaderProvider<URI>
+  ): Actor.Authenticated {
     return toActor(
       avatarLoaderProvider,
-      (Injector.from<CoreModule>().instanceProvider().provide() as SomeMastodonInstance)
-        .requester
+      requester
         .get({ path("api").path("v1").path("accounts").path("verify_credentials").build() }) {
           headers { append(HttpHeaders.Authorization, "Bearer $accessToken") }
         }

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/auth/authentication/activity/MastodonAuthenticationActivity.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/auth/authentication/activity/MastodonAuthenticationActivity.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023-2024 Orcinus
+ * Copyright © 2023–2024 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -22,6 +22,7 @@ import androidx.compose.runtime.Composable
 import br.com.orcinus.orca.composite.composable.ComposableActivity
 import br.com.orcinus.orca.core.auth.actor.Actor
 import br.com.orcinus.orca.core.instance.InstanceProvider
+import br.com.orcinus.orca.core.mastodon.MastodonCoreModule
 import br.com.orcinus.orca.core.mastodon.auth.authentication.MastodonAuthentication
 import br.com.orcinus.orca.core.mastodon.auth.authentication.MastodonAuthenticationViewModel
 import br.com.orcinus.orca.core.mastodon.instance.ContextualMastodonInstance
@@ -36,7 +37,7 @@ import br.com.orcinus.orca.std.injector.Injector
  */
 class MastodonAuthenticationActivity : ComposableActivity() {
   /** [CoreModule] into which core-HTTP-related dependencies have been injected. */
-  private val module by lazy { Injector.from<CoreModule>() }
+  private val module by lazy { Injector.from<MastodonCoreModule>() }
 
   /** Code provided by the API when the user was authorized. */
   private val authorizationCode by extra<String>(AUTHORIZATION_CODE_KEY)
@@ -49,6 +50,7 @@ class MastodonAuthenticationActivity : ComposableActivity() {
     viewModels<MastodonAuthenticationViewModel> {
       MastodonAuthenticationViewModel.createFactory(
         application,
+        instance.requester,
         instance.imageLoaderProvider,
         authorizationCode
       )

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/MastodonFeedPaginator.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/MastodonFeedPaginator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023-2024 Orcinus
+ * Copyright © 2023–2024 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -20,12 +20,14 @@ import br.com.orcinus.orca.core.mastodon.feed.profile.post.MastodonPost
 import br.com.orcinus.orca.core.mastodon.feed.profile.post.pagination.MastodonPostPaginator
 import br.com.orcinus.orca.core.mastodon.feed.profile.post.pagination.MastodonStatusesPaginator
 import br.com.orcinus.orca.core.mastodon.feed.profile.post.stat.comment.MastodonCommentPaginator
+import br.com.orcinus.orca.core.mastodon.instance.requester.Requester
 import br.com.orcinus.orca.std.image.SomeImageLoaderProvider
 import java.net.URI
 
 /** [MastodonPostPaginator] that paginates through [MastodonPost]s of the feed. */
 internal class MastodonFeedPaginator(
   override val context: Context,
+  override val requester: Requester,
   override val imageLoaderProvider: SomeImageLoaderProvider<URI>,
   override val commentPaginatorProvider: MastodonCommentPaginator.Provider
 ) : MastodonStatusesPaginator() {

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/MastodonProfilePostPaginator.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/MastodonProfilePostPaginator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023-2024 Orcinus
+ * Copyright © 2023–2024 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -21,6 +21,7 @@ import br.com.orcinus.orca.core.mastodon.feed.profile.post.pagination.MastodonPo
 import br.com.orcinus.orca.core.mastodon.feed.profile.post.pagination.MastodonStatusesPaginator
 import br.com.orcinus.orca.core.mastodon.feed.profile.post.stat.comment.MastodonCommentPaginator
 import br.com.orcinus.orca.core.mastodon.feed.profile.post.status.MastodonStatus
+import br.com.orcinus.orca.core.mastodon.instance.requester.Requester
 import br.com.orcinus.orca.std.image.SomeImageLoaderProvider
 import java.net.URI
 
@@ -32,6 +33,7 @@ import java.net.URI
  */
 internal class MastodonProfilePostPaginator(
   override val context: Context,
+  override val requester: Requester,
   override val imageLoaderProvider: SomeImageLoaderProvider<URI>,
   override val commentPaginatorProvider: MastodonCommentPaginator.Provider,
   id: String

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/cache/storage/MastodonProfileStorage.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/cache/storage/MastodonProfileStorage.kt
@@ -19,6 +19,9 @@ import br.com.orcinus.orca.core.feed.profile.Profile
 import br.com.orcinus.orca.core.feed.profile.post.Post
 import br.com.orcinus.orca.core.mastodon.feed.profile.MastodonProfile
 import br.com.orcinus.orca.core.mastodon.feed.profile.MastodonProfilePostPaginator
+import br.com.orcinus.orca.core.mastodon.feed.profile.type.editable.MastodonEditableProfile
+import br.com.orcinus.orca.core.mastodon.feed.profile.type.followable.MastodonFollowableProfile
+import br.com.orcinus.orca.core.mastodon.instance.requester.Requester
 import br.com.orcinus.orca.platform.cache.Storage
 import br.com.orcinus.orca.std.image.ImageLoader
 import br.com.orcinus.orca.std.image.SomeImageLoaderProvider
@@ -28,15 +31,18 @@ import kotlinx.coroutines.flow.first
 /**
  * [Storage] for [Profile]s.
  *
- * @param avatarLoaderProvider [ImageLoader.Provider] that provides the [ImageLoader] by which the
- *   [Profile]'s avatar will be loaded from a [URI].
- * @param postPaginatorProvider [MastodonProfilePostPaginator.Provider] by which a
+ * @property requester [Requester] by which a [MastodonEditableProfile]'s editing requests are
+ *   performed and a [MastodonFollowableProfile]'s follow status is obtained.
+ * @property avatarLoaderProvider [ImageLoader.Provider] that provides the [ImageLoader] by which
+ *   the [Profile]'s avatar will be loaded from a [URI].
+ * @property postPaginatorProvider [MastodonProfilePostPaginator.Provider] by which a
  *   [MastodonProfilePostPaginator] for paginating through a [MastodonProfile]'s [Post]s will be
  *   provided.
- * @param entityDao [MastodonProfileEntityDao] that will perform SQL transactions on
+ * @property entityDao [MastodonProfileEntityDao] that will perform SQL transactions on
  *   [Mastodon profile entities][MastodonProfileEntity].
  */
 internal class MastodonProfileStorage(
+  private val requester: Requester,
   private val avatarLoaderProvider: SomeImageLoaderProvider<URI>,
   private val postPaginatorProvider: MastodonProfilePostPaginator.Provider,
   private val entityDao: MastodonProfileEntityDao
@@ -54,7 +60,7 @@ internal class MastodonProfileStorage(
     return entityDao
       .selectByID(key)
       .first()
-      .toProfile(avatarLoaderProvider, entityDao, postPaginatorProvider)
+      .toProfile(requester, avatarLoaderProvider, entityDao, postPaginatorProvider)
   }
 
   override suspend fun onRemove(key: String) {

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/MastodonDeletablePost.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/MastodonDeletablePost.kt
@@ -16,22 +16,17 @@
 package br.com.orcinus.orca.core.mastodon.feed.profile.post
 
 import br.com.orcinus.orca.core.feed.profile.post.DeletablePost
-import br.com.orcinus.orca.core.mastodon.MastodonCoreModule
-import br.com.orcinus.orca.core.mastodon.instance.SomeMastodonInstance
 import br.com.orcinus.orca.core.mastodon.instance.requester.authentication.authenticated
-import br.com.orcinus.orca.core.mastodon.instanceProvider
-import br.com.orcinus.orca.std.injector.Injector
 
 /**
  * [DeletablePost] that is deleted by sending a request to the Mastodon API.
  *
- * @param delegate [MastodonPost] to delegate its functionality to.
+ * @property delegate [MastodonPost] to delegate its functionality to.
  */
 internal data class MastodonDeletablePost(private val delegate: MastodonPost) :
   DeletablePost(delegate) {
   override suspend fun delete() {
-    (Injector.from<MastodonCoreModule>().instanceProvider().provide() as SomeMastodonInstance)
-      .requester
+    delegate.requester
       .authenticated()
       .delete({ path("api").path("v1").path("statuses").path(id).build() })
   }

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/MastodonPost.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/MastodonPost.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023-2024 Orcinus
+ * Copyright © 2023–2024 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -20,9 +20,10 @@ import br.com.orcinus.orca.core.feed.profile.post.DeletablePost
 import br.com.orcinus.orca.core.feed.profile.post.Post
 import br.com.orcinus.orca.core.feed.profile.post.content.Content
 import br.com.orcinus.orca.core.mastodon.feed.profile.post.stat.FavoriteStat
-import br.com.orcinus.orca.core.mastodon.feed.profile.post.stat.ReblogStat
+import br.com.orcinus.orca.core.mastodon.feed.profile.post.stat.RepostStat
 import br.com.orcinus.orca.core.mastodon.feed.profile.post.stat.comment.CommentStat
 import br.com.orcinus.orca.core.mastodon.feed.profile.post.stat.comment.MastodonCommentPaginator
+import br.com.orcinus.orca.core.mastodon.instance.requester.Requester
 import br.com.orcinus.orca.std.image.ImageLoader
 import br.com.orcinus.orca.std.image.SomeImageLoaderProvider
 import java.net.URI
@@ -31,17 +32,20 @@ import java.time.ZonedDateTime
 /**
  * [Post] whose actions communicate with the Mastodon API.
  *
- * @param imageLoaderProvider [ImageLoader.Provider] that provides the [ImageLoader] by which images
- *   will be loaded from a [URI].
- * @param commentPaginatorProvider [MastodonCommentPaginator.Provider] by which a
+ * @property requester [Requester] by which [comment]-, [favorite]- and [repost]-related requests
+ *   are performed.
+ * @property imageLoaderProvider [ImageLoader.Provider] that provides the [ImageLoader] by which
+ *   images will be loaded from a [URI].
+ * @property commentPaginatorProvider [MastodonCommentPaginator.Provider] by which a
  *   [MastodonCommentPaginator] for paginating through the comments will be provided.
- * @param commentCount Amount of comments that this [MastodonPost] has received.
- * @param favoriteCount Amount of times that this [MastodonPost] has been marked as favorite.
- * @param reblogCount Amount of times that this [MastodonPost] has been reblogged.
+ * @property commentCount Amount of comments that this [MastodonPost] has received.
+ * @property favoriteCount Amount of times that this [MastodonPost] has been marked as favorite.
+ * @property reblogCount Amount of times that this [MastodonPost] has been reblogged.
  * @see comment
  */
-data class MastodonPost
+class MastodonPost
 internal constructor(
+  internal val requester: Requester,
   override val id: String,
   private val imageLoaderProvider: SomeImageLoaderProvider<URI>,
   override val author: Author,
@@ -53,9 +57,9 @@ internal constructor(
   private val reblogCount: Int,
   override val uri: URI
 ) : Post {
-  override val comment = CommentStat(id, commentCount, commentPaginatorProvider)
-  override val favorite = FavoriteStat(id, favoriteCount)
-  override val repost = ReblogStat(id, reblogCount)
+  override val comment = CommentStat(requester, id, commentCount, commentPaginatorProvider)
+  override val favorite = FavoriteStat(requester, id, favoriteCount)
+  override val repost = RepostStat(requester, id, reblogCount)
 
   override fun asDeletable(): DeletablePost {
     return MastodonDeletablePost(this)

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/cache/MastodonPostFetcher.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/cache/MastodonPostFetcher.kt
@@ -17,41 +17,41 @@ package br.com.orcinus.orca.core.mastodon.feed.profile.post.cache
 
 import android.content.Context
 import br.com.orcinus.orca.core.feed.profile.post.Post
+import br.com.orcinus.orca.core.feed.profile.post.stat.Stat
 import br.com.orcinus.orca.core.mastodon.feed.profile.post.stat.comment.MastodonCommentPaginator
 import br.com.orcinus.orca.core.mastodon.feed.profile.post.status.MastodonStatus
-import br.com.orcinus.orca.core.mastodon.instance.SomeMastodonInstance
+import br.com.orcinus.orca.core.mastodon.instance.requester.Requester
 import br.com.orcinus.orca.core.mastodon.instance.requester.authentication.authenticated
-import br.com.orcinus.orca.core.module.CoreModule
-import br.com.orcinus.orca.core.module.instanceProvider
 import br.com.orcinus.orca.platform.cache.Fetcher
 import br.com.orcinus.orca.std.image.ImageLoader
 import br.com.orcinus.orca.std.image.SomeImageLoaderProvider
-import br.com.orcinus.orca.std.injector.Injector
 import io.ktor.client.call.body
 import java.net.URI
 
 /**
  * [Fetcher] that requests [Post]s to the API.
  *
- * @param context [Context] with which a fetched [MastodonStatus] will be converted into a [Post].
- * @param imageLoaderProvider [ImageLoader.Provider] that provides the [ImageLoader] by which images
- *   will be loaded from a [URI].
- * @param commentPaginatorProvider [MastodonCommentPaginator] by which a [MastodonCommentPaginator]
- *   for paginating through the fetched [Post]s will be provided.
+ * @property context [Context] with which a fetched [MastodonStatus] will be converted into a
+ *   [Post].
+ * @property requester [Requester] by which [Stat]-related requests are performed.
+ * @property imageLoaderProvider [ImageLoader.Provider] that provides the [ImageLoader] by which
+ *   images will be loaded from a [URI].
+ * @property commentPaginatorProvider [MastodonCommentPaginator] by which a
+ *   [MastodonCommentPaginator] for paginating through the fetched [Post]s will be provided.
  * @see MastodonStatus.toPost
  * @see Post.comment
  */
 internal class MastodonPostFetcher(
   private val context: Context,
+  private val requester: Requester,
   private val imageLoaderProvider: SomeImageLoaderProvider<URI>,
   private val commentPaginatorProvider: MastodonCommentPaginator.Provider
 ) : Fetcher<Post>() {
   override suspend fun onFetch(key: String): Post {
-    return (Injector.from<CoreModule>().instanceProvider().provide() as SomeMastodonInstance)
-      .requester
+    return requester
       .authenticated()
       .get({ path("api").path("v1").path("statuses").path(key).build() })
       .body<MastodonStatus>()
-      .toPost(context, imageLoaderProvider, commentPaginatorProvider)
+      .toPost(context, requester, imageLoaderProvider, commentPaginatorProvider)
   }
 }

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/cache/storage/MastodonPostEntity.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/cache/storage/MastodonPostEntity.kt
@@ -26,9 +26,11 @@ import br.com.orcinus.orca.core.feed.profile.post.content.Content
 import br.com.orcinus.orca.core.feed.profile.post.content.highlight.Headline
 import br.com.orcinus.orca.core.feed.profile.post.content.highlight.Highlight
 import br.com.orcinus.orca.core.feed.profile.post.repost.Repost
+import br.com.orcinus.orca.core.feed.profile.post.stat.Stat
 import br.com.orcinus.orca.core.mastodon.feed.profile.cache.storage.style.MastodonStyleEntity
 import br.com.orcinus.orca.core.mastodon.feed.profile.post.MastodonPost
 import br.com.orcinus.orca.core.mastodon.feed.profile.post.stat.comment.MastodonCommentPaginator
+import br.com.orcinus.orca.core.mastodon.instance.requester.Requester
 import br.com.orcinus.orca.core.module.CoreModule
 import br.com.orcinus.orca.core.module.instanceProvider
 import br.com.orcinus.orca.platform.autos.kit.scaffold.bar.top.`if`
@@ -81,6 +83,7 @@ internal data class MastodonPostEntity(
   /**
    * Converts this [MastodonPostEntity] into a [Post].
    *
+   * @param requester [Requester] by which [Stat]-related requests are performed.
    * @param profileCache [Cache] from which the [Author]'s [Profile] will be retrieved.
    * @param dao [MastodonPostEntityDao] that will select the persisted
    *   [Mastodon style entities][MastodonStyleEntity].
@@ -91,6 +94,7 @@ internal data class MastodonPostEntity(
    * @see Post.comment
    */
   suspend fun toPost(
+    requester: Requester,
     profileCache: Cache<Profile>,
     dao: MastodonPostEntityDao,
     imageLoaderProvider: SomeImageLoaderProvider<URI>,
@@ -112,6 +116,7 @@ internal data class MastodonPostEntity(
     val publicationDateTime = ZonedDateTime.parse(publicationDateTime)
     val uri = URI(uri)
     return MastodonPost(
+        requester,
         id,
         imageLoaderProvider,
         author,

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/cache/storage/MastodonPostStorage.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/cache/storage/MastodonPostStorage.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023-2024 Orcinus
+ * Copyright © 2023–2024 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -19,10 +19,12 @@ import br.com.orcinus.orca.core.feed.profile.Profile
 import br.com.orcinus.orca.core.feed.profile.post.Post
 import br.com.orcinus.orca.core.feed.profile.post.content.Content
 import br.com.orcinus.orca.core.feed.profile.post.content.highlight.Highlight
+import br.com.orcinus.orca.core.feed.profile.post.stat.Stat
 import br.com.orcinus.orca.core.mastodon.feed.profile.cache.storage.style.MastodonStyleEntity
 import br.com.orcinus.orca.core.mastodon.feed.profile.cache.storage.style.MastodonStyleEntityDao
 import br.com.orcinus.orca.core.mastodon.feed.profile.cache.storage.style.toHttpStyleEntity
 import br.com.orcinus.orca.core.mastodon.feed.profile.post.stat.comment.MastodonCommentPaginator
+import br.com.orcinus.orca.core.mastodon.instance.requester.Requester
 import br.com.orcinus.orca.platform.cache.Cache
 import br.com.orcinus.orca.platform.cache.Storage
 import br.com.orcinus.orca.std.image.ImageLoader
@@ -32,21 +34,23 @@ import java.net.URI
 /**
  * [Storage] for [Post]s.
  *
- * @param profileCache [Cache] of [Profile]s with which [Mastodon post entities][MastodonPostEntity]
- *   will be converted to [Post]s.
- * @param postEntityDao [MastodonStyleEntityDao] that will perform SQL transactions on
+ * @property requester [Requester] by which [Stat]-related requests are performed.
+ * @property profileCache [Cache] of [Profile]s with which
+ *   [Mastodon post entities][MastodonPostEntity] will be converted to [Post]s.
+ * @property postEntityDao [MastodonStyleEntityDao] that will perform SQL transactions on
  *   [Mastodon post entities][MastodonPostEntity].
- * @param styleEntityDao [MastodonStyleEntityDao] for inserting and deleting
+ * @property styleEntityDao [MastodonStyleEntityDao] for inserting and deleting
  *   [Mastodon style entities][MastodonStyleEntity].
- * @param coverLoaderProvider [ImageLoader.Provider] that provides the [ImageLoader] by which a
+ * @property coverLoaderProvider [ImageLoader.Provider] that provides the [ImageLoader] by which a
  *   [Post]'s [content][Post.content]'s [highlight][Content.highlight]'s
  *   [headline][Highlight.headline] cover will be loaded from a [URI].
- * @param commentPaginatorProvider [MastodonCommentPaginator.Provider] by which a
+ * @property commentPaginatorProvider [MastodonCommentPaginator.Provider] by which a
  *   [MastodonCommentPaginator] for paginating through the stored [Post]s' comments will be
  *   provided.
  * @see Post.comment
  */
 internal class MastodonPostStorage(
+  private val requester: Requester,
   private val profileCache: Cache<Profile>,
   private val postEntityDao: MastodonPostEntityDao,
   private val styleEntityDao: MastodonStyleEntityDao,
@@ -67,7 +71,7 @@ internal class MastodonPostStorage(
   override suspend fun onGet(key: String): Post {
     return postEntityDao
       .selectByID(key)
-      .toPost(profileCache, postEntityDao, coverLoaderProvider, commentPaginatorProvider)
+      .toPost(requester, profileCache, postEntityDao, coverLoaderProvider, commentPaginatorProvider)
   }
 
   override suspend fun onRemove(key: String) {

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/pagination/MastodonPostPaginator.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/pagination/MastodonPostPaginator.kt
@@ -18,14 +18,10 @@ package br.com.orcinus.orca.core.mastodon.feed.profile.post.pagination
 import br.com.orcinus.orca.core.feed.profile.post.Post
 import br.com.orcinus.orca.core.mastodon.feed.profile.post.pagination.type.KTypeCreator
 import br.com.orcinus.orca.core.mastodon.feed.profile.post.pagination.type.kTypeCreatorOf
-import br.com.orcinus.orca.core.mastodon.instance.SomeMastodonInstance
 import br.com.orcinus.orca.core.mastodon.instance.requester.Requester
 import br.com.orcinus.orca.core.mastodon.instance.requester.authentication.authenticated
-import br.com.orcinus.orca.core.module.CoreModule
-import br.com.orcinus.orca.core.module.instanceProvider
 import br.com.orcinus.orca.ext.coroutines.getValue
 import br.com.orcinus.orca.ext.coroutines.setValue
-import br.com.orcinus.orca.std.injector.Injector
 import io.ktor.client.request.HttpRequest
 import io.ktor.client.statement.HttpResponse
 import kotlin.jvm.optionals.getOrNull
@@ -71,17 +67,15 @@ internal abstract class MastodonPostPaginator<T : Any> : KTypeCreator<T> {
       .onEach { lastResponse = it }
       .map { it.body(this).toPosts() }
 
-  /** [Requester] through which the [HttpRequest]s will be performed. */
-  private val requester
-    get() =
-      (Injector.from<CoreModule>().instanceProvider().provide() as SomeMastodonInstance).requester
-
   /**
    * Index of the page that's the current one.
    *
    * @see pageFlow
    */
   private var page by pageFlow
+
+  /** [Requester] by which requests will be performed. */
+  protected abstract val requester: Requester
 
   /** URI [String] to which the initial [HttpRequest] should be sent. */
   protected abstract val route: String

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/pagination/MastodonStatusesPaginator.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/pagination/MastodonStatusesPaginator.kt
@@ -63,6 +63,6 @@ internal abstract class MastodonStatusesPaginator : MastodonPostPaginator<List<M
   }
 
   final override fun List<MastodonStatus>.toPosts(): List<Post> {
-    return map { it.toPost(context, imageLoaderProvider, commentPaginatorProvider) }
+    return map { it.toPost(context, requester, imageLoaderProvider, commentPaginatorProvider) }
   }
 }

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/stat/ToggleableStat.extensions.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/stat/ToggleableStat.extensions.kt
@@ -18,24 +18,21 @@ package br.com.orcinus.orca.core.mastodon.feed.profile.post.stat
 import br.com.orcinus.orca.core.feed.profile.Profile
 import br.com.orcinus.orca.core.feed.profile.post.stat.toggleable.ToggleableStat
 import br.com.orcinus.orca.core.mastodon.feed.profile.post.MastodonPost
-import br.com.orcinus.orca.core.mastodon.instance.SomeMastodonInstance
+import br.com.orcinus.orca.core.mastodon.instance.requester.Requester
 import br.com.orcinus.orca.core.mastodon.instance.requester.authentication.authenticated
-import br.com.orcinus.orca.core.module.CoreModule
-import br.com.orcinus.orca.core.module.instanceProvider
-import br.com.orcinus.orca.std.injector.Injector
 
 /**
- * Builds a [ToggleableStat] for A [MastodonPost]'s favorites that obtains them from the API.
+ * Builds a [ToggleableStat] for a [MastodonPost]'s favorites that obtains them from the API.
  *
+ * @param requester [Requester] by which a request to toggle the "favorited" status is performed.
  * @param id ID of the [MastodonPost] for which the [ToggleableStat] is.
  * @param count Amount of times that the [MastodonPost] has been marked as favorite.
  */
 @Suppress("FunctionName")
-internal fun FavoriteStat(id: String, count: Int): ToggleableStat<Profile> {
+internal fun FavoriteStat(requester: Requester, id: String, count: Int): ToggleableStat<Profile> {
   return ToggleableStat(count) {
     onSetEnabled { isEnabled ->
-      (Injector.from<CoreModule>().instanceProvider().provide() as SomeMastodonInstance)
-        .requester
+      requester
         .authenticated()
         .post({
           path("api")
@@ -50,17 +47,17 @@ internal fun FavoriteStat(id: String, count: Int): ToggleableStat<Profile> {
 }
 
 /**
- * Builds a [ToggleableStat] for A [MastodonPost]'s reblogs that obtains them from the API.
+ * Builds a [ToggleableStat] for a [MastodonPost]'s reposts that obtains them from the API.
  *
+ * @param requester [Requester] by which a request to toggle the "reposted" status is performed.
  * @param id ID of the [MastodonPost] for which the [ToggleableStat] is.
- * @param count Amount of times that the [MastodonPost] has been reblogged.
+ * @param count Amount of times that the [MastodonPost] has been reposted.
  */
 @Suppress("FunctionName")
-internal fun ReblogStat(id: String, count: Int): ToggleableStat<Profile> {
+internal fun RepostStat(requester: Requester, id: String, count: Int): ToggleableStat<Profile> {
   return ToggleableStat(count) {
     onSetEnabled { isEnabled ->
-      (Injector.from<CoreModule>().instanceProvider().provide() as SomeMastodonInstance)
-        .requester
+      requester
         .authenticated()
         .post({
           path("api")

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/stat/comment/MastodonCommentPaginator.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/stat/comment/MastodonCommentPaginator.kt
@@ -22,6 +22,7 @@ import br.com.orcinus.orca.core.mastodon.feed.profile.post.MastodonContext
 import br.com.orcinus.orca.core.mastodon.feed.profile.post.pagination.MastodonPostPaginator
 import br.com.orcinus.orca.core.mastodon.feed.profile.post.pagination.type.KTypeCreator
 import br.com.orcinus.orca.core.mastodon.feed.profile.post.pagination.type.kTypeCreatorOf
+import br.com.orcinus.orca.core.mastodon.instance.requester.Requester
 import br.com.orcinus.orca.std.image.ImageLoader
 import br.com.orcinus.orca.std.image.SomeImageLoaderProvider
 import java.net.URI
@@ -29,16 +30,17 @@ import java.net.URI
 /**
  * [MastodonPostPaginator] for paginating through the comments of a [Post].
  *
- * @param context [Context] with which [MastodonContext]s will be converted into [Post]s.
- * @param imageLoaderProvider [ImageLoader.Provider] that provides the [ImageLoader] by which images
- *   will be loaded from a [URI].
  * @param id ID of the original [Post].
+ * @property context [Context] with which [MastodonContext]s will be converted into [Post]s.
+ * @property imageLoaderProvider [ImageLoader.Provider] that provides the [ImageLoader] by which
+ *   images will be loaded from a [URI].
  * @see Post.comment
- * @see toPosts
  * @see Post.id
+ * @see toPosts
  */
 internal class MastodonCommentPaginator(
   private val context: Context,
+  override val requester: Requester,
   private val imageLoaderProvider: SomeImageLoaderProvider<URI>,
   id: String
 ) : MastodonPostPaginator<MastodonContext>(), KTypeCreator<MastodonContext> by kTypeCreatorOf() {
@@ -59,7 +61,7 @@ internal class MastodonCommentPaginator(
 
   override fun MastodonContext.toPosts(): List<Post> {
     return descendants.map {
-      it.toPost(context, imageLoaderProvider) { this@MastodonCommentPaginator }
+      it.toPost(context, requester, imageLoaderProvider) { this@MastodonCommentPaginator }
     }
   }
 }

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/status/MastodonStatus.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/status/MastodonStatus.kt
@@ -21,9 +21,11 @@ import br.com.orcinus.orca.core.auth.actor.Actor
 import br.com.orcinus.orca.core.feed.profile.post.Post
 import br.com.orcinus.orca.core.feed.profile.post.content.Content
 import br.com.orcinus.orca.core.feed.profile.post.repost.Repost
+import br.com.orcinus.orca.core.feed.profile.post.stat.Stat
 import br.com.orcinus.orca.core.mastodon.feed.profile.account.MastodonAccount
 import br.com.orcinus.orca.core.mastodon.feed.profile.post.MastodonPost
 import br.com.orcinus.orca.core.mastodon.feed.profile.post.stat.comment.MastodonCommentPaginator
+import br.com.orcinus.orca.core.mastodon.instance.requester.Requester
 import br.com.orcinus.orca.core.module.CoreModule
 import br.com.orcinus.orca.core.module.instanceProvider
 import br.com.orcinus.orca.platform.autos.kit.scaffold.bar.top.`if`
@@ -37,23 +39,23 @@ import java.time.ZonedDateTime
 import kotlinx.serialization.Serializable
 
 /**
- * Structure returned by the API that is the DTO version of either A [MastodonPost] or a [Repost];
+ * Structure returned by the API that is the DTO version of either a [MastodonPost] or a [Repost];
  * which one it represents is determined by [reblog]'s nullability.
  *
- * @param id Unique identifier.
- * @param createdAt ISO-8601-formatted [String] indicating the date and time of creation.
- * @param account [MastodonAccount] of the author that's created this [MastodonStatus].
- * @param reblogsCount Amount of times it's been reblogged.
- * @param favouritesCount Amount of times it's been favorited.
- * @param repliesCount Amount of replies that's been received.
- * @param url String [URL] that leads to this [MastodonStatus].
- * @param reblog [MastodonStatus] that's being reblogged in this one.
- * @param card [MastodonCard] for the highlighted [URI] that's in the [content].
- * @param content Text that's been written.
- * @param mediaAttachments [MastodonAttachment]s of attached media.
- * @param favourited Whether it's been favorited by the currently
+ * @property id Unique identifier.
+ * @property createdAt ISO-8601-formatted [String] indicating the date and time of creation.
+ * @property account [MastodonAccount] of the author that's created this [MastodonStatus].
+ * @property reblogsCount Amount of times it's been reblogged.
+ * @property favouritesCount Amount of times it's been favorited.
+ * @property repliesCount Amount of replies that's been received.
+ * @property url String [URL] that leads to this [MastodonStatus].
+ * @property reblog [MastodonStatus] that's being reblogged in this one.
+ * @property card [MastodonCard] for the highlighted [URI] that's in the [content].
+ * @property content Text that's been written.
+ * @property mediaAttachments [MastodonAttachment]s of attached media.
+ * @property favourited Whether it's been favorited by the currently
  *   [authenticated][Actor.Authenticated] [Actor].
- * @param reblogged Whether the [authenticated][Actor.Authenticated] [Actor] has reblogged this
+ * @property reblogged Whether the [authenticated][Actor.Authenticated] [Actor] has reblogged this
  *   [MastodonStatus].
  */
 @Serializable
@@ -77,6 +79,7 @@ internal constructor(
    * Converts this [MastodonStatus] into a [Post].
    *
    * @param context [Context] with which the [content] will be converted into [Markdown].
+   * @param requester [Requester] by which [Stat]-related requests are performed.
    * @param imageLoaderProvider [ImageLoader.Provider] that provides the [ImageLoader] by which
    *   images will be loaded from a [URI].
    * @param commentPaginatorProvider [MastodonCommentPaginator.Provider] by which a
@@ -86,6 +89,7 @@ internal constructor(
    */
   internal fun toPost(
     context: Context,
+    requester: Requester,
     imageLoaderProvider: SomeImageLoaderProvider<URI>,
     commentPaginatorProvider: MastodonCommentPaginator.Provider
   ): Post {
@@ -99,6 +103,7 @@ internal constructor(
     val publicationDateTime = ZonedDateTime.parse(reblog?.createdAt ?: createdAt)
     val uri = URI(reblog?.url ?: url)
     return MastodonPost(
+        requester,
         id,
         imageLoaderProvider,
         author,

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/type/editable/MastodonEditableProfile.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/type/editable/MastodonEditableProfile.kt
@@ -21,6 +21,7 @@ import br.com.orcinus.orca.core.feed.profile.type.editable.EditableProfile
 import br.com.orcinus.orca.core.mastodon.feed.profile.MastodonProfile
 import br.com.orcinus.orca.core.mastodon.feed.profile.MastodonProfilePostPaginator
 import br.com.orcinus.orca.core.mastodon.feed.profile.post.MastodonPost
+import br.com.orcinus.orca.core.mastodon.instance.requester.Requester
 import br.com.orcinus.orca.std.image.SomeImageLoader
 import br.com.orcinus.orca.std.markdown.Markdown
 import java.net.URI
@@ -28,11 +29,13 @@ import java.net.URI
 /**
  * [MastodonProfile] that can be edited.
  *
- * @param postPaginatorProvider [MastodonProfilePostPaginator.Provider] by which a
+ * @property requester [Requester] by which the [editor]'s editing requests are performed.
+ * @property postPaginatorProvider [MastodonProfilePostPaginator.Provider] by which a
  *   [MastodonProfilePostPaginator] for paginating through the [MastodonProfile]'s [MastodonPost]s
  *   will be provided.
  */
-internal data class MastodonEditableProfile(
+internal class MastodonEditableProfile(
+  private val requester: Requester,
   private val postPaginatorProvider: MastodonProfilePostPaginator.Provider,
   override val id: String,
   override val account: Account,
@@ -55,5 +58,5 @@ internal data class MastodonEditableProfile(
     uri
   ),
   EditableProfile() {
-  override val editor = MastodonEditor()
+  override val editor = MastodonEditor(requester)
 }

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/type/followable/MastodonFollowableProfile.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/type/followable/MastodonFollowableProfile.kt
@@ -22,21 +22,22 @@ import br.com.orcinus.orca.core.feed.profile.type.followable.Follow
 import br.com.orcinus.orca.core.feed.profile.type.followable.FollowableProfile
 import br.com.orcinus.orca.core.mastodon.feed.profile.MastodonProfile
 import br.com.orcinus.orca.core.mastodon.feed.profile.MastodonProfilePostPaginator
-import br.com.orcinus.orca.core.mastodon.instance.SomeMastodonInstance
+import br.com.orcinus.orca.core.mastodon.instance.requester.Requester
 import br.com.orcinus.orca.core.mastodon.instance.requester.authentication.authenticated
 import br.com.orcinus.orca.std.image.SomeImageLoader
-import br.com.orcinus.orca.std.injector.Injector
 import br.com.orcinus.orca.std.markdown.Markdown
 import java.net.URI
 
 /**
  * [MastodonProfile] that can be followed.
  *
- * @param postPaginatorProvider [MastodonProfilePostPaginator.Provider] by which a
+ * @property requester [Requester] by which a request to change the follow status is performed.
+ * @property postPaginatorProvider [MastodonProfilePostPaginator.Provider] by which a
  *   [MastodonProfilePostPaginator] for paginating through the [MastodonProfile]'s [Post]s will be
  *   provided.
  */
-internal data class MastodonFollowableProfile<T : Follow>(
+internal class MastodonFollowableProfile<T : Follow>(
+  private val requester: Requester,
   private val postPaginatorProvider: MastodonProfilePostPaginator.Provider,
   override val id: String,
   override val account: Account,
@@ -61,8 +62,7 @@ internal data class MastodonFollowableProfile<T : Follow>(
   ),
   FollowableProfile<T>() {
   override suspend fun onChangeFollowTo(follow: T) {
-    Injector.get<SomeMastodonInstance>()
-      .requester
+    requester
       .authenticated()
       .post({
         path("api")

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/instance/MastodonInstance.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/instance/MastodonInstance.kt
@@ -21,7 +21,6 @@ import br.com.orcinus.orca.core.instance.Instance
 import br.com.orcinus.orca.core.instance.domain.Domain
 import br.com.orcinus.orca.core.mastodon.instance.requester.Logger
 import br.com.orcinus.orca.core.mastodon.instance.requester.Requester
-import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO
 import io.ktor.client.request.HttpRequest
 import io.ktor.http.URLBuilder
@@ -36,7 +35,7 @@ typealias SomeMastodonInstance = MastodonInstance<*, *>
  *
  * @param F [Authorizer] with which authorization will be performed.
  * @param S [Authenticator] to authenticate the user with.
- * @param authorizer [Authorizer] by which the user will be authorized.
+ * @property authorizer [Authorizer] by which the user will be authorized.
  */
 abstract class MastodonInstance<F : Authorizer, S : Authenticator>
 internal constructor(final override val domain: Domain, internal val authorizer: F) :
@@ -44,7 +43,7 @@ internal constructor(final override val domain: Domain, internal val authorizer:
   /** [Url] to which routes will be appended when [HttpRequest]s are sent. */
   internal val url = URLBuilder().apply { set(scheme = "https", host = "$domain") }.build()
 
-  /** [HttpClient] by which [HttpRequest]s will be sent. */
+  /** [Requester] by which requests are performed. */
   internal open val requester =
     Requester(Logger.Android, baseURI = domain.uri, clientEngineFactory = CIO)
 }


### PR DESCRIPTION
Passes [`Requester`](https://github.com/orcinusbr/orca-android/blob/6eaf7413cd741a74d638e517451860951edd4158/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/instance/requester/Requester.kt)s as arguments instead of obtaining the one injected into the [`CoreModule`](https://github.com/orcinusbr/orca-android/blob/6eaf7413cd741a74d638e517451860951edd4158/core-module/src/main/java/br/com/orcinus/orca/core/module/CoreModule.kt) through the [`Injector`](https://github.com/orcinusbr/orca-android/blob/6eaf7413cd741a74d638e517451860951edd4158/std/injector/src/main/java/br/com/orcinus/orca/std/injector/Injector.kt).