### PR TITLE
Keep all Orca classes

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -55,8 +55,8 @@ android {
     applicationId = "com.jeanbarrossilva.orca"
     minSdk = libs.versions.android.sdk.min.get().toInt()
     targetSdk = libs.versions.android.sdk.target.get().toInt()
-    versionCode = 5
-    versionName = "v0.3"
+    versionCode = 6
+    versionName = "v0.3.1"
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }
 

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -14,3 +14,4 @@
 #
 
 -dontobfuscate
+-keep class br.com.orcinus.orca.** { *; }


### PR DESCRIPTION
App is crashing in the latest testing build because some Orca classes have been minified.