### PR TITLE
Fix profile details screen's frozen posts' stats

### DIFF
--- a/feature/profile-details/src/main/java/br/com/orcinus/orca/feature/profiledetails/ProfileDetailsViewModel.kt
+++ b/feature/profile-details/src/main/java/br/com/orcinus/orca/feature/profiledetails/ProfileDetailsViewModel.kt
@@ -110,7 +110,7 @@ private constructor(
   @OptIn(ExperimentalCoroutinesApi::class)
   private fun getPostPreviewsAt(index: Int): Flow<List<PostPreview>> {
     return profileFlow.filterNotNull().flatMapConcat { profile ->
-      profile.getPosts(index).flatMapEach { post ->
+      profile.getPosts(index).flatMapEach(selector = PostPreview::id) { post ->
         post.toPostPreviewFlow(colors, onLinkClick, onThumbnailClickListener)
       }
     }


### PR DESCRIPTION
Similar to #331's fix, but on the profile details screen.

<img src="https://github.com/orcinusbr/orca-android/assets/38408390/7d1550c3-6d76-4a9e-94c7-d8a6dbbc14e0" width="256" />
<img src="https://github.com/orcinusbr/orca-android/assets/38408390/ad97ee6e-ff50-4ae8-bea3-ed93bcfee6d9" width="256" />