### PR TITLE
Show timeline as a grid on large devices

### DIFF
--- a/composite/timeline-test/src/test/java/br/com/orcinus/orca/composite/timeline/test/SemanticsNodeInteractionExtensionsTests.kt
+++ b/composite/timeline-test/src/test/java/br/com/orcinus/orca/composite/timeline/test/SemanticsNodeInteractionExtensionsTests.kt
@@ -16,6 +16,7 @@
 package br.com.orcinus.orca.composite.timeline.test
 
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
@@ -41,10 +42,10 @@ internal class SemanticsNodeInteractionExtensionsTests {
 
   @Test
   fun scrollsToTimelineBottom() {
-    composeRule.setContent {
-      Timeline(onNext = {}) { items(2) { Spacer(Modifier.fillParentMaxSize()) } }
-    }
     composeRule
+      .apply {
+        setContent { Timeline(onNext = {}) { items(2) { Spacer(Modifier.fillMaxSize()) } } }
+      }
       .onTimeline()
       .performScrollToBottom()
       .onChildren()

--- a/composite/timeline/src/main/java/br/com/orcinus/orca/composite/timeline/RenderEffect.kt
+++ b/composite/timeline/src/main/java/br/com/orcinus/orca/composite/timeline/RenderEffect.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023-2024 Orcinus
+ * Copyright © 2023–2024 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -67,7 +67,7 @@ internal fun LazyStaggeredGridScope.renderEffect(
   vararg keys: Any?,
   effect: () -> Unit
 ) {
-  item(RenderEffectKey, contentType, StaggeredGridItemSpan.FullLine) {
+  item(RenderEffectKey, contentType, span = StaggeredGridItemSpan.FullLine) {
     RenderEffect(*keys, effect = effect)
   }
 }

--- a/composite/timeline/src/main/java/br/com/orcinus/orca/composite/timeline/RenderEffect.kt
+++ b/composite/timeline/src/main/java/br/com/orcinus/orca/composite/timeline/RenderEffect.kt
@@ -16,7 +16,8 @@
 package br.com.orcinus.orca.composite.timeline
 
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.staggeredgrid.LazyStaggeredGridScope
+import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridItemSpan
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.Immutable
@@ -25,12 +26,12 @@ import androidx.compose.ui.platform.testTag
 import java.io.Serializable
 
 /** Tag that identifies a [RenderEffect] for testing purposes. */
-const val RenderEffectTag = "render-effect"
+@InternalTimelineApi const val RenderEffectTag = "render-effect"
 
 /**
  * Key to which a [RenderEffect] is associated when it is added to a lazy list.
  *
- * @see LazyListScope.renderEffect
+ * @see LazyStaggeredGridScope.renderEffect
  */
 @Immutable
 private object RenderEffectKey : Serializable {
@@ -61,8 +62,14 @@ private object RenderEffectKey : Serializable {
  *   [RenderEffect] item to be added.
  * @param effect Callback run when the [RenderEffect] is rendered.
  */
-internal fun LazyListScope.renderEffect(contentType: Any, vararg keys: Any?, effect: () -> Unit) {
-  item(RenderEffectKey, contentType) { RenderEffect(*keys, effect = effect) }
+internal fun LazyStaggeredGridScope.renderEffect(
+  contentType: Any,
+  vararg keys: Any?,
+  effect: () -> Unit
+) {
+  item(RenderEffectKey, contentType, StaggeredGridItemSpan.FullLine) {
+    RenderEffect(*keys, effect = effect)
+  }
 }
 
 /**

--- a/composite/timeline/src/main/java/br/com/orcinus/orca/composite/timeline/Timeline.kt
+++ b/composite/timeline/src/main/java/br/com/orcinus/orca/composite/timeline/Timeline.kt
@@ -53,6 +53,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import br.com.orcinus.orca.composite.timeline.post.PostPreview
+import br.com.orcinus.orca.composite.timeline.post.PostPreviewDefaults
 import br.com.orcinus.orca.composite.timeline.post.time.RelativeTimeProvider
 import br.com.orcinus.orca.composite.timeline.post.time.rememberRelativeTimeProvider
 import br.com.orcinus.orca.core.feed.profile.post.Post
@@ -63,6 +64,7 @@ import br.com.orcinus.orca.platform.autos.kit.scaffold.bar.snack.presenter.Error
 import br.com.orcinus.orca.platform.autos.kit.scaffold.bar.snack.presenter.SnackbarPresenter
 import br.com.orcinus.orca.platform.autos.kit.scaffold.bar.snack.presenter.rememberSnackbarPresenter
 import br.com.orcinus.orca.platform.autos.kit.scaffold.bar.top.text.AutoSizeText
+import br.com.orcinus.orca.platform.autos.kit.scaffold.plus
 import br.com.orcinus.orca.platform.autos.overlays.refresh.Refresh
 import br.com.orcinus.orca.platform.autos.overlays.refresh.Refreshable
 import br.com.orcinus.orca.platform.autos.theme.AutosTheme
@@ -189,7 +191,7 @@ fun LoadingTimeline(
     onNext = {},
     modifier,
     header,
-    contentPadding = contentPadding,
+    contentPadding = contentPadding + PaddingValues(bottom = PostPreviewDefaults.spacing),
     refresh = Refresh.immediate { onNext(TimelineDefaults.InitialSubsequentPaginationIndex) }
   ) {
     items(128) { PostPreview() }
@@ -236,7 +238,14 @@ fun LoadedTimeline(
   if (postPreviews.isEmpty()) {
     EmptyTimelineMessage(onNext, contentPadding, modifier, header?.let { { it() } })
   } else {
-    Timeline(onNext, modifier, header?.let { { it() } }, state, contentPadding, refresh) {
+    Timeline(
+      onNext,
+      modifier,
+      header?.let { { it() } },
+      state,
+      contentPadding + PaddingValues(bottom = PostPreviewDefaults.spacing),
+      refresh
+    ) {
       items(
         postPreviews,
         key = PostPreview::id,

--- a/composite/timeline/src/main/java/br/com/orcinus/orca/composite/timeline/post/PostPreview.kt
+++ b/composite/timeline/src/main/java/br/com/orcinus/orca/composite/timeline/post/PostPreview.kt
@@ -107,6 +107,13 @@ private val metadataModifier = Modifier.testTag(PostPreviewMetadataTag)
 /** [Modifier] to be applied to a [PostPreview]'s body. */
 private val bodyModifier = Modifier.testTag(PostPreviewBodyTag)
 
+/** Default values used by a [PostPreview]. */
+internal object PostPreviewDefaults {
+  /** Amount of [Dp] by which a [PostPreview] is spaced by default. */
+  val spacing
+    @Composable get() = AutosTheme.spacings.medium.dp
+}
+
 /**
  * Information to be displayed on a [Post]'s preview.
  *
@@ -195,13 +202,6 @@ internal constructor(
       return postProvider.provideAllCurrent().map { it.toPostPreview(colors) }
     }
   }
-}
-
-/** Default values used by a [PostPreview]. */
-object PostPreviewDefaults {
-  /** Amount of [Dp] by which a [PostPreview] is spaced by default. */
-  val spacing
-    @Composable get() = AutosTheme.spacings.medium.dp
 }
 
 /**

--- a/composite/timeline/src/main/java/br/com/orcinus/orca/composite/timeline/post/PostPreview.kt
+++ b/composite/timeline/src/main/java/br/com/orcinus/orca/composite/timeline/post/PostPreview.kt
@@ -47,6 +47,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import br.com.orcinus.orca.autos.colors.Colors
 import br.com.orcinus.orca.composite.timeline.R
@@ -196,6 +197,13 @@ internal constructor(
   }
 }
 
+/** Default values used by a [PostPreview]. */
+object PostPreviewDefaults {
+  /** Amount of [Dp] by which a [PostPreview] is spaced by default. */
+  val spacing
+    @Composable get() = AutosTheme.spacings.medium.dp
+}
+
 /**
  * Loading preview of a [Post].
  *
@@ -340,7 +348,6 @@ private fun PostPreview(
       onClick?.let { IgnoringMutableInteractionSource(HoverInteraction::class) }
         ?: EmptyMutableInteractionSource()
     }
-  val spacing = AutosTheme.spacings.medium.dp
   val metadataTextStyle = AutosTheme.typography.bodySmall
 
   Card(
@@ -350,11 +357,14 @@ private fun PostPreview(
     colors = CardDefaults.cardColors(containerColor = Color.Transparent),
     interactionSource = interactionSource
   ) {
-    Column(Modifier.padding(spacing), Arrangement.spacedBy(spacing)) {
-      Row(horizontalArrangement = Arrangement.spacedBy(spacing)) {
+    Column(
+      Modifier.padding(PostPreviewDefaults.spacing),
+      Arrangement.spacedBy(PostPreviewDefaults.spacing)
+    ) {
+      Row(horizontalArrangement = Arrangement.spacedBy(PostPreviewDefaults.spacing)) {
         avatar()
 
-        Column(verticalArrangement = Arrangement.spacedBy(spacing)) {
+        Column(verticalArrangement = Arrangement.spacedBy(PostPreviewDefaults.spacing)) {
           Column(verticalArrangement = Arrangement.spacedBy(AutosTheme.spacings.extraSmall.dp)) {
             ProvideTextStyle(AutosTheme.typography.bodyLarge, name)
 

--- a/composite/timeline/src/test/java/br/com/orcinus/orca/composite/timeline/TimelineTests.kt
+++ b/composite/timeline/src/test/java/br/com/orcinus/orca/composite/timeline/TimelineTests.kt
@@ -15,11 +15,8 @@
 
 package br.com.orcinus.orca.composite.timeline
 
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.lazy.staggeredgrid.items
 import androidx.compose.runtime.mutableStateListOf
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.TouchInjectionScope
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
@@ -65,18 +62,23 @@ internal class TimelineTests {
   @Test
   fun providesNextIndexWhenReachingBottom() {
     val indices = mutableStateListOf<Int>()
-    composeRule.setContent {
-      Timeline(
-        onNext = {
-          if (indices.size < 2) {
-            indices += it
+    composeRule
+      .apply {
+        setContent {
+          Timeline(
+            onNext = {
+              if (indices.size < 2) {
+                indices += it
+              }
+            }
+          ) {
+            items(indices) {}
           }
         }
-      ) {
-        items(indices) { Spacer(Modifier.fillMaxWidth()) }
       }
-    }
-    composeRule.onTimeline().performScrollToBottom().performScrollToBottom()
+      .onTimeline()
+      .performScrollToBottom()
+      .performScrollToBottom()
     assertThat(indices).containsExactly(1, 2)
   }
 
@@ -84,11 +86,7 @@ internal class TimelineTests {
   fun doesNotProvideNextIndexWhenReachingBottomMultipleTimesAndNoItemsHaveBeenAdded() {
     val indices = hashSetOf<Int>()
     composeRule
-      .apply {
-        setContent {
-          Timeline(onNext = { indices += it }) { item { Spacer(Modifier.fillMaxWidth()) } }
-        }
-      }
+      .apply { setContent { Timeline(onNext = { indices += it }) {} } }
       .onTimeline()
       .performScrollToBottom()
       .performTouchInput(TouchInjectionScope::swipeDown)

--- a/composite/timeline/src/test/java/br/com/orcinus/orca/composite/timeline/TimelineTests.kt
+++ b/composite/timeline/src/test/java/br/com/orcinus/orca/composite/timeline/TimelineTests.kt
@@ -16,28 +16,21 @@
 package br.com.orcinus.orca.composite.timeline
 
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.lazy.staggeredgrid.items
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.TouchInjectionScope
-import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.filter
-import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.junit4.createComposeRule
-import androidx.compose.ui.test.onChildren
-import androidx.compose.ui.test.onFirst
 import androidx.compose.ui.test.onNodeWithTag
-import androidx.compose.ui.test.onSiblings
 import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.swipeDown
 import assertk.assertThat
 import assertk.assertions.containsExactly
 import assertk.assertions.isEqualTo
-import br.com.orcinus.orca.composite.timeline.post.PostPreview
 import br.com.orcinus.orca.composite.timeline.test.onTimeline
 import br.com.orcinus.orca.composite.timeline.test.performScrollToBottom
-import br.com.orcinus.orca.core.sample.instance.SampleInstance
 import br.com.orcinus.orca.platform.autos.i18n.ReadableThrowable
 import br.com.orcinus.orca.platform.autos.kit.scaffold.Scaffold
 import br.com.orcinus.orca.platform.autos.kit.scaffold.bar.snack.presenter.rememberSnackbarPresenter
@@ -45,8 +38,6 @@ import br.com.orcinus.orca.platform.autos.overlays.refresh.Refresh
 import br.com.orcinus.orca.platform.autos.test.kit.scaffold.bar.snack.onSnackbar
 import br.com.orcinus.orca.platform.autos.test.overlays.refresh.onRefreshIndicator
 import br.com.orcinus.orca.platform.autos.theme.AutosTheme
-import br.com.orcinus.orca.platform.core.image.sample
-import br.com.orcinus.orca.std.image.compose.ComposableImageLoader
 import com.jeanbarrossilva.loadable.list.ListLoadable
 import kotlin.test.Test
 import kotlin.time.Duration.Companion.days
@@ -72,78 +63,6 @@ internal class TimelineTests {
   }
 
   @Test
-  fun showsDividerWhenHeaderIsNotAddedOnPostPreviewBeforeLastOne() {
-    composeRule.setContent {
-      AutosTheme {
-        LoadedTimeline(
-          PostPreview.createSamples(
-              SampleInstance.Builder.create(ComposableImageLoader.Provider.sample)
-                .withDefaultProfiles()
-                .withDefaultPosts()
-                .build()
-                .postProvider
-            )
-            .take(2)
-        )
-      }
-    }
-    composeRule
-      .onTimeline()
-      .onChildren()
-      .onFirst()
-      .onSiblings()
-      .filter(hasTestTag(TimelineDividerTag))
-      .assertCountEquals(0)
-  }
-
-  @Test
-  fun showsDividersWhenHeaderIsAddedOnPostPreviewBeforeLastOne() {
-    composeRule.setContent {
-      AutosTheme {
-        LoadedTimeline(
-          PostPreview.createSamples(
-              SampleInstance.Builder.create(ComposableImageLoader.Provider.sample)
-                .withDefaultProfiles()
-                .withDefaultPosts()
-                .build()
-                .postProvider
-            )
-            .take(2)
-        ) {}
-      }
-    }
-    composeRule
-      .onTimeline()
-      .onChildren()[1]
-      .onSiblings()
-      .filter(hasTestTag(TimelineDividerTag))
-      .assertCountEquals(1)
-  }
-
-  @Test
-  fun doesNotShowDividersOnLastPostPreview() {
-    composeRule.setContent {
-      AutosTheme {
-        LoadedTimeline(
-          PostPreview.createSamples(
-              SampleInstance.Builder.create(ComposableImageLoader.Provider.sample)
-                .withDefaultProfiles()
-                .withDefaultPosts()
-                .build()
-                .postProvider
-            )
-            .take(1)
-        )
-      }
-    }
-    composeRule
-      .onTimeline()
-      .onChildren()
-      .filter(hasTestTag(TimelineDividerTag))
-      .assertCountEquals(0)
-  }
-
-  @Test
   fun providesNextIndexWhenReachingBottom() {
     val indices = mutableStateListOf<Int>()
     composeRule.setContent {
@@ -154,7 +73,7 @@ internal class TimelineTests {
           }
         }
       ) {
-        items(indices) { Spacer(Modifier.fillParentMaxSize()) }
+        items(indices) { Spacer(Modifier.fillMaxWidth()) }
       }
     }
     composeRule.onTimeline().performScrollToBottom().performScrollToBottom()
@@ -167,7 +86,7 @@ internal class TimelineTests {
     composeRule
       .apply {
         setContent {
-          Timeline(onNext = { indices += it }) { item { Spacer(Modifier.fillParentMaxSize()) } }
+          Timeline(onNext = { indices += it }) { item { Spacer(Modifier.fillMaxWidth()) } }
         }
       }
       .onTimeline()

--- a/feature/feed/src/main/java/br/com/orcinus/orca/feature/feed/Feed.kt
+++ b/feature/feed/src/main/java/br/com/orcinus/orca/feature/feed/Feed.kt
@@ -33,8 +33,10 @@ import androidx.compose.ui.draw.blur
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import br.com.orcinus.orca.composite.timeline.Timeline
 import br.com.orcinus.orca.composite.timeline.post.PostPreview
+import br.com.orcinus.orca.composite.timeline.post.PostPreviewDefaults
 import br.com.orcinus.orca.composite.timeline.search.Searchable
 import br.com.orcinus.orca.core.feed.profile.search.ProfileSearchResult
 import br.com.orcinus.orca.core.sample.instance.SampleInstance
@@ -45,8 +47,6 @@ import br.com.orcinus.orca.platform.autos.kit.scaffold.bar.snack.presenter.remem
 import br.com.orcinus.orca.platform.autos.kit.scaffold.bar.top.TopAppBar
 import br.com.orcinus.orca.platform.autos.kit.scaffold.bar.top.TopAppBarDefaults
 import br.com.orcinus.orca.platform.autos.kit.scaffold.bar.top.text.AutoSizeText
-import br.com.orcinus.orca.platform.autos.kit.scaffold.plus
-import br.com.orcinus.orca.platform.autos.overlays.asPaddingValues
 import br.com.orcinus.orca.platform.autos.overlays.refresh.Refresh
 import br.com.orcinus.orca.platform.autos.theme.AutosTheme
 import br.com.orcinus.orca.platform.autos.theme.MultiThemePreview
@@ -206,8 +206,10 @@ private fun Feed(
           onNext,
           Modifier.nestedScroll(topAppBarScrollBehavior.nestedScrollConnection),
           contentPadding =
-            PaddingValues(top = searchTextFieldLayoutHeight) +
-              AutosTheme.overlays.fab.asPaddingValues,
+            PaddingValues(
+              top = searchTextFieldLayoutHeight,
+              bottom = PostPreviewDefaults.spacing + 56.dp
+            ),
           refresh = Refresh(isTimelineRefreshing, onTimelineRefresh),
           snackbarPresenter = snackbarPresenter
         )

--- a/feature/feed/src/main/java/br/com/orcinus/orca/feature/feed/Feed.kt
+++ b/feature/feed/src/main/java/br/com/orcinus/orca/feature/feed/Feed.kt
@@ -36,7 +36,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import br.com.orcinus.orca.composite.timeline.Timeline
 import br.com.orcinus.orca.composite.timeline.post.PostPreview
-import br.com.orcinus.orca.composite.timeline.post.PostPreviewDefaults
 import br.com.orcinus.orca.composite.timeline.search.Searchable
 import br.com.orcinus.orca.core.feed.profile.search.ProfileSearchResult
 import br.com.orcinus.orca.core.sample.instance.SampleInstance
@@ -205,11 +204,7 @@ private fun Feed(
           onPostClick,
           onNext,
           Modifier.nestedScroll(topAppBarScrollBehavior.nestedScrollConnection),
-          contentPadding =
-            PaddingValues(
-              top = searchTextFieldLayoutHeight,
-              bottom = PostPreviewDefaults.spacing + 56.dp
-            ),
+          contentPadding = PaddingValues(top = searchTextFieldLayoutHeight, bottom = 56.dp),
           refresh = Refresh(isTimelineRefreshing, onTimelineRefresh),
           snackbarPresenter = snackbarPresenter
         )

--- a/feature/profile-details/src/main/java/br/com/orcinus/orca/feature/profiledetails/ProfileDetails.kt
+++ b/feature/profile-details/src/main/java/br/com/orcinus/orca/feature/profiledetails/ProfileDetails.kt
@@ -53,7 +53,6 @@ import br.com.orcinus.orca.composite.timeline.LoadingTimeline
 import br.com.orcinus.orca.composite.timeline.Timeline
 import br.com.orcinus.orca.composite.timeline.TimelineDefaults
 import br.com.orcinus.orca.composite.timeline.post.PostPreview
-import br.com.orcinus.orca.composite.timeline.post.PostPreviewDefaults
 import br.com.orcinus.orca.composite.timeline.post.time.RelativeTimeProvider
 import br.com.orcinus.orca.composite.timeline.post.time.rememberRelativeTimeProvider
 import br.com.orcinus.orca.core.feed.profile.account.Account
@@ -459,10 +458,7 @@ private fun ProfileDetails(
         },
         timelineState,
         contentPadding =
-          PaddingValues(
-            bottom =
-              PostPreviewDefaults.spacing + if (details is ProfileDetails.Editable) 56.dp else 0.dp
-          ),
+          PaddingValues(bottom = if (details is ProfileDetails.Editable) 56.dp else 0.dp),
         Refresh(isTimelineRefreshing, onTimelineRefresh),
         relativeTimeProvider
       ) {

--- a/feature/profile-details/src/main/java/br/com/orcinus/orca/feature/profiledetails/ProfileDetails.kt
+++ b/feature/profile-details/src/main/java/br/com/orcinus/orca/feature/profiledetails/ProfileDetails.kt
@@ -22,8 +22,8 @@ import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.statusBarsPadding
-import androidx.compose.foundation.lazy.LazyListState
-import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.lazy.staggeredgrid.LazyStaggeredGridState
+import androidx.compose.foundation.lazy.staggeredgrid.rememberLazyStaggeredGridState
 import androidx.compose.material3.Button
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -340,7 +340,7 @@ private fun ProfileDetails(
     topAppBarScrollBehavior,
     title = { MediumTextualPlaceholder() },
     actions = {},
-    timelineState = rememberLazyListState(),
+    timelineState = rememberLazyStaggeredGridState(),
     timeline = { shouldNestScrollToTopAppBar ->
       LoadingTimeline(
         onNext,
@@ -383,7 +383,7 @@ private fun ProfileDetails(
   var isTopBarDropdownExpanded by
     remember(isTopBarDropdownMenuExpanded) { mutableStateOf(isTopBarDropdownMenuExpanded) }
   val snackbarPresenter = rememberSnackbarPresenter()
-  val timelineState = rememberLazyListState(initialFirstVisibleTimelineItemIndex)
+  val timelineState = rememberLazyStaggeredGridState(initialFirstVisibleTimelineItemIndex)
 
   ProfileDetails(
     topAppBarScrollBehavior,
@@ -474,7 +474,7 @@ private fun ProfileDetails(
   topAppBarScrollBehavior: TopAppBarScrollBehavior,
   title: @Composable () -> Unit,
   actions: @Composable RowScope.() -> Unit,
-  timelineState: LazyListState,
+  timelineState: LazyStaggeredGridState,
   timeline: @Composable (shouldNestScrollToTopAppBar: Boolean) -> Unit,
   floatingActionButton: @Composable () -> Unit,
   snackbarPresenter: SnackbarPresenter,

--- a/feature/profile-details/src/main/java/br/com/orcinus/orca/feature/profiledetails/ProfileDetails.kt
+++ b/feature/profile-details/src/main/java/br/com/orcinus/orca/feature/profiledetails/ProfileDetails.kt
@@ -20,6 +20,7 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.staggeredgrid.LazyStaggeredGridState
@@ -47,10 +48,12 @@ import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.unit.dp
 import br.com.orcinus.orca.composite.timeline.LoadingTimeline
 import br.com.orcinus.orca.composite.timeline.Timeline
 import br.com.orcinus.orca.composite.timeline.TimelineDefaults
 import br.com.orcinus.orca.composite.timeline.post.PostPreview
+import br.com.orcinus.orca.composite.timeline.post.PostPreviewDefaults
 import br.com.orcinus.orca.composite.timeline.post.time.RelativeTimeProvider
 import br.com.orcinus.orca.composite.timeline.post.time.rememberRelativeTimeProvider
 import br.com.orcinus.orca.core.feed.profile.account.Account
@@ -455,8 +458,13 @@ private fun ProfileDetails(
           nestedScroll(topAppBarScrollBehavior.nestedScrollConnection)
         },
         timelineState,
-        refresh = Refresh(isTimelineRefreshing, onTimelineRefresh),
-        relativeTimeProvider = relativeTimeProvider
+        contentPadding =
+          PaddingValues(
+            bottom =
+              PostPreviewDefaults.spacing + if (details is ProfileDetails.Editable) 56.dp else 0.dp
+          ),
+        Refresh(isTimelineRefreshing, onTimelineRefresh),
+        relativeTimeProvider
       ) {
         Header(details)
       }

--- a/platform/autos/src/main/java/br/com/orcinus/orca/platform/autos/kit/scaffold/bar/snack/presenter/ErrorPresentation.kt
+++ b/platform/autos/src/main/java/br/com/orcinus/orca/platform/autos/kit/scaffold/bar/snack/presenter/ErrorPresentation.kt
@@ -16,6 +16,7 @@
 package br.com.orcinus.orca.platform.autos.kit.scaffold.bar.snack.presenter
 
 import androidx.annotation.VisibleForTesting
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.staggeredgrid.LazyStaggeredGridState
 import androidx.compose.foundation.lazy.staggeredgrid.LazyVerticalStaggeredGrid
 import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
@@ -24,6 +25,7 @@ import androidx.compose.material3.Snackbar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import br.com.orcinus.orca.platform.autos.i18n.ReadableThrowable
 import br.com.orcinus.orca.platform.autos.overlays.refresh.Refresh
 import br.com.orcinus.orca.platform.autos.overlays.refresh.Refreshable
@@ -67,7 +69,8 @@ fun ErrorPresentation(
     }
 
     LazyVerticalStaggeredGrid(
-      StaggeredGridCells.Fixed(count = 1),
+      StaggeredGridCells.Adaptive(minSize = 1.dp),
+      Modifier.fillMaxSize(),
       state = lazyStaggeredGridState
     ) {}
   }

--- a/platform/autos/src/main/java/br/com/orcinus/orca/platform/autos/kit/scaffold/bar/snack/presenter/ErrorPresentation.kt
+++ b/platform/autos/src/main/java/br/com/orcinus/orca/platform/autos/kit/scaffold/bar/snack/presenter/ErrorPresentation.kt
@@ -16,9 +16,10 @@
 package br.com.orcinus.orca.platform.autos.kit.scaffold.bar.snack.presenter
 
 import androidx.annotation.VisibleForTesting
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.LazyListState
-import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.lazy.staggeredgrid.LazyStaggeredGridState
+import androidx.compose.foundation.lazy.staggeredgrid.LazyVerticalStaggeredGrid
+import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
+import androidx.compose.foundation.lazy.staggeredgrid.rememberLazyStaggeredGridState
 import androidx.compose.material3.Snackbar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -40,15 +41,16 @@ import java.nio.channels.UnresolvedAddressException
  * @param snackbarPresenter [SnackbarPresenter] by which a [Snackbar] informing the error is
  *   presented when it is caused by a [ReadableThrowable] or is an [UnresolvedAddressException].
  * @param modifier [Modifier] to be applied to the underlying [Refreshable].
- * @param lazyListState [LazyListState] through which scroll will be observed.
+ * @param lazyStaggeredGridState [LazyStaggeredGridState] through which scroll will be observed.
  */
 @Composable
+@Throws
 fun ErrorPresentation(
   error: Throwable,
   refreshListener: Refresh.Listener,
   snackbarPresenter: SnackbarPresenter,
   modifier: Modifier = Modifier,
-  lazyListState: LazyListState = rememberLazyListState()
+  lazyStaggeredGridState: LazyStaggeredGridState = rememberLazyStaggeredGridState()
 ) {
   Refreshable(Refresh.immediate(refreshListener), modifier) {
     val defaultError = ReadableThrowable.default
@@ -64,7 +66,10 @@ fun ErrorPresentation(
       }
     }
 
-    LazyColumn(state = lazyListState) {}
+    LazyVerticalStaggeredGrid(
+      StaggeredGridCells.Fixed(count = 1),
+      state = lazyStaggeredGridState
+    ) {}
   }
 }
 


### PR DESCRIPTION
In order to make better use of the available space on the screen and mainly prevent Orca from being just a stretched out version of the phone app on tablets, the timeline now is shown as a staggered grid. The amount of rows it has will depend on the size of the display, but there is no set maximum amount.

<img src="https://github.com/user-attachments/assets/56cb68f4-79fa-4fc9-b149-d1a0fe34a34c" width="400" />
<img src="https://github.com/user-attachments/assets/dbaec29c-2552-48ff-aec4-fc03f4a9c74a" width="400" />
