### PR TITLE
Init follow statuses lazily

### DIFF
--- a/core/src/main/java/br/com/orcinus/orca/core/feed/profile/type/followable/Follow.kt
+++ b/core/src/main/java/br/com/orcinus/orca/core/feed/profile/type/followable/Follow.kt
@@ -28,42 +28,62 @@ abstract class Follow private constructor() : Serializable {
     override val visibilityName = "public"
 
     companion object {
+      /** [Follow] returned by [unfollowed]. */
+      @JvmStatic private lateinit var _unfollowed: Public
+
+      /** [Follow] returned by [following]. */
+      @JvmStatic private lateinit var _following: Public
+
       /**
        * [Follow] status in which a user doesn't receive any updates related to the other's
        * activity.
        */
       @InternalCoreApi
+      @JvmStatic
       fun unfollowed(): Public {
-        return object : Public() {
-          override fun toString(): String {
-            return "Follow.Public.unfollowed"
-          }
+        return if (::_unfollowed.isInitialized) {
+          _unfollowed
+        } else {
+          _unfollowed =
+            object : Public() {
+              override fun toString(): String {
+                return "Follow.Public.unfollowed"
+              }
 
-          override fun toggled(): Follow {
-            return following()
-          }
+              override fun toggled(): Follow {
+                return following()
+              }
 
-          override fun next(): Follow {
-            return following()
-          }
+              override fun next(): Follow {
+                return following()
+              }
+            }
+          _unfollowed
         }
       }
 
       /** [Follow] status in which a user has subscribed to receive updates from another. */
       @InternalCoreApi
+      @JvmStatic
       fun following(): Public {
-        return object : Public() {
-          override fun toString(): String {
-            return "Follow.Public.following"
-          }
+        return if (::_following.isInitialized) {
+          _following
+        } else {
+          _following =
+            object : Public() {
+              override fun toString(): String {
+                return "Follow.Public.following"
+              }
 
-          override fun toggled(): Follow {
-            return unfollowed()
-          }
+              override fun toggled(): Follow {
+                return unfollowed()
+              }
 
-          override fun next(): Follow? {
-            return null
-          }
+              override fun next(): Follow? {
+                return null
+              }
+            }
+          _following
         }
       }
     }
@@ -74,24 +94,40 @@ abstract class Follow private constructor() : Serializable {
     override val visibilityName = "private"
 
     companion object {
+      /** [Follow] returned by [unfollowed]. */
+      @JvmStatic private lateinit var _unfollowed: Private
+
+      /** [Follow] returned by [requested]. */
+      @JvmStatic private lateinit var _requested: Private
+
+      /** [Follow] returned by [following]. */
+      @JvmStatic private lateinit var _following: Private
+
       /**
        * [Follow] status in which a user doesn't receive any updates related to the other's
        * activity.
        */
       @InternalCoreApi
+      @JvmStatic
       fun unfollowed(): Private {
-        return object : Private() {
-          override fun toString(): String {
-            return "Follow.Private.unfollowed"
-          }
+        return if (::_unfollowed.isInitialized) {
+          _unfollowed
+        } else {
+          _unfollowed =
+            object : Private() {
+              override fun toString(): String {
+                return "Follow.Private.unfollowed"
+              }
 
-          override fun toggled(): Follow {
-            return requested()
-          }
+              override fun toggled(): Follow {
+                return requested()
+              }
 
-          override fun next(): Follow {
-            return requested()
-          }
+              override fun next(): Follow {
+                return requested()
+              }
+            }
+          _unfollowed
         }
       }
 
@@ -100,37 +136,51 @@ abstract class Follow private constructor() : Serializable {
        * accepted or denied.
        */
       @InternalCoreApi
+      @JvmStatic
       fun requested(): Private {
-        return object : Private() {
-          override fun toString(): String {
-            return "Follow.Private.requested"
-          }
+        return if (::_requested.isInitialized) {
+          _requested
+        } else {
+          _requested =
+            object : Private() {
+              override fun toString(): String {
+                return "Follow.Private.requested"
+              }
 
-          override fun toggled(): Follow {
-            return unfollowed()
-          }
+              override fun toggled(): Follow {
+                return unfollowed()
+              }
 
-          override fun next(): Follow {
-            return following()
-          }
+              override fun next(): Follow {
+                return following()
+              }
+            }
+          _requested
         }
       }
 
       /** [Follow] status in which a user has subscribed to receive updates from another. */
       @InternalCoreApi
+      @JvmStatic
       fun following(): Private {
-        return object : Private() {
-          override fun toString(): String {
-            return "Follow.Private.following"
-          }
+        return if (::_following.isInitialized) {
+          _following
+        } else {
+          _following =
+            object : Private() {
+              override fun toString(): String {
+                return "Follow.Private.following"
+              }
 
-          override fun toggled(): Follow {
-            return unfollowed()
-          }
+              override fun toggled(): Follow {
+                return unfollowed()
+              }
 
-          override fun next(): Follow? {
-            return null
-          }
+              override fun next(): Follow? {
+                return null
+              }
+            }
+          _following
         }
       }
     }

--- a/core/src/test/java/br/com/orcinus/orca/core/feed/profile/type/followable/FollowTests.kt
+++ b/core/src/test/java/br/com/orcinus/orca/core/feed/profile/type/followable/FollowTests.kt
@@ -15,11 +15,38 @@
 
 package br.com.orcinus.orca.core.feed.profile.type.followable
 
+import assertk.assertThat
+import assertk.assertions.isSameAs
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
 internal class FollowTests {
+  @Test
+  fun publicUnfollowedStatusIsInitializedOnce() {
+    assertThat(Follow.Public.unfollowed()).isSameAs(Follow.Public.unfollowed())
+  }
+
+  @Test
+  fun publicFollowingStatusIsInitializedOnce() {
+    assertThat(Follow.Public.following()).isSameAs(Follow.Public.following())
+  }
+
+  @Test
+  fun privateUnfollowedStatusIsInitializedOnce() {
+    assertThat(Follow.Private.unfollowed()).isSameAs(Follow.Private.unfollowed())
+  }
+
+  @Test
+  fun privateRequestedStatusIsInitializedOnce() {
+    assertThat(Follow.Private.requested()).isSameAs(Follow.Private.requested())
+  }
+
+  @Test
+  fun privateFollowingStatusIsInitializedOnce() {
+    assertThat(Follow.Private.following()).isSameAs(Follow.Private.following())
+  }
+
   @Test
   fun `GIVEN a blank string WHEN parsing it into a follow status THEN it throws`() {
     assertFailsWith<Follow.Companion.BlankStringException> { Follow.of(" ") }


### PR DESCRIPTION
Prevents the creation of multiple structurally equal follow statuses.