### PR TITLE
Fix crash on navigation to term muting setting

### DIFF
--- a/app/src/testDemo/java/br/com/orcinus/orca/app/demo/SettingsTests.kt
+++ b/app/src/testDemo/java/br/com/orcinus/orca/app/demo/SettingsTests.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2024 Orcinus
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package br.com.orcinus.orca.app.demo
+
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.performClick
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import br.com.orcinus.orca.app.R
+import br.com.orcinus.orca.app.activity.OrcaActivity
+import br.com.orcinus.orca.feature.settings.termmuting.TermMutingActivity
+import br.com.orcinus.orca.platform.autos.test.kit.action.setting.onSetting
+import br.com.orcinus.orca.platform.intents.test.intendStartingOf
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import org.junit.Rule
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+internal class SettingsTests {
+  @get:Rule val composeRule = createAndroidComposeRule<OrcaActivity>()
+
+  @BeforeTest
+  fun setUp() {
+    onView(withId(R.id.settings)).perform(click())
+  }
+
+  @Test
+  fun navigatesToTermMuting() {
+    intendStartingOf<TermMutingActivity> {
+      composeRule
+        .onSetting(
+          composeRule.activity.getString(
+            br.com.orcinus.orca.feature.settings.R.string.feature_settings_muting
+          )
+        )
+        .performClick()
+      composeRule
+        .onSetting(
+          composeRule.activity.getString(
+            br.com.orcinus.orca.feature.settings.R.string.feature_settings_add
+          )
+        )
+        .performClick()
+    }
+  }
+}

--- a/feature/settings/term-muting/src/main/java/br/com/orcinus/orca/feature/settings/termmuting/TermMutingActivity.kt
+++ b/feature/settings/term-muting/src/main/java/br/com/orcinus/orca/feature/settings/termmuting/TermMutingActivity.kt
@@ -34,7 +34,7 @@ class TermMutingActivity internal constructor() : ComposableActivity() {
 
   companion object {
     fun start(context: Context) {
-      context.on<TermMutingActivity>().start()
+      context.on<TermMutingActivity>().asNewTask().start()
     }
   }
 }

--- a/platform/autos-test/src/main/java/br/com/orcinus/orca/platform/autos/test/kit/action/setting/SemanticsMatcher.extensions.kt
+++ b/platform/autos-test/src/main/java/br/com/orcinus/orca/platform/autos/test/kit/action/setting/SemanticsMatcher.extensions.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2024 Orcinus
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package br.com.orcinus.orca.platform.autos.test.kit.action.setting
+
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.test.SemanticsMatcher
+import br.com.orcinus.orca.platform.autos.kit.action.setting.SettingTag
+
+/** [SemanticsMatcher] that matches a setting. */
+fun isSetting(): SemanticsMatcher {
+  return SemanticsMatcher("is setting") {
+    it.config.getOrNull(SemanticsProperties.TestTag)?.equals(SettingTag) ?: false
+  }
+}

--- a/platform/autos-test/src/main/java/br/com/orcinus/orca/platform/autos/test/kit/action/setting/SemanticsNodeInteractionsProvider.extensions.kt
+++ b/platform/autos-test/src/main/java/br/com/orcinus/orca/platform/autos/test/kit/action/setting/SemanticsNodeInteractionsProvider.extensions.kt
@@ -15,14 +15,21 @@
 
 package br.com.orcinus.orca.platform.autos.test.kit.action.setting
 
-import androidx.compose.ui.semantics.SemanticsProperties
-import androidx.compose.ui.semantics.getOrNull
-import androidx.compose.ui.test.SemanticsMatcher
-import br.com.orcinus.orca.platform.autos.kit.action.setting.SettingTag
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.SemanticsNodeInteractionsProvider
+import androidx.compose.ui.test.filterToOne
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.hasTextExactly
+import androidx.compose.ui.test.onAncestors
+import br.com.orcinus.orca.platform.autos.kit.action.setting.LabelTag
 
-/** [SemanticsMatcher] that matches a setting. */
-internal fun isSetting(): SemanticsMatcher {
-  return SemanticsMatcher("is setting") {
-    it.config.getOrNull(SemanticsProperties.TestTag)?.equals(SettingTag) ?: false
-  }
+/**
+ * [SemanticsNodeInteraction] of a setting.
+ *
+ * @param label Label of the setting.
+ */
+fun SemanticsNodeInteractionsProvider.onSetting(label: String): SemanticsNodeInteraction {
+  return onNode(hasTestTag(LabelTag) and hasTextExactly(label, includeEditableText = false))
+    .onAncestors()
+    .filterToOne(isSetting())
 }

--- a/platform/autos-test/src/test/java/br/com/orcinus/orca/platform/autos/test/kit/action/setting/SemanticsMatcherExtensionsTests.kt
+++ b/platform/autos-test/src/test/java/br/com/orcinus/orca/platform/autos/test/kit/action/setting/SemanticsMatcherExtensionsTests.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2024 Orcinus
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package br.com.orcinus.orca.platform.autos.test.kit.action.setting
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import br.com.orcinus.orca.platform.autos.kit.action.setting.list.Settings
+import br.com.orcinus.orca.platform.autos.theme.AutosTheme
+import kotlin.test.Test
+import org.junit.Rule
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+internal class SemanticsMatcherExtensionsTests {
+  @get:Rule val composeRule = createComposeRule()
+
+  @Test
+  fun matchesSetting() {
+    composeRule
+      .apply { setContent { AutosTheme { Settings { setting(label = {}) } } } }
+      .onNode(isSetting())
+      .assertIsDisplayed()
+  }
+}

--- a/platform/autos-test/src/test/java/br/com/orcinus/orca/platform/autos/test/kit/action/setting/SemanticsNodeInteractionsProviderExtensionsTests.kt
+++ b/platform/autos-test/src/test/java/br/com/orcinus/orca/platform/autos/test/kit/action/setting/SemanticsNodeInteractionsProviderExtensionsTests.kt
@@ -15,14 +15,25 @@
 
 package br.com.orcinus.orca.platform.autos.test.kit.action.setting
 
-import androidx.compose.ui.semantics.SemanticsProperties
-import androidx.compose.ui.semantics.getOrNull
-import androidx.compose.ui.test.SemanticsMatcher
-import br.com.orcinus.orca.platform.autos.kit.action.setting.SettingTag
+import androidx.compose.material3.Text
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import br.com.orcinus.orca.platform.autos.kit.action.setting.list.Settings
+import br.com.orcinus.orca.platform.autos.theme.AutosTheme
+import kotlin.test.Test
+import org.junit.Rule
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
-/** [SemanticsMatcher] that matches a setting. */
-internal fun isSetting(): SemanticsMatcher {
-  return SemanticsMatcher("is setting") {
-    it.config.getOrNull(SemanticsProperties.TestTag)?.equals(SettingTag) ?: false
+@RunWith(RobolectricTestRunner::class)
+internal class SemanticsNodeInteractionsProviderExtensionsTests {
+  @get:Rule val composeRule = createComposeRule()
+
+  @Test
+  fun findsSetting() {
+    composeRule
+      .apply { setContent { AutosTheme { Settings { setting({ Text("🤍") }) } } } }
+      .onSetting("🤍")
+      .assertIsDisplayed()
   }
 }

--- a/platform/autos/src/main/java/br/com/orcinus/orca/platform/autos/kit/action/setting/Setting.kt
+++ b/platform/autos/src/main/java/br/com/orcinus/orca/platform/autos/kit/action/setting/Setting.kt
@@ -17,6 +17,7 @@ package br.com.orcinus.orca.platform.autos.kit.action.setting
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -32,6 +33,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import br.com.orcinus.orca.platform.autos.InternalPlatformAutosApi
@@ -43,6 +45,9 @@ import br.com.orcinus.orca.platform.autos.theme.MultiThemePreview
 
 /** Tag that identifies a [Setting] for testing purposes. */
 @InternalPlatformAutosApi const val SettingTag = "setting"
+
+/** Tag that identifies a [Setting]'s label for testing purposes. */
+@InternalPlatformAutosApi const val LabelTag = "setting-label"
 
 /** Default values of a [Setting]. */
 internal object SettingDefaults {
@@ -86,12 +91,14 @@ internal fun Setting(
       ) {
         icon()
 
-        ProvideTextStyle(
-          AutosTheme.typography.labelMedium.copy(
-            color = AutosTheme.colors.background.content.asColor
-          ),
-          label
-        )
+        Box(Modifier.testTag(LabelTag).semantics(mergeDescendants = true) {}) {
+          ProvideTextStyle(
+            AutosTheme.typography.labelMedium.copy(
+              color = AutosTheme.colors.background.content.asColor
+            ),
+            label
+          )
+        }
       }
 
       Spacer(Modifier.width(SettingDefaults.spacing))

--- a/platform/autos/src/main/java/br/com/orcinus/orca/platform/autos/kit/action/setting/Setting.kt
+++ b/platform/autos/src/main/java/br/com/orcinus/orca/platform/autos/kit/action/setting/Setting.kt
@@ -31,13 +31,18 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import br.com.orcinus.orca.platform.autos.InternalPlatformAutosApi
 import br.com.orcinus.orca.platform.autos.colors.asColor
 import br.com.orcinus.orca.platform.autos.forms.asShape
 import br.com.orcinus.orca.platform.autos.iconography.asImageVector
 import br.com.orcinus.orca.platform.autos.theme.AutosTheme
 import br.com.orcinus.orca.platform.autos.theme.MultiThemePreview
+
+/** Tag that identifies a [Setting] for testing purposes. */
+@InternalPlatformAutosApi const val SettingTag = "setting"
 
 /** Default values of a [Setting]. */
 internal object SettingDefaults {
@@ -69,7 +74,7 @@ internal fun Setting(
   icon: @Composable () -> Unit = {},
   action: ActionScope.() -> Unit = {}
 ) {
-  Surface(Modifier.fillMaxWidth(), shape) {
+  Surface(Modifier.fillMaxWidth().testTag(SettingTag), shape) {
     Row(
       Modifier.clickable(onClick = onClick).padding(SettingDefaults.spacing).then(modifier),
       Arrangement.SpaceBetween,


### PR DESCRIPTION
[`TermMutingActivity`](https://github.com/orcinusbr/orca-android/blob/a044c4af479c3369989aa48d93b6f2a762532e67/feature/settings/term-muting/src/main/java/br/com/orcinus/orca/feature/settings/termmuting/TermMutingActivity.kt) wasn't being started as a new task. It has to be started as such because the [`Context`](https://developer.android.com/reference/android/content/Context) by which it is started is the running [`OrcaApplication`](https://github.com/orcinusbr/orca-android/blob/a044c4af479c3369989aa48d93b6f2a762532e67/app/src/main/java/br/com/orcinus/orca/app/OrcaApplication.kt) rather than an [`Activity`](https://developer.android.com/guide/components/activities/intro-activities).

<img src="https://github.com/user-attachments/assets/a6f6334c-b016-4b84-8823-e45c9ee6313c" width="256" />
<img src="https://github.com/user-attachments/assets/8878c471-1dae-4d08-92d2-d1bc8c1a7a7e" width="256" />