### PR TITLE
Make `OrcaActivity`'s creation callback inherit its super visibility

### DIFF
--- a/app/src/main/java/br/com/orcinus/orca/app/activity/OrcaActivity.kt
+++ b/app/src/main/java/br/com/orcinus/orca/app/activity/OrcaActivity.kt
@@ -20,7 +20,6 @@ import android.os.Bundle
 import android.view.MenuItem
 import android.view.View
 import android.view.Window
-import androidx.annotation.VisibleForTesting
 import androidx.core.view.WindowCompat
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
@@ -56,8 +55,7 @@ internal open class OrcaActivity : StartableActivity() {
   /** Whether all injected dependencies should be dejected when [onDestroy] is finally called. */
   protected open val areDependenciesDejectedOnDestruction = true
 
-  @VisibleForTesting
-  public override fun onCreate(savedInstanceState: Bundle?) {
+  override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     WindowCompat.setDecorFitsSystemWindows(window, false)
     binding = ActivityOrcaBinding.inflate(layoutInflater)


### PR DESCRIPTION
Super specific, but this is a vestige of the previous PR: [`OrcaActivity`](https://github.com/orcinusbr/orca-android/blob/d701e4783d13306eda2d08eea87eb1b4967d04ac/app/src/main/java/br/com/orcinus/orca/app/activity/OrcaActivity.kt)'s [`onCreate(Bundle?): Unit`](https://github.com/orcinusbr/orca-android/blob/d701e4783d13306eda2d08eea87eb1b4967d04ac/app/src/main/java/br/com/orcinus/orca/app/activity/OrcaActivity.kt#L58) was unnecessarily made visible to tests.