### PR TITLE
Privatize Mastodon API's DTOs' properties

### DIFF
--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/auth/authentication/MastodonAuthenticationToken.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/auth/authentication/MastodonAuthenticationToken.kt
@@ -28,10 +28,10 @@ import kotlinx.serialization.Serializable
  * Structure returned by the Mastodon API that holds the access token that's been given when
  * authorization was successfully granted to the user.
  *
- * @param accessToken Token that gives Orca user-level access to the API resources.
+ * @property accessToken Token that gives Orca user-level access to the API resources.
  */
 @Serializable
-internal data class MastodonAuthenticationToken(val accessToken: String) {
+internal data class MastodonAuthenticationToken(private val accessToken: String) {
   /**
    * Converts this [MastodonAuthenticationToken] into an [authenticated][Actor.Authenticated]
    * [Actor].

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/auth/authentication/MastodonAuthenticationVerification.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/auth/authentication/MastodonAuthenticationVerification.kt
@@ -24,11 +24,14 @@ import kotlinx.serialization.Serializable
 /**
  * Structure returned by the API when the user's credentials are verified.
  *
- * @param id Unique identifier of the user.
- * @param avatar URI [String] that leads to the avatar image.
+ * @property id Unique identifier of the user.
+ * @property avatar URI [String] that leads to the avatar image.
  */
 @Serializable
-internal data class MastodonAuthenticationVerification(val id: String, val avatar: String) {
+internal data class MastodonAuthenticationVerification(
+  private val id: String,
+  private val avatar: String
+) {
   /**
    * Converts this [MastodonAuthenticationVerification] into an [authenticated][Actor.Authenticated]
    * [Actor].

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/account/MastodonAccount.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/account/MastodonAccount.kt
@@ -56,16 +56,16 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 internal data class MastodonAccount(
-  val id: String,
-  val username: String,
-  val acct: String,
-  val uri: String,
-  val displayName: String,
-  val locked: Boolean,
-  val note: String,
-  val avatar: String,
-  val followersCount: Int,
-  val followingCount: Int
+  private val id: String,
+  private val username: String,
+  private val acct: String,
+  private val uri: String,
+  private val displayName: String,
+  private val locked: Boolean,
+  private val note: String,
+  private val avatar: String,
+  private val followersCount: Int,
+  private val followingCount: Int
 ) {
   /**
    * Converts this [MastodonAccount] into an [Author].
@@ -198,7 +198,7 @@ internal data class MastodonAccount(
         })
         .body<List<MastodonRelationship>>()
         .first()
-        .toFollow(this)
+        .toFollow(locked)
     return MastodonFollowableProfile(
       requester,
       postPaginatorProvider,

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/account/MastodonRelationship.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/account/MastodonRelationship.kt
@@ -22,21 +22,21 @@ import kotlinx.serialization.Serializable
 /**
  * Structure returned by the API when the relationship between two [MastodonAccount]s is requested.
  *
- * @param following Whether the currently [authenticated][Actor.Authenticated] [Actor] is following
- *   the other [MastodonAccount] to which this refers to.
+ * @property following Whether the currently [authenticated][Actor.Authenticated] [Actor] is
+ *   following the other [MastodonAccount] to which this refers to.
  */
 @Serializable
-internal data class MastodonRelationship(val following: Boolean) {
+internal data class MastodonRelationship(private val following: Boolean) {
   /**
-   * Converts this [MastodonRelationship] into a [MastodonAccount].
+   * Converts this [MastodonRelationship] into a follow status.
    *
-   * @param account [MastodonAccount] of the user that has a relationship with the currently
-   *   [authenticated][Actor.Authenticated] [Actor].
+   * @param isAccountLocked Whether the [MastodonAccount] of the user that has a relationship with
+   *   the currently [authenticated][Actor.Authenticated] [Actor] is locked.
    */
-  fun toFollow(account: MastodonAccount): Follow {
+  fun toFollow(isAccountLocked: Boolean): Follow {
     return when {
-      account.locked && following -> Follow.Private.following()
-      account.locked -> Follow.Private.unfollowed()
+      isAccountLocked && following -> Follow.Private.following()
+      isAccountLocked -> Follow.Private.unfollowed()
       following -> Follow.Public.following()
       else -> Follow.Public.unfollowed()
     }

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/MastodonContext.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/MastodonContext.kt
@@ -21,12 +21,7 @@ import kotlinx.serialization.Serializable
 /**
  * Structure returned by the API that represents a thread of [MastodonStatus]es.
  *
- * @param ancestors [MastodonStatus]es to which the referred one is a comment.
- * @param descendants [MastodonStatus]es that have been published as comments to the one this
+ * @property descendants [MastodonStatus]es that have been published as comments to the one this
  *   [MastodonContext] refers to.
  */
-@Serializable
-internal data class MastodonContext(
-  val ancestors: List<MastodonStatus>,
-  val descendants: List<MastodonStatus>
-)
+@Serializable internal data class MastodonContext(val descendants: List<MastodonStatus>)

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/status/MastodonAttachment.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/status/MastodonAttachment.kt
@@ -23,11 +23,14 @@ import kotlinx.serialization.Serializable
  * Structure returned by the API that allows displaying media that's been attached to an
  * [MastodonStatus].
  *
- * @param previewUrl [String] URI that leads to the image to be shown as a preview.
- * @param description Describes the contents of the media.
+ * @property previewUrl [String] URI that leads to the image to be shown as a preview.
+ * @property description Describes the contents of the media.
  */
 @Serializable
-internal data class MastodonAttachment(val previewUrl: String, val description: String?) {
+internal data class MastodonAttachment(
+  private val previewUrl: String,
+  private val description: String?
+) {
   /** Converts this [MastodonAttachment] into an [Attachment]. */
   fun toAttachment(): Attachment {
     return Attachment(description?.ifBlank { null }, URI(previewUrl))

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/status/MastodonCard.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/status/MastodonCard.kt
@@ -24,17 +24,17 @@ import kotlinx.serialization.Serializable
 /**
  * Structure returned by the API that represents the most prominent content of A [MastodonStatus].
  *
- * @param url URL [String] that leads to the webpage to which this [MastodonCard] refers.
- * @param title Title of the webpage.
- * @param description Description of the webpage.
- * @param image URI [String] that leads to the cover image.
+ * @property url URL [String] that leads to the webpage to which this [MastodonCard] refers.
+ * @property title Title of the webpage.
+ * @property description Description of the webpage.
+ * @property image URI [String] that leads to the cover image.
  */
 @Serializable
 internal data class MastodonCard(
-  val url: String,
-  val title: String,
-  val description: String,
-  val image: String?
+  private val url: String,
+  private val title: String,
+  private val description: String,
+  private val image: String?
 ) {
   /**
    * Converts this [MastodonCard] into a [Headline].

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/status/MastodonStatus.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/status/MastodonStatus.kt
@@ -59,21 +59,20 @@ import kotlinx.serialization.Serializable
  *   [MastodonStatus].
  */
 @Serializable
-data class MastodonStatus
-internal constructor(
-  internal val id: String,
-  internal val createdAt: String,
-  internal val account: MastodonAccount,
-  internal val reblogsCount: Int,
-  internal val favouritesCount: Int,
-  internal val repliesCount: Int,
-  internal val uri: String,
-  internal val reblog: MastodonStatus?,
-  internal val card: MastodonCard?,
-  internal val content: String,
-  internal val mediaAttachments: List<MastodonAttachment>,
-  internal val favourited: Boolean?,
-  internal val reblogged: Boolean?
+internal data class MastodonStatus(
+  private val id: String,
+  private val createdAt: String,
+  private val account: MastodonAccount,
+  private val reblogsCount: Int,
+  private val favouritesCount: Int,
+  private val repliesCount: Int,
+  private val uri: String,
+  private val reblog: MastodonStatus?,
+  private val card: MastodonCard?,
+  private val content: String,
+  private val mediaAttachments: List<MastodonAttachment>,
+  private val favourited: Boolean?,
+  private val reblogged: Boolean?
 ) {
   /**
    * Converts this [MastodonStatus] into a [Post].


### PR DESCRIPTION
Makes all of API DTOs' fields private, since they're not really referenced (neither should they be) by other structures.