### PR TITLE
Initialize post favoriting and reposting stats' states

### DIFF
--- a/composite/timeline/src/test/java/br/com/orcinus/orca/composite/timeline/post/PostExtensionsTests.kt
+++ b/composite/timeline/src/test/java/br/com/orcinus/orca/composite/timeline/post/PostExtensionsTests.kt
@@ -87,7 +87,7 @@ internal class PostExtensionsTests {
                 override suspend fun onRemoval(element: Post) {}
               }
             override val favorite =
-              object : ToggleableStat<Profile>(count = 0) {
+              object : ToggleableStat<Profile>(isEnabled = false, count = 0) {
                 override fun get(page: Int): Flow<List<Profile>> {
                   return emptyFlow()
                 }
@@ -95,7 +95,7 @@ internal class PostExtensionsTests {
                 override suspend fun onSetEnabled(isEnabled: Boolean) {}
               }
             override val repost =
-              object : ToggleableStat<Profile>(count = 0) {
+              object : ToggleableStat<Profile>(isEnabled = false, count = 0) {
                 override fun get(page: Int): Flow<List<Profile>> {
                   return emptyFlow()
                 }

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/MastodonPost.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/MastodonPost.kt
@@ -41,6 +41,8 @@ import java.time.ZonedDateTime
  *   [Profile]s.
  * @param profilePostPaginatorProvider Paginates through the [MastodonPost]s of [Profile]s that are
  *   obtained by the [Stat]s.
+ * @param isFavorited Whether the [MastodonPost] is initially favorited.
+ * @param isReposted Whether the [MastodonPost] is reposted by default.
  * @property requester [Requester] by which [comment]-, [favorite]- and [repost]-related requests
  *   are performed.
  * @property imageLoaderProvider [ImageLoader.Provider] that provides the [ImageLoader] by which
@@ -66,7 +68,9 @@ internal class MastodonPost(
   override val publicationDateTime: ZonedDateTime,
   private val commentPaginatorProvider: MastodonCommentPaginator.Provider,
   private val commentCount: Int,
+  isFavorited: Boolean,
   private val favoriteCount: Int,
+  isReposted: Boolean,
   private val repostCount: Int,
   override val uri: URI
 ) : Post() {
@@ -78,7 +82,8 @@ internal class MastodonPost(
       profilePostPaginatorProvider,
       imageLoaderProvider,
       id,
-      favoriteCount
+      favoriteCount,
+      isFavorited
     )
   override val repost =
     MastodonRepostStat(
@@ -87,7 +92,8 @@ internal class MastodonPost(
       profilePostPaginatorProvider,
       imageLoaderProvider,
       id,
-      repostCount
+      repostCount,
+      isReposted
     )
 
   override suspend fun toOwnedPost(): MastodonOwnedPost {

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/cache/storage/MastodonPostEntity.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/cache/storage/MastodonPostEntity.kt
@@ -61,7 +61,7 @@ import java.time.ZonedDateTime
  * @param publicationDateTime [String] representation of the moment in which the [Post] was
  *   published.
  * @param commentCount Amount of comments that the [Post] has received.
- * @param isFavorite Whether the [Post] has been favorited by the currently
+ * @param isFavorited Whether the [Post] has been favorited by the currently
  *   [authenticated][Actor.Authenticated] [Actor].
  * @param isReposted Whether the [Post] is reblogged.
  * @param repostCount Amount of times the [Post] has been reblogged.
@@ -78,7 +78,7 @@ internal data class MastodonPostEntity(
   @ColumnInfo(name = "headline_cover_uri") val headlineCoverURI: String?,
   @ColumnInfo(name = "publication_date_time") val publicationDateTime: String,
   @ColumnInfo(name = "comment_count") val commentCount: Int,
-  @ColumnInfo(name = "is_favorite") val isFavorite: Boolean,
+  @ColumnInfo(name = "is_favorited") val isFavorited: Boolean,
   @ColumnInfo(name = "favorite_count") val favoriteCount: Int,
   @ColumnInfo(name = "is_reposted") val isReposted: Boolean,
   @ColumnInfo(name = "repost_count") val repostCount: Int,
@@ -141,7 +141,9 @@ internal data class MastodonPostEntity(
         publicationDateTime,
         commentPaginatorProvider,
         commentCount,
+        isFavorited,
         favoriteCount,
+        isReposted,
         repostCount,
         uri
       )

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/stat/toggleable/MastodonFavoriteStat.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/stat/toggleable/MastodonFavoriteStat.kt
@@ -36,6 +36,7 @@ import kotlinx.coroutines.flow.flow
  * favoriting/unfavoriting itself are performed through the API.
  *
  * @param count Initial amount of [Profile]s by which the [MastodonPost] has been favorited.
+ * @param isFavorited Whether the [MastodonPost] is initially favorited.
  * @property context [Context] with which the fetched [MastodonAccount]s are converted into
  *   [Profile]s.
  * @property requester [Requester] by which the network calls are made.
@@ -44,8 +45,8 @@ import kotlinx.coroutines.flow.flow
  * @property avatarLoaderProvider [ImageLoader.Provider] that loads the avatar of converted
  *   [Profile]s.
  * @property id ID of the [MastodonPost].
- * @see MastodonPost.id
  * @see MastodonAccount.toProfile
+ * @see MastodonPost.id
  */
 internal class MastodonFavoriteStat(
   private val context: Context,
@@ -53,8 +54,9 @@ internal class MastodonFavoriteStat(
   private val profilePostPaginatorProvider: MastodonProfilePostPaginator.Provider,
   private val avatarLoaderProvider: SomeImageLoaderProvider<URI>,
   private val id: String,
-  count: Int
-) : ToggleableStat<Profile>(count) {
+  count: Int,
+  isFavorited: Boolean
+) : ToggleableStat<Profile>(isFavorited, count) {
   override fun get(page: Int): Flow<List<Profile>> {
     return flow {
       emit(

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/stat/toggleable/MastodonRepostStat.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/stat/toggleable/MastodonRepostStat.kt
@@ -36,6 +36,7 @@ import kotlinx.coroutines.flow.flow
  * performed through the API.
  *
  * @param count Initial amount of [Profile]s by which the [MastodonPost] has been reposted.
+ * @param isReposted Whether the [MastodonPost] is initially reposted.
  * @property context [Context] with which the fetched [MastodonAccount]s are converted into
  *   [Profile]s.
  * @property requester [Requester] by which the network calls are made.
@@ -44,8 +45,8 @@ import kotlinx.coroutines.flow.flow
  * @property avatarLoaderProvider [ImageLoader.Provider] that loads the avatar of converted
  *   [Profile]s.
  * @property id ID of the [MastodonPost].
- * @see MastodonPost.id
  * @see MastodonAccount.toProfile
+ * @see MastodonPost.id
  */
 internal class MastodonRepostStat(
   private val context: Context,
@@ -53,8 +54,9 @@ internal class MastodonRepostStat(
   private val profilePostPaginatorProvider: MastodonProfilePostPaginator.Provider,
   private val avatarLoaderProvider: SomeImageLoaderProvider<URI>,
   private val id: String,
-  count: Int
-) : ToggleableStat<Profile>(count) {
+  count: Int,
+  isReposted: Boolean
+) : ToggleableStat<Profile>(isReposted, count) {
   override fun get(page: Int): Flow<List<Profile>> {
     return flow {
       emit(

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/status/MastodonStatus.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/status/MastodonStatus.kt
@@ -74,8 +74,8 @@ internal data class MastodonStatus(
   private val card: MastodonCard?,
   private val content: String,
   private val mediaAttachments: List<MastodonAttachment>,
-  private val favourited: Boolean?,
-  private val reblogged: Boolean?
+  val favourited: Boolean?,
+  val reblogged: Boolean?
 ) {
   /**
    * Converts this [MastodonStatus] into a [Post].
@@ -123,7 +123,9 @@ internal data class MastodonStatus(
         publicationDateTime,
         commentPaginatorProvider,
         commentCount = reblog?.repliesCount ?: repliesCount,
+        isFavorited = favourited ?: false,
         favouritesCount,
+        isReposted = reblogged ?: false,
         reblogsCount,
         uri
       )

--- a/core/sample/src/main/java/br/com/orcinus/orca/core/sample/feed/profile/post/stat/toggleable/SampleToggleableStat.kt
+++ b/core/sample/src/main/java/br/com/orcinus/orca/core/sample/feed/profile/post/stat/toggleable/SampleToggleableStat.kt
@@ -25,7 +25,8 @@ import kotlinx.coroutines.flow.StateFlow
  * @param T Element which can be added or retrieved.
  * @property toggle Object that will get added this is enabled or removed when it is disabled.
  */
-internal class SampleToggleableStat<T>(private val toggle: T) : ToggleableStat<T>(count = 0) {
+internal class SampleToggleableStat<T>(private val toggle: T) :
+  ToggleableStat<T>(isEnabled = false, count = 0) {
   /** [MutableStateFlow] containing the elements. */
   private val elementsFlow = MutableStateFlow(emptyList<T>())
 

--- a/core/src/main/java/br/com/orcinus/orca/core/feed/profile/post/stat/toggleable/ToggleableStat.kt
+++ b/core/src/main/java/br/com/orcinus/orca/core/feed/profile/post/stat/toggleable/ToggleableStat.kt
@@ -24,13 +24,15 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
 /**
- * [Stat] that can have its enable-ability toggled.
+ * [Stat] that can have its enableability toggled.
  *
+ * @param isEnabled Whether this [ToggleableStat] is enabled by default.
  * @param count Initial amount of elements.
  */
-abstract class ToggleableStat<T> @InternalCoreApi constructor(count: Int) : Stat<T>(count) {
+abstract class ToggleableStat<T> @InternalCoreApi constructor(isEnabled: Boolean, count: Int) :
+  Stat<T>(count) {
   /** [MutableStateFlow] that gets emitted to whenever this [ToggleableStat] is toggled. */
-  private val isEnabledMutableFlow = MutableStateFlow(false)
+  private val isEnabledMutableFlow = MutableStateFlow(isEnabled)
 
   /** [StateFlow] to which the current enable-ability state will be emitted. */
   val isEnabledFlow = isEnabledMutableFlow.asStateFlow()

--- a/core/src/test/java/br/com/orcinus/orca/core/feed/profile/post/stat/toggleable/ToggleableStatTests.kt
+++ b/core/src/test/java/br/com/orcinus/orca/core/feed/profile/post/stat/toggleable/ToggleableStatTests.kt
@@ -26,9 +26,9 @@ import kotlinx.coroutines.test.runTest
 
 internal class ToggleableStatTests {
   @Test
-  fun isInitiallyDisabled() {
+  fun emitsInitialEnableability() {
     runTest {
-      object : ToggleableStat<Any>(count = 0) {
+      object : ToggleableStat<Any>(isEnabled = false, count = 0) {
           override fun get(page: Int): Flow<List<Any>> {
             return emptyFlow()
           }
@@ -42,7 +42,7 @@ internal class ToggleableStatTests {
 
   @Test
   fun enables() {
-    object : ToggleableStat<Any>(count = 0) {
+    object : ToggleableStat<Any>(isEnabled = false, count = 0) {
         override fun get(page: Int): Flow<List<Any>> {
           return emptyFlow()
         }
@@ -62,7 +62,7 @@ internal class ToggleableStatTests {
 
   @Test
   fun disables() {
-    object : ToggleableStat<Any>(count = 0) {
+    object : ToggleableStat<Any>(isEnabled = false, count = 0) {
         override fun get(page: Int): Flow<List<Any>> {
           return emptyFlow()
         }


### PR DESCRIPTION
Fixed a bug in which a post "favorited" and "reposted" states wouldn't update until they were changed again. By default, all were shown as unfavorited and unreposted.

<img src="https://github.com/user-attachments/assets/edc098ac-e9d1-4b5c-be81-1b8f8a2385f8" width="256" />
<img src="https://github.com/user-attachments/assets/49c24556-3999-44ca-838b-d9c9855da991" width="256" />