### PR TITLE
Fix crash on pagination

### DIFF
--- a/core/mastodon/build.gradle.kts
+++ b/core/mastodon/build.gradle.kts
@@ -82,6 +82,7 @@ dependencies {
   testImplementation(project(":core:sample"))
   testImplementation(project(":core:sample-test"))
   testImplementation(project(":core-test"))
+  testImplementation(project(":ext:testing"))
   testImplementation(project(":platform:autos-test"))
   testImplementation(project(":platform:intents-test"))
   testImplementation(project(":platform:testing"))

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/pagination/Headers.extensions.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/pagination/Headers.extensions.kt
@@ -30,7 +30,7 @@ internal fun Headers.filterIsLink(): List<LinkHeader> {
     .map {
       LinkHeader(
         uri = it.substringAfter('<').substringBefore('>'),
-        rel = it.substringAfter("rel=").substringBeforeLast('"')
+        rel = it.substringAfter("rel=").removePrefix("\"").substringBefore(',').substringBefore('"')
       )
     }
 }

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/pagination/Headers.extensions.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/pagination/Headers.extensions.kt
@@ -30,7 +30,7 @@ internal fun Headers.filterIsLink(): List<LinkHeader> {
     .map {
       LinkHeader(
         uri = it.substringAfter('<').substringBefore('>'),
-        rel = it.substringAfter("rel=").removePrefix("\"").substringBefore(',').substringBefore('"')
+        rel = it.substringAfter("rel=").removePrefix("\"").substringBefore('"').substringBefore(',')
       )
     }
 }

--- a/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/pagination/HeadersExtensionsTests.kt
+++ b/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/pagination/HeadersExtensionsTests.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2024 Orcinus
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package br.com.orcinus.orca.core.mastodon.feed.profile.post.pagination
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.prop
+import assertk.assertions.single
+import br.com.orcinus.orca.ext.testing.hasPropertiesEqualToThoseOf
+import br.com.orcinus.orca.ext.uri.URIBuilder
+import io.ktor.http.HttpHeaders
+import io.ktor.http.LinkHeader
+import io.ktor.http.headersOf
+import kotlin.test.Test
+
+internal class HeadersExtensionsTests {
+  private val linkHeader =
+    LinkHeader(
+      "${URIBuilder.url().scheme("https").host("orca.orcinus.com.br").build()}",
+      LinkHeader.Rel.Next
+    )
+
+  @Test
+  fun filtersIsLink() {
+    assertThat(
+        headersOf(
+            HttpHeaders.Authorization to listOf("Bearer 123"),
+            HttpHeaders.Link to listOf("$linkHeader")
+          )
+          .filterIsLink()
+      )
+      .single()
+      .hasPropertiesEqualToThoseOf(linkHeader)
+  }
+
+  @Test
+  fun filtersIsLinkWhenRelIsNotSurroundedByQuotes() {
+    assertThat(
+        headersOf(
+            HttpHeaders.Authorization to listOf("Bearer 123"),
+            HttpHeaders.Link to
+              listOf("<${linkHeader.uri}>; ${LinkHeader.Parameters.Rel}=${LinkHeader.Rel.Next}")
+          )
+          .filterIsLink()
+      )
+      .single()
+      .hasPropertiesEqualToThoseOf(linkHeader)
+      .prop("rel") { it.parameter(LinkHeader.Parameters.Rel) }
+      .isEqualTo(LinkHeader.Rel.Next)
+  }
+
+  @Test
+  fun filtersIsLinkWhenRelIsSurroundedByQuotes() {
+    assertThat(
+        headersOf(
+            HttpHeaders.Authorization to listOf("Bearer 123"),
+            HttpHeaders.Link to
+              listOf("<${linkHeader.uri}>; ${LinkHeader.Parameters.Rel}=\"${LinkHeader.Rel.Next}\"")
+          )
+          .filterIsLink()
+      )
+      .single()
+      .hasPropertiesEqualToThoseOf(linkHeader)
+      .prop("rel") { it.parameter(LinkHeader.Parameters.Rel) }
+      .isEqualTo(LinkHeader.Rel.Next)
+  }
+}


### PR DESCRIPTION
App was crashing when reaching the bottom of a timeline, due to the fact that the link for paginating to the next page included in the HTTP response has its `rel` parameter surrounded by double quotes (and [`Headers.filterIsLink(): List<LinkHeader>`](https://github.com/orcinusbr/orca-android/blob/e56c91c313667c8bfa9e195e31f6438dcb846fe7/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/pagination/Headers.extensions.kt#L25), which is the method that parses the string into the object itself, was expecting it to be passed in with the [token syntax](https://datatracker.ietf.org/doc/html/rfc8288#section-3)).