### PR TITLE
Fix empty search results

### DIFF
--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/account/MastodonAccount.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/account/MastodonAccount.kt
@@ -21,6 +21,7 @@ import br.com.orcinus.orca.core.auth.actor.Actor
 import br.com.orcinus.orca.core.feed.profile.Profile
 import br.com.orcinus.orca.core.feed.profile.account.Account
 import br.com.orcinus.orca.core.feed.profile.post.Author
+import br.com.orcinus.orca.core.feed.profile.search.ProfileSearchResult
 import br.com.orcinus.orca.core.feed.profile.type.followable.Follow
 import br.com.orcinus.orca.core.mastodon.feed.profile.MastodonProfile
 import br.com.orcinus.orca.core.mastodon.feed.profile.MastodonProfilePostPaginator
@@ -105,6 +106,22 @@ internal data class MastodonAccount(
     } else {
       toFollowableProfile(context, requester, avatarLoaderProvider, postPaginatorProvider)
     }
+  }
+
+  /**
+   * Converts this [MastodonAccount] into a [ProfileSearchResult].
+   *
+   * @param avatarLoaderProvider [ImageLoader.Provider] that provides the [ImageLoader] by which the
+   *   [ProfileSearchResult]'s avatar will be loaded from a [URI].
+   */
+  fun toProfileSearchResult(
+    avatarLoaderProvider: SomeImageLoaderProvider<URI>
+  ): ProfileSearchResult {
+    val account = toAccount()
+    val avatarURI = URI(avatar)
+    val avatarLoader = avatarLoaderProvider.provide(avatarURI)
+    val uri = URI(uri)
+    return ProfileSearchResult(id, account, avatarLoader, displayName, uri)
   }
 
   /** Converts this [MastodonAccount] into an [Account]. */

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/search/MastodonSearch.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/search/MastodonSearch.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2024 Orcinus
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package br.com.orcinus.orca.core.mastodon.feed.profile.search
+
+import br.com.orcinus.orca.core.mastodon.feed.profile.account.MastodonAccount
+import kotlinx.serialization.Serializable
+
+/**
+ * Structure returned by the API when searching.
+ *
+ * @param accounts [MastodonAccount]s that match the query.
+ */
+@Serializable internal data class MastodonSearch(val accounts: List<MastodonAccount>)

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/search/cache/MastodonProfileSearchResultsFetcher.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/search/cache/MastodonProfileSearchResultsFetcher.kt
@@ -19,7 +19,6 @@ import android.content.Context
 import br.com.orcinus.orca.core.feed.profile.Profile
 import br.com.orcinus.orca.core.feed.profile.post.Post
 import br.com.orcinus.orca.core.feed.profile.search.ProfileSearchResult
-import br.com.orcinus.orca.core.feed.profile.search.toProfileSearchResult
 import br.com.orcinus.orca.core.mastodon.feed.profile.MastodonProfile
 import br.com.orcinus.orca.core.mastodon.feed.profile.MastodonProfilePostPaginator
 import br.com.orcinus.orca.core.mastodon.feed.profile.account.MastodonAccount
@@ -65,10 +64,6 @@ internal class MastodonProfileSearchResultsFetcher(
       })
       .body<MastodonSearch>()
       .accounts
-      .map {
-        it
-          .toProfile(context, requester, avatarLoaderProvider, postPaginatorProvider)
-          .toProfileSearchResult()
-      }
+      .map { it.toProfileSearchResult(avatarLoaderProvider) }
   }
 }

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/search/cache/MastodonProfileSearchResultsFetcher.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/search/cache/MastodonProfileSearchResultsFetcher.kt
@@ -23,6 +23,7 @@ import br.com.orcinus.orca.core.feed.profile.search.toProfileSearchResult
 import br.com.orcinus.orca.core.mastodon.feed.profile.MastodonProfile
 import br.com.orcinus.orca.core.mastodon.feed.profile.MastodonProfilePostPaginator
 import br.com.orcinus.orca.core.mastodon.feed.profile.account.MastodonAccount
+import br.com.orcinus.orca.core.mastodon.feed.profile.search.MastodonSearch
 import br.com.orcinus.orca.core.mastodon.instance.requester.Requester
 import br.com.orcinus.orca.core.mastodon.instance.requester.authentication.authenticated
 import br.com.orcinus.orca.platform.cache.Fetcher
@@ -54,9 +55,16 @@ internal class MastodonProfileSearchResultsFetcher(
     return requester
       .authenticated()
       .get({
-        path("api").path("v2").path("accounts").path("search").query().parameter("q", key).build()
+        path("api")
+          .path("v2")
+          .path("search")
+          .query()
+          .parameter("type", "accounts")
+          .parameter("q", key)
+          .build()
       })
-      .body<List<MastodonAccount>>()
+      .body<MastodonSearch>()
+      .accounts
       .map {
         it
           .toProfile(context, requester, avatarLoaderProvider, postPaginatorProvider)

--- a/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/feed/profile/account/MastodonAccountTests.kt
+++ b/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/feed/profile/account/MastodonAccountTests.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2024 Orcinus
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package br.com.orcinus.orca.core.mastodon.feed.profile.account
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import br.com.orcinus.orca.core.feed.profile.Profile
+import br.com.orcinus.orca.core.feed.profile.search.ProfileSearchResult
+import br.com.orcinus.orca.core.feed.profile.type.followable.Follow
+import br.com.orcinus.orca.core.feed.profile.type.followable.FollowableProfile
+import br.com.orcinus.orca.ext.uri.URIBuilder
+import br.com.orcinus.orca.platform.core.sample
+import br.com.orcinus.orca.std.image.compose.async.AsyncImageLoader
+import kotlin.test.Test
+
+internal class MastodonAccountTests {
+  @Test
+  fun convertsIntoProfileSearchResult() {
+    with(Profile.sample) {
+      val avatarURI =
+        URIBuilder.url()
+          .scheme("https")
+          .host("orca.orcinus.com.br")
+          .path("api")
+          .path("v1")
+          .path("accounts")
+          .path(id)
+          .path("avatar")
+          .build()
+      assertThat(
+          MastodonAccount(
+              id,
+              account.username.toString(),
+              acct = "$account",
+              "$uri",
+              displayName = name,
+              locked = (this as? FollowableProfile<*>)?.follow is Follow.Private,
+              note = "$bio",
+              avatar = "$avatarURI",
+              followersCount = followerCount,
+              followingCount
+            )
+            .toProfileSearchResult(avatarLoaderProvider = AsyncImageLoader.Provider)
+        )
+        .isEqualTo(
+          ProfileSearchResult(id, account, AsyncImageLoader.Provider.provide(avatarURI), name, uri)
+        )
+    }
+  }
+}

--- a/std/image/compose/src/main/java/br/com/orcinus/orca/std/image/compose/async/AsyncImageLoader.kt
+++ b/std/image/compose/src/main/java/br/com/orcinus/orca/std/image/compose/async/AsyncImageLoader.kt
@@ -46,6 +46,7 @@ import coil.compose.AsyncImagePainter
 import com.jeanbarrossilva.loadable.placeholder.Placeholder
 import com.jeanbarrossilva.loadable.placeholder.PlaceholderDefaults
 import java.net.URI
+import java.util.Objects
 
 /** [ComposableImageLoader] that loads an image asynchronously. */
 class AsyncImageLoader private constructor(override val source: URI) :
@@ -55,6 +56,14 @@ class AsyncImageLoader private constructor(override val source: URI) :
     override fun provide(source: URI): AsyncImageLoader {
       return AsyncImageLoader(source)
     }
+  }
+
+  override fun equals(other: Any?): Boolean {
+    return other is AsyncImageLoader && source == other.source
+  }
+
+  override fun hashCode(): Int {
+    return Objects.hash(source)
   }
 
   override fun load(): ComposableImage {


### PR DESCRIPTION
Search results weren't appearing. The request endpoint was incorrect. 🥲

A nice side-effect of this PR is that searching is now faster. Previously, the retrieved [`MastodonAccount`](https://github.com/orcinusbr/orca-android/blob/43088f8d80af93ab6cefebc649bef901a77f8d3e/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/account/MastodonAccount.kt)s were being converted into [`Profile`](https://github.com/orcinusbr/orca-android/blob/43088f8d80af93ab6cefebc649bef901a77f8d3e/core/src/main/java/br/com/orcinus/orca/core/feed/profile/Profile.kt)s (which requires some additional network calls and provides information that weren't necessary for the purpose of searching) for them to then be turned into [`ProfileSearchResult`](https://github.com/orcinusbr/orca-android/blob/43088f8d80af93ab6cefebc649bef901a77f8d3e/core/src/main/java/br/com/orcinus/orca/core/feed/profile/search/ProfileSearchResult.kt)s; now, [`MastodonAccount`](https://github.com/orcinusbr/orca-android/blob/43088f8d80af93ab6cefebc649bef901a77f8d3e/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/account/MastodonAccount.kt)s are directly converted into [`ProfileSearchResult`](https://github.com/orcinusbr/orca-android/blob/43088f8d80af93ab6cefebc649bef901a77f8d3e/core/src/main/java/br/com/orcinus/orca/core/feed/profile/search/ProfileSearchResult.kt)s, which performs no additional requests.