### PR TITLE
Ignore Kotlin build directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .externalNativeBuild
 .gradle/
 .idea/*
+.kotlin/
 !.idea/icon.svg
 build/
 /app/default/release


### PR DESCRIPTION
[Kotlin 2.0.0 outputs build artifacts to `.kotlin`](https://kotlinlang.org/docs/whatsnew20.html#new-directory-for-kotlin-data-in-gradle-projects).