### PR TITLE
Rename core callbacks and caller methods

### DIFF
--- a/core-test/src/main/java/br/com/orcinus/orca/core/test/auth/Authenticator.factory.kt
+++ b/core-test/src/main/java/br/com/orcinus/orca/core/test/auth/Authenticator.factory.kt
@@ -37,7 +37,7 @@ fun Authenticator(
     override val authorizer = authorizer
     override val actorProvider = actorProvider
 
-    override suspend fun onAuthenticate(authorizationCode: String): Actor {
+    override suspend fun onAuthentication(authorizationCode: String): Actor {
       return onAuthenticate(authorizationCode)
     }
   }

--- a/core-test/src/main/java/br/com/orcinus/orca/core/test/auth/AuthorizerBuilder.kt
+++ b/core-test/src/main/java/br/com/orcinus/orca/core/test/auth/AuthorizerBuilder.kt
@@ -54,7 +54,7 @@ class AuthorizerBuilder {
   /** Builds the [Authorizer]. */
   fun build(): Authorizer {
     return object : Authorizer() {
-      public override suspend fun authorize(): String {
+      public override suspend fun onAuthorization(): String {
         before?.invoke()
         return authorizationCode
       }

--- a/core-test/src/main/java/br/com/orcinus/orca/core/test/auth/actor/InMemoryActorProvider.kt
+++ b/core-test/src/main/java/br/com/orcinus/orca/core/test/auth/actor/InMemoryActorProvider.kt
@@ -17,17 +17,32 @@ package br.com.orcinus.orca.core.test.auth.actor
 
 import br.com.orcinus.orca.core.auth.actor.Actor
 import br.com.orcinus.orca.core.auth.actor.ActorProvider
+import kotlinx.coroutines.runBlocking
 
 /** [ActorProvider] that remembers and retrieves [Actor]s from memory. */
 class InMemoryActorProvider : ActorProvider() {
   /**
    * [Actor] that has been remembered.
    *
-   * @see remember
+   * @see ActorProvider.remember
    */
   private var actor: Actor = Actor.Unauthenticated
 
-  public override suspend fun remember(actor: Actor) {
+  /**
+   * Remembers the given [actor] so that it can be retrieved later.
+   *
+   * @param actor [Actor] to remember.
+   * @see retrieve
+   */
+  fun remember(actor: Actor) {
+    /*
+     * InMemoryActorProvider's onRemembrance(Actor) doesn't actually suspend, so calling it
+     * blockingly doesn't interrupt the execution flow.
+     */
+    runBlocking { onRemembrance(actor) }
+  }
+
+  override suspend fun onRemembrance(actor: Actor) {
     this.actor = actor
   }
 

--- a/core-test/src/test/java/br/com/orcinus/core/test/auth/actor/FixedActorProvider.kt
+++ b/core-test/src/test/java/br/com/orcinus/core/test/auth/actor/FixedActorProvider.kt
@@ -24,7 +24,7 @@ import br.com.orcinus.orca.core.auth.actor.ActorProvider
  * @property actor [Actor] to be provided.
  */
 internal class FixedActorProvider(private val actor: Actor) : ActorProvider() {
-  override suspend fun remember(actor: Actor) {}
+  override suspend fun onRemembrance(actor: Actor) {}
 
   override suspend fun retrieve(): Actor {
     return actor

--- a/core-test/src/test/java/br/com/orcinus/core/test/auth/actor/InMemoryActorProviderTests.kt
+++ b/core-test/src/test/java/br/com/orcinus/core/test/auth/actor/InMemoryActorProviderTests.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023–2024 Orcinus
+ * Copyright © 2024 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -13,21 +13,22 @@
  * not, see https://www.gnu.org/licenses.
  */
 
-package br.com.orcinus.orca.core.sample.auth.actor
+package br.com.orcinus.core.test.auth.actor
 
+import assertk.assertThat
+import assertk.assertions.isSameAs
 import br.com.orcinus.orca.core.auth.actor.Actor
-import br.com.orcinus.orca.core.auth.actor.ActorProvider
+import br.com.orcinus.orca.core.test.auth.actor.InMemoryActorProvider
+import br.com.orcinus.orca.std.image.test.NoOpImageLoader
+import kotlin.test.Test
+import kotlinx.coroutines.test.runTest
 
-/** [ActorProvider] returned by [sample]. */
-private val sampleActorProvider =
-  object : ActorProvider() {
-    override suspend fun onRemembrance(actor: Actor) {}
-
-    override suspend fun retrieve(): Actor {
-      return Actor.Authenticated.sample
+internal class InMemoryActorProviderTests {
+  @Test
+  fun remembers() {
+    runTest {
+      val actor = Actor.Authenticated("id", "access-token", NoOpImageLoader)
+      assertThat(InMemoryActorProvider().apply { remember(actor) }.provide()).isSameAs(actor)
     }
   }
-
-/** [ActorProvider] that always provides a sample [authenticated][Actor.Authenticated] [Actor]. */
-val ActorProvider.Companion.sample
-  get() = sampleActorProvider
+}

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/auth/authentication/MastodonAuthenticator.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/auth/authentication/MastodonAuthenticator.kt
@@ -40,7 +40,7 @@ class MastodonAuthenticator(
   /** [Continuation] of the coroutine that's suspended on authentication. */
   private var continuation: Continuation<Actor>? = null
 
-  override suspend fun onAuthenticate(authorizationCode: String): Actor {
+  override suspend fun onAuthentication(authorizationCode: String): Actor {
     return suspendCoroutine {
       continuation = it
       MastodonAuthenticationActivity.start(context, authorizationCode)

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/auth/authorization/MastodonAuthorizer.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/auth/authorization/MastodonAuthorizer.kt
@@ -33,7 +33,7 @@ class MastodonAuthorizer(private val context: Context) : Authorizer() {
   /** [Continuation] of the coroutine that's suspended on authorization. */
   private var continuation: Continuation<String>? = null
 
-  override suspend fun authorize(): String {
+  override suspend fun onAuthorization(): String {
     return suspendCoroutine {
       continuation = it
       context.on<MastodonAuthorizationActivity>().asNewTask().start()

--- a/core/sample/src/main/java/br/com/orcinus/orca/core/sample/auth/Authorizer.extensions.kt
+++ b/core/sample/src/main/java/br/com/orcinus/orca/core/sample/auth/Authorizer.extensions.kt
@@ -20,7 +20,7 @@ import br.com.orcinus.orca.core.auth.Authorizer
 /** [Authorizer] returned by [sample]. */
 private val sampleAuthorizer =
   object : Authorizer() {
-    override suspend fun authorize(): String {
+    override suspend fun onAuthorization(): String {
       return "sample-authorization-code"
     }
   }

--- a/core/sample/src/main/java/br/com/orcinus/orca/core/sample/auth/SampleAuthenticator.kt
+++ b/core/sample/src/main/java/br/com/orcinus/orca/core/sample/auth/SampleAuthenticator.kt
@@ -26,7 +26,7 @@ internal object SampleAuthenticator : Authenticator() {
   override val authorizer: Authorizer = Authorizer.sample
   override val actorProvider = ActorProvider.sample
 
-  override suspend fun onAuthenticate(authorizationCode: String): Actor {
+  override suspend fun onAuthentication(authorizationCode: String): Actor {
     return Actor.Authenticated.sample
   }
 }

--- a/core/sample/src/main/java/br/com/orcinus/orca/core/sample/auth/SampleAuthorizer.kt
+++ b/core/sample/src/main/java/br/com/orcinus/orca/core/sample/auth/SampleAuthorizer.kt
@@ -19,7 +19,7 @@ import br.com.orcinus.orca.core.auth.Authorizer
 
 /** [Authorizer] that provides a sample authorization code. */
 internal object SampleAuthorizer : Authorizer() {
-  override suspend fun authorize(): String {
+  override suspend fun onAuthorization(): String {
     return "sample-authorization-code"
   }
 }

--- a/core/sample/src/main/java/br/com/orcinus/orca/core/sample/auth/actor/SampleActorProvider.kt
+++ b/core/sample/src/main/java/br/com/orcinus/orca/core/sample/auth/actor/SampleActorProvider.kt
@@ -20,7 +20,7 @@ import br.com.orcinus.orca.core.auth.actor.ActorProvider
 
 /** [ActorProvider] that always provides a sample [authenticated][Actor.Authenticated] [Actor]. */
 internal object SampleActorProvider : ActorProvider() {
-  override suspend fun remember(actor: Actor) {}
+  override suspend fun onRemembrance(actor: Actor) {}
 
   override suspend fun retrieve(): Actor {
     return Actor.Authenticated.sample

--- a/core/shared-preferences/src/main/java/br/com/orcinus/orca/core/sharedpreferences/actor/SharedPreferencesActorProvider.kt
+++ b/core/shared-preferences/src/main/java/br/com/orcinus/orca/core/sharedpreferences/actor/SharedPreferencesActorProvider.kt
@@ -33,7 +33,7 @@ class SharedPreferencesActorProvider(
   private val preferences: SharedPreferences =
     context.getSharedPreferences("shared-preferences-actor-provider", Context.MODE_PRIVATE)
 
-  override suspend fun remember(actor: Actor) {
+  override suspend fun onRemembrance(actor: Actor) {
     val mirroredActor = actor.toMirroredActor()
     val mirroredActorAsJson = Json.encodeToString(mirroredActor)
     preferences.edit { putString(MIRRORED_ACTOR_KEY, mirroredActorAsJson) }

--- a/core/src/main/java/br/com/orcinus/orca/core/auth/Authenticator.kt
+++ b/core/src/main/java/br/com/orcinus/orca/core/auth/Authenticator.kt
@@ -33,7 +33,7 @@ abstract class Authenticator @InternalCoreApi constructor() {
   /** Authorizes the user with the [authorizer] and then tries to authenticates them. */
   suspend fun authenticate(): Actor {
     val authorizationCode = authorizer.authorize()
-    val actor = onAuthenticate(authorizationCode)
+    val actor = onAuthentication(authorizationCode)
     actorProvider.remember(actor)
     return actor
   }
@@ -43,5 +43,5 @@ abstract class Authenticator @InternalCoreApi constructor() {
    *
    * @param authorizationCode Code that resulted from authorizing the user.
    */
-  protected abstract suspend fun onAuthenticate(authorizationCode: String): Actor
+  protected abstract suspend fun onAuthentication(authorizationCode: String): Actor
 }

--- a/core/src/main/java/br/com/orcinus/orca/core/auth/Authenticator.kt
+++ b/core/src/main/java/br/com/orcinus/orca/core/auth/Authenticator.kt
@@ -32,7 +32,7 @@ abstract class Authenticator @InternalCoreApi constructor() {
 
   /** Authorizes the user with the [authorizer] and then tries to authenticates them. */
   suspend fun authenticate(): Actor {
-    val authorizationCode = authorizer._authorize()
+    val authorizationCode = authorizer.authorize()
     val actor = onAuthenticate(authorizationCode)
     actorProvider._remember(actor)
     return actor

--- a/core/src/main/java/br/com/orcinus/orca/core/auth/Authenticator.kt
+++ b/core/src/main/java/br/com/orcinus/orca/core/auth/Authenticator.kt
@@ -34,7 +34,7 @@ abstract class Authenticator @InternalCoreApi constructor() {
   suspend fun authenticate(): Actor {
     val authorizationCode = authorizer.authorize()
     val actor = onAuthenticate(authorizationCode)
-    actorProvider._remember(actor)
+    actorProvider.remember(actor)
     return actor
   }
 

--- a/core/src/main/java/br/com/orcinus/orca/core/auth/Authorizer.kt
+++ b/core/src/main/java/br/com/orcinus/orca/core/auth/Authorizer.kt
@@ -17,24 +17,23 @@ package br.com.orcinus.orca.core.auth
 
 import br.com.orcinus.orca.core.InternalCoreApi
 
-/** Authorizes the user through [authorize]. */
+/** Authorizes the user through [onAuthorization]. */
 abstract class Authorizer @InternalCoreApi constructor() {
   /**
    * Authorizes the user, allowing the application to perform operations on their behalf.
    *
    * @return Resulting authorization code.
    */
-  @Suppress("FunctionName")
-  internal suspend fun _authorize(): String {
-    return authorize()
+  internal suspend fun authorize(): String {
+    return onAuthorization()
   }
 
   /**
-   * Authorizes the user, allowing the application to perform operations on their behalf.
+   * Callback called whenever authorization is requested to be performed.
    *
    * @return Resulting authorization code.
    */
-  protected abstract suspend fun authorize(): String
+  protected abstract suspend fun onAuthorization(): String
 
   companion object
 }

--- a/core/src/main/java/br/com/orcinus/orca/core/auth/Authorizer.kt
+++ b/core/src/main/java/br/com/orcinus/orca/core/auth/Authorizer.kt
@@ -17,7 +17,7 @@ package br.com.orcinus.orca.core.auth
 
 import br.com.orcinus.orca.core.InternalCoreApi
 
-/** Authorizes the user through [onAuthorization]. */
+/** Authorizes the user through [authorize]. */
 abstract class Authorizer @InternalCoreApi constructor() {
   /**
    * Authorizes the user, allowing the application to perform operations on their behalf.

--- a/core/src/main/java/br/com/orcinus/orca/core/auth/actor/ActorProvider.kt
+++ b/core/src/main/java/br/com/orcinus/orca/core/auth/actor/ActorProvider.kt
@@ -27,24 +27,25 @@ abstract class ActorProvider @InternalCoreApi constructor() {
   /**
    * Remembers the given [actor] so that it can be retrieved later.
    *
+   * @param actor [Actor] to remember.
    * @see retrieve
    */
-  @Suppress("FunctionName")
-  internal suspend fun _remember(actor: Actor) {
-    remember(actor)
+  internal suspend fun remember(actor: Actor) {
+    onRemembrance(actor)
   }
 
   /**
-   * Remembers the given [actor] so that it can be retrieved later.
+   * Callback called whenever an [Actor] is requested to be remembered.
    *
+   * @param actor [Actor] to remember.
    * @see retrieve
    */
-  protected abstract suspend fun remember(actor: Actor)
+  protected abstract suspend fun onRemembrance(actor: Actor)
 
   /**
    * Retrieves a remembered [Actor].
    *
-   * @see remember
+   * @see onRemembrance
    */
   protected abstract suspend fun retrieve(): Actor
 

--- a/core/src/test/java/br/com/orcinus/orca/core/auth/AuthenticationLockTests.kt
+++ b/core/src/test/java/br/com/orcinus/orca/core/auth/AuthenticationLockTests.kt
@@ -4,6 +4,7 @@ import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isTrue
 import br.com.orcinus.orca.core.auth.actor.Actor
+import br.com.orcinus.orca.core.auth.actor.ActorProvider
 import br.com.orcinus.orca.core.sample.test.auth.actor.sample
 import br.com.orcinus.orca.core.test.auth.AuthenticationLock
 import br.com.orcinus.orca.core.test.auth.Authenticator
@@ -32,7 +33,10 @@ internal class AuthenticationLockTests {
   @Test
   fun unlocksWhenActorIsAuthenticated() {
     runTest {
-      val actorProvider = InMemoryActorProvider().apply { remember(Actor.Authenticated.sample) }
+      val actorProvider =
+        InMemoryActorProvider().apply {
+          (this as ActorProvider).remember(Actor.Authenticated.sample)
+        }
       val authenticator = Authenticator(actorProvider = actorProvider)
       var hasListenerBeenNotified = false
       authenticator.authenticate()
@@ -46,7 +50,10 @@ internal class AuthenticationLockTests {
   @Test
   fun schedulesUnlocksForWhenOngoingOnesAreFinished() {
     runTest {
-      val actorProvider = InMemoryActorProvider().apply { remember(Actor.Authenticated.sample) }
+      val actorProvider =
+        InMemoryActorProvider().apply {
+          (this as ActorProvider).remember(Actor.Authenticated.sample)
+        }
       val lock = AuthenticationLock(actorProvider)
       lock.scheduleUnlock { delay(32.seconds) }
       repeat(1_024) { lock.scheduleUnlock { delay(8.seconds) } }

--- a/core/src/test/java/br/com/orcinus/orca/core/feed/profile/post/provider/PostExtensionsTests.kt
+++ b/core/src/test/java/br/com/orcinus/orca/core/feed/profile/post/provider/PostExtensionsTests.kt
@@ -19,6 +19,7 @@ import assertk.assertThat
 import assertk.assertions.isSameAs
 import assertk.assertions.isTrue
 import br.com.orcinus.orca.core.auth.actor.Actor
+import br.com.orcinus.orca.core.auth.actor.ActorProvider
 import br.com.orcinus.orca.core.feed.profile.post.DeletablePost
 import br.com.orcinus.orca.core.feed.profile.post.Post
 import br.com.orcinus.orca.core.sample.feed.profile.post.Posts
@@ -63,7 +64,10 @@ internal class PostExtensionsTests {
   @Test
   fun returnsItselfWhenMakingDeletablePostDeletable() {
     runTest {
-      val actorProvider = InMemoryActorProvider().apply { remember(Actor.Authenticated.sample) }
+      val actorProvider =
+        InMemoryActorProvider().apply {
+          (this as ActorProvider).remember(Actor.Authenticated.sample)
+        }
       val authenticationLock = AuthenticationLock(actorProvider)
       val post =
         object : DeletablePost(Posts.withSample.single()) {


### PR DESCRIPTION
Renames irregularly named methods, given that most are currently prefixed by an "_" in order to protect the callback and internalize the caller method.