### PR TITLE
Support abstract `:std:injector` modules

### DIFF
--- a/std/injector/src/main/java/br/com/orcinus/orca/std/injector/Injector.kt
+++ b/std/injector/src/main/java/br/com/orcinus/orca/std/injector/Injector.kt
@@ -134,7 +134,6 @@ object Injector : Module() {
   /**
    * Injects the dependencies declared within the given [module].
    *
-   * @param T [Module] into which its dependencies will be injected.
    * @param module [Module] whose dependencies will be injected into it.
    */
   @PublishedApi

--- a/std/injector/src/main/java/br/com/orcinus/orca/std/injector/Iterable.extensions.kt
+++ b/std/injector/src/main/java/br/com/orcinus/orca/std/injector/Iterable.extensions.kt
@@ -22,6 +22,7 @@ import br.com.orcinus.orca.std.injector.module.injection.lazyInjectionOf
 import kotlin.reflect.KProperty1
 import kotlin.reflect.full.hasAnnotation
 import kotlin.reflect.jvm.jvmErasure
+import kotlin.reflect.typeOf
 
 /**
  * Returns a [List] containing only [KProperty1]s that characterize an injection into a [Module].
@@ -31,14 +32,17 @@ import kotlin.reflect.jvm.jvmErasure
  * - have a return type of [Injection], which allows for operations to be performed within the
  *   [Module] (when it is a lazy one) and provides a dependency.
  *
- * @param T [Module] into which the resulting dependencies of the [KProperty1]s' values will be
+ * @param M [Module] into which the resulting dependencies of the [KProperty1]s' values will be
  *   injected.
  * @see lazyInjectionOf
  */
 @PublishedApi
-internal fun <T : Module> Iterable<KProperty1<T, *>>.filterIsInjection():
-  List<KProperty1<T, Injection<Any>>> {
+internal fun <M : Module> Iterable<KProperty1<out M, *>>.filterIsInjection():
+  List<KProperty1<M, Injection<Any>>> {
   @Suppress("UNCHECKED_CAST")
-  return filter { it.hasAnnotation<Inject>() && it.returnType.jvmErasure == Injection::class }
-    as List<KProperty1<T, Injection<Any>>>
+  return filter {
+    it.any(delimiter = typeOf<Module>()) { hasAnnotation<Inject>() } &&
+      it.returnType.jvmErasure == Injection::class
+  }
+    as List<KProperty1<M, Injection<Any>>>
 }

--- a/std/injector/src/main/java/br/com/orcinus/orca/std/injector/KClass.extensions.kt
+++ b/std/injector/src/main/java/br/com/orcinus/orca/std/injector/KClass.extensions.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2024 Orcinus
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package br.com.orcinus.orca.std.injector
+
+import kotlin.reflect.KClass
+import kotlin.reflect.KProperty
+import kotlin.reflect.KType
+import kotlin.reflect.full.isSubtypeOf
+import kotlin.reflect.full.memberProperties
+
+/**
+ * Returns the properties that are overridden by the given one throughout the entire inheritance
+ * tree until the [delimiter] is reached (exclusively).
+ *
+ * @param property [KProperty] whose overridden super-properties will be returned.
+ * @param delimiter [KType] up until which matches of the [property] are to be searched for.
+ */
+internal fun KClass<*>.getPropertiesOverriddenBy(
+  property: KProperty<*>,
+  delimiter: KType
+): List<KProperty<*>> {
+  return getPropertiesOverriddenBy(property, delimiter, isInclusive = false)
+}
+
+/**
+ * Returns the properties that are overridden by the given one throughout the entire inheritance
+ * tree until the [delimiter] is reached.
+ *
+ * @param property [KProperty] whose overridden super-properties will be returned.
+ * @param delimiter [KType] up until which the [property] is to be searched for.
+ * @param isInclusive Whether the receiver [KClass]' [property] override should be included in the
+ *   resulting [List].
+ */
+private fun KClass<*>.getPropertiesOverriddenBy(
+  property: KProperty<*>,
+  delimiter: KType,
+  isInclusive: Boolean
+): List<KProperty<*>> {
+  return supertypes
+    .filter { it == this && isInclusive || it.isSubtypeOf(delimiter) }
+    .mapNotNull { it.classifier as KClass<*>? }
+    .mapNotNull { superclass ->
+      superclass.memberProperties
+        .find { superProperty -> superProperty.name == property.name }
+        ?.let { overriddenProperty ->
+          superclass
+            .getPropertiesOverriddenBy(overriddenProperty, delimiter, isInclusive = true)
+            .plus(overriddenProperty)
+        }
+    }
+    .fold(emptyList()) { accumulator, overriddenProperties -> accumulator + overriddenProperties }
+}

--- a/std/injector/src/main/java/br/com/orcinus/orca/std/injector/KProperty.extensions.kt
+++ b/std/injector/src/main/java/br/com/orcinus/orca/std/injector/KProperty.extensions.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2024 Orcinus
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package br.com.orcinus.orca.std.injector
+
+import kotlin.reflect.KClass
+import kotlin.reflect.KProperty
+import kotlin.reflect.KType
+import kotlin.reflect.full.instanceParameter
+
+/**
+ * Returns whether the [predicate] is satisfied by the receiver [KProperty] or any of the ones which
+ * are overridden by it in the entire inheritance tree of the [KClass] that declares it.
+ *
+ * @param delimiter [KType] up until which matches of this [KProperty] are to be searched for.
+ * @param predicate Condition to be met by one of the properties in order for this method to return
+ *   `true`.
+ */
+internal fun KProperty<*>.any(delimiter: KType, predicate: KProperty<*>.() -> Boolean): Boolean {
+  return instanceParameter
+    ?.type
+    ?.classifier
+    ?.let { it as KClass<*>? }
+    ?.getPropertiesOverriddenBy(this, delimiter)
+    ?.plus(this)
+    ?.any(predicate)
+    ?: false
+}

--- a/std/injector/src/test/java/br/com/orcinus/orca/std/injector/KClassExtensionsTests.kt
+++ b/std/injector/src/test/java/br/com/orcinus/orca/std/injector/KClassExtensionsTests.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2024 Orcinus
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package br.com.orcinus.orca.std.injector
+
+import assertk.assertThat
+import assertk.assertions.containsExactly
+import kotlin.reflect.typeOf
+import kotlin.test.Test
+
+internal class KClassExtensionsTests {
+  private abstract class Animal {
+    abstract val isAwesome: Boolean
+  }
+
+  private abstract class Dolphin : Animal()
+
+  private class Orca : Dolphin() {
+    override val isAwesome = true
+  }
+
+  @Test
+  fun getsPropertiesOverriddenByAnother() {
+    assertThat(Orca::class.getPropertiesOverriddenBy(Orca::isAwesome, delimiter = typeOf<Animal>()))
+      .containsExactly(Animal::isAwesome, Dolphin::isAwesome)
+  }
+}


### PR DESCRIPTION
Adds support for modules like the following sample one:

```kotlin
abstract class CoreModule : Module() {
  @Inject @InternalCoreApi abstract val instanceProvider: Injection<out InstanceProvider>
  @Inject @InternalCoreApi abstract val authenticationLock: Injection<out SomeAuthenticationLock>
  @Inject @InternalCoreApi abstract val termMuter: Injection<TermMuter>
}
```