### PR TITLE
Move profile-follow-toggling to a domain service

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Note that Orca isn't a fork of the official app. Its overall structure has been 
 ## Structure
 
 <div align="center">
-    <img src="https://github.com/orcinusbr/orca-android/assets/38408390/027d8f28-06f4-4eb6-87f4-3e3de93b3189" />
+    <img src="https://github.com/user-attachments/assets/9b7e42a3-baca-44e2-b5bd-7da2e135d7f4" />
 </div>
 
 Each module represents the context to which its underlying structures are related.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -102,6 +102,7 @@ dependencies {
   "androidTestDemoImplementation"(libs.kotlin.test)
 
   "demoImplementation"(project(":platform:core"))
+  "demoImplementation"(project(":ext:uri"))
 
   ksp(project(":std:injector-processor"))
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -102,7 +102,6 @@ dependencies {
   "androidTestDemoImplementation"(libs.kotlin.test)
 
   "demoImplementation"(project(":platform:core"))
-  "demoImplementation"(project(":ext:uri"))
 
   ksp(project(":std:injector-processor"))
 

--- a/app/src/androidTestDemo/java/br/com/orcinus/orca/app/demo/ProfileDetailsTests.kt
+++ b/app/src/androidTestDemo/java/br/com/orcinus/orca/app/demo/ProfileDetailsTests.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2024 Orcinus
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package br.com.orcinus.orca.app.demo
+
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.onLast
+import androidx.compose.ui.test.performClick
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import br.com.orcinus.orca.app.R
+import br.com.orcinus.orca.app.demo.activity.NonDependencyDejectingOrcaActivity
+import br.com.orcinus.orca.composite.timeline.test.isTimeline
+import br.com.orcinus.orca.composite.timeline.test.post.figure.link.onLinkCards
+import br.com.orcinus.orca.composite.timeline.test.post.performScrollToPostPreviewWithLinkCard
+import br.com.orcinus.orca.core.auth.actor.Actor
+import br.com.orcinus.orca.core.sample.instance.SampleInstance
+import br.com.orcinus.orca.platform.core.image.sample
+import br.com.orcinus.orca.platform.core.sample
+import br.com.orcinus.orca.platform.intents.test.intendBrowsingTo
+import br.com.orcinus.orca.std.image.compose.ComposableImageLoader
+import kotlin.test.BeforeTest
+import org.junit.Rule
+import org.junit.Test
+
+internal class ProfileDetailsTests {
+  @get:Rule val composeRule = createAndroidComposeRule<NonDependencyDejectingOrcaActivity>()
+
+  @BeforeTest
+  fun setUp() {
+    onView(withId(R.id.profile_details)).perform(click())
+  }
+
+  @Test
+  fun navigatesToPostLink() {
+    val instance =
+      SampleInstance.Builder.create(ComposableImageLoader.Provider.sample)
+        .withDefaultProfiles()
+        .withDefaultPosts()
+        .build()
+    intendBrowsingTo(
+      instance.postProvider
+        .provideAllCurrentBy(Actor.Authenticated.sample.id)
+        .firstNotNullOf { it.content.highlight }
+        .uri
+    ) {
+      composeRule
+        .onAllNodes(isTimeline())
+        .onLast()
+        .performScrollToPostPreviewWithLinkCard(instance.feedProvider)
+      composeRule.onLinkCards().onFirst().performClick()
+    }
+  }
+}

--- a/app/src/demo/java/br/com/orcinus/orca/app/demo/DemoOrcaApplication.kt
+++ b/app/src/demo/java/br/com/orcinus/orca/app/demo/DemoOrcaApplication.kt
@@ -17,6 +17,7 @@ package br.com.orcinus.orca.app.demo
 
 import br.com.orcinus.orca.app.OrcaApplication
 import br.com.orcinus.orca.app.demo.module.core.DemoCoreModule
+import br.com.orcinus.orca.app.demo.module.feature.profiledetails.DemoProfileDetailsModule
 import br.com.orcinus.orca.core.feed.profile.Profile
 import br.com.orcinus.orca.core.feed.profile.post.Post
 import br.com.orcinus.orca.core.sample.instance.SampleInstance
@@ -36,4 +37,5 @@ internal class DemoOrcaApplication : OrcaApplication() {
         .withDefaultPosts()
         .build()
     )
+  override val profileDetailsModule = DemoProfileDetailsModule
 }

--- a/app/src/demo/java/br/com/orcinus/orca/app/demo/module/feature/profiledetails/DemoProfileDetailsModule.kt
+++ b/app/src/demo/java/br/com/orcinus/orca/app/demo/module/feature/profiledetails/DemoProfileDetailsModule.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023–2024 Orcinus
+ * Copyright © 2024 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -13,21 +13,22 @@
  * not, see https://www.gnu.org/licenses.
  */
 
-package br.com.orcinus.orca.app.module.feature.profiledetails
+package br.com.orcinus.orca.app.demo.module.feature.profiledetails
 
-import android.content.Context
-import br.com.orcinus.orca.core.mastodon.feed.profile.type.followable.MastodonFollowService
-import br.com.orcinus.orca.core.mastodon.instance.requester.Requester
+import br.com.orcinus.orca.app.module.feature.profiledetails.MainProfileDetailsBoundary
+import br.com.orcinus.orca.core.feed.profile.ProfileProvider
 import br.com.orcinus.orca.core.module.CoreModule
 import br.com.orcinus.orca.core.module.instanceProvider
+import br.com.orcinus.orca.core.sample.feed.profile.SampleProfileProvider
+import br.com.orcinus.orca.core.sample.feed.profile.type.followable.SampleFollowService
 import br.com.orcinus.orca.feature.profiledetails.ProfileDetailsModule
 import br.com.orcinus.orca.std.injector.Injector
 import br.com.orcinus.orca.std.injector.module.injection.lazyInjectionOf
 
-internal class MainProfileDetailsModule(context: Context) :
+internal object DemoProfileDetailsModule :
   ProfileDetailsModule(
     lazyInjectionOf { Injector.from<CoreModule>().instanceProvider().provide().profileProvider },
-    lazyInjectionOf { MastodonFollowService(Injector.get<Requester>()) },
+    lazyInjectionOf { SampleFollowService(get<ProfileProvider>() as SampleProfileProvider) },
     lazyInjectionOf { Injector.from<CoreModule>().instanceProvider().provide().postProvider },
-    lazyInjectionOf { MainProfileDetailsBoundary(context) }
+    lazyInjectionOf { MainProfileDetailsBoundary(context = Injector.get()) }
   )

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,7 +19,7 @@
         android:allowBackup="true"
         android:icon="@mipmap/icon_launcher"
         android:label="@string/app_name"
-        android:name=".OrcaApplication"
+        android:name=".MainOrcaApplication"
         android:roundIcon="@mipmap/icon_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Autos">

--- a/app/src/main/java/br/com/orcinus/orca/app/MainOrcaApplication.kt
+++ b/app/src/main/java/br/com/orcinus/orca/app/MainOrcaApplication.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2024 Orcinus
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package br.com.orcinus.orca.app
+
+import br.com.orcinus.orca.app.module.core.MainMastodonCoreModule
+import br.com.orcinus.orca.app.module.feature.profiledetails.MainProfileDetailsModule
+import br.com.orcinus.orca.core.mastodon.auth.authorization.viewmodel.MastodonAuthorizationViewModel
+import br.com.orcinus.orca.core.mastodon.instance.requester.Requester
+import br.com.orcinus.orca.std.injector.Injector
+
+/**
+ * [OrcaApplication] for the main version of Orca, whose [coreModule] contains core structures which
+ * perform HTTP requests to the Mastodon API through the [Requester] that gets injected when it is
+ * created.
+ */
+internal class MainOrcaApplication : OrcaApplication() {
+  override val coreModule = MainMastodonCoreModule
+  override val profileDetailsModule = MainProfileDetailsModule(this)
+
+  override fun onCreate() {
+    super.onCreate()
+    Injector.injectLazily {
+      Requester.create(MastodonAuthorizationViewModel.getDomain(context = Injector.get()).uri)
+    }
+  }
+}

--- a/app/src/main/java/br/com/orcinus/orca/app/OrcaApplication.kt
+++ b/app/src/main/java/br/com/orcinus/orca/app/OrcaApplication.kt
@@ -24,7 +24,6 @@ import br.com.orcinus.orca.app.module.core.MainMastodonCoreModule
 import br.com.orcinus.orca.app.module.feature.feed.MainFeedModule
 import br.com.orcinus.orca.app.module.feature.gallery.MainGalleryModule
 import br.com.orcinus.orca.app.module.feature.postdetails.MainPostDetailsModule
-import br.com.orcinus.orca.app.module.feature.profiledetails.MainProfileDetailsModule
 import br.com.orcinus.orca.app.module.feature.search.MainSearchModule
 import br.com.orcinus.orca.app.module.feature.settings.MainSettingsModule
 import br.com.orcinus.orca.app.module.feature.settings.termmuting.MainTermMutingModule
@@ -37,6 +36,7 @@ import br.com.orcinus.orca.feature.search.SearchModule
 import br.com.orcinus.orca.feature.settings.SettingsModule
 import br.com.orcinus.orca.feature.settings.termmuting.TermMutingModule
 import br.com.orcinus.orca.std.injector.Injector
+import br.com.orcinus.orca.std.injector.module.Module
 
 /**
  * Class whose instance lives throughout the whole lifecycle of the application.
@@ -55,17 +55,20 @@ import br.com.orcinus.orca.std.injector.Injector
  * @see Injector.inject
  * @see OrcaActivity.onDestroy
  */
-internal open class OrcaApplication : Application() {
+internal abstract class OrcaApplication : Application() {
   /**
    * [CoreModule] to be registered. Overridability is useful because the application can be built
-   * with distinct flavors with different core structures (e. g., in the default, main flavor, ones
-   * that access the API through network requests; in the demo flavor, ones that store and retrieve
+   * with distinct flavors with different core structures (e. g., in the default, main version, ones
+   * that access the API through network requests; in the demo version, ones that store and retrieve
    * data locally).
    *
    * @see Injector.register
    * @see MainMastodonCoreModule
    */
-  protected open val coreModule: CoreModule = MainMastodonCoreModule
+  protected abstract val coreModule: CoreModule
+
+  /** [Module] into which the dependencies required by the profile details feature are injected. */
+  protected abstract val profileDetailsModule: ProfileDetailsModule
 
   override fun onCreate() {
     super.onCreate()
@@ -74,7 +77,7 @@ internal open class OrcaApplication : Application() {
     Injector.register<FeedModule>(MainFeedModule(this))
     Injector.register<GalleryModule>(MainGalleryModule)
     Injector.register<PostDetailsModule>(MainPostDetailsModule(this))
-    Injector.register<ProfileDetailsModule>(MainProfileDetailsModule(this))
+    Injector.register(profileDetailsModule)
     Injector.register<SearchModule>(MainSearchModule)
     Injector.register<SettingsModule>(MainSettingsModule(this))
     Injector.register<TermMutingModule>(MainTermMutingModule)

--- a/app/src/testDemo/java/br/com/orcinus/orca/app/demo/ProfileDetailsTests.kt
+++ b/app/src/testDemo/java/br/com/orcinus/orca/app/demo/ProfileDetailsTests.kt
@@ -17,28 +17,16 @@ package br.com.orcinus.orca.app.demo
 
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onFirst
-import androidx.compose.ui.test.onLast
-import androidx.compose.ui.test.performClick
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import assertk.assertThat
 import br.com.orcinus.orca.app.R
 import br.com.orcinus.orca.app.activity.OrcaActivity
-import br.com.orcinus.orca.composite.timeline.test.isTimeline
-import br.com.orcinus.orca.composite.timeline.test.post.figure.link.onLinkCards
 import br.com.orcinus.orca.composite.timeline.test.post.onPostPreviews
-import br.com.orcinus.orca.composite.timeline.test.post.performScrollToPostPreviewWithLinkCard
-import br.com.orcinus.orca.core.auth.actor.Actor
-import br.com.orcinus.orca.core.sample.instance.SampleInstance
 import br.com.orcinus.orca.feature.postdetails.PostDetailsFragment
-import br.com.orcinus.orca.platform.core.image.sample
-import br.com.orcinus.orca.platform.core.sample
-import br.com.orcinus.orca.platform.intents.test.intendBrowsingTo
 import br.com.orcinus.orca.platform.navigation.test.isAt
-import br.com.orcinus.orca.std.image.compose.ComposableImageLoader
 import kotlin.test.BeforeTest
-import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -51,29 +39,6 @@ internal class ProfileDetailsTests {
   @BeforeTest
   fun setUp() {
     onView(withId(R.id.profile_details)).perform(click())
-  }
-
-  @Test
-  fun navigatesToPostLink() {
-    runTest {
-      val instance =
-        SampleInstance.Builder.create(ComposableImageLoader.Provider.sample)
-          .withDefaultProfiles()
-          .withDefaultPosts()
-          .build()
-      intendBrowsingTo(
-        instance.postProvider
-          .provideAllCurrentBy(Actor.Authenticated.sample.id)
-          .firstNotNullOf { it.content.highlight }
-          .uri
-      ) {
-        composeRule
-          .onAllNodes(isTimeline())
-          .onLast()
-          .performScrollToPostPreviewWithLinkCard(instance.feedProvider)
-        composeRule.onLinkCards().onFirst().performClick()
-      }
-    }
   }
 
   @Test

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/auth/authentication/activity/MastodonAuthenticationActivity.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/auth/authentication/activity/MastodonAuthenticationActivity.kt
@@ -49,7 +49,7 @@ class MastodonAuthenticationActivity : ComposableActivity() {
     viewModels<MastodonAuthenticationViewModel> {
       MastodonAuthenticationViewModel.createFactory(
         application,
-        instance.requester,
+        requester = Injector.get(),
         instance.imageLoaderProvider,
         authorizationCode
       )

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/account/MastodonAccount.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/account/MastodonAccount.kt
@@ -217,7 +217,6 @@ internal data class MastodonAccount(
         .first()
         .toFollow(locked)
     return MastodonFollowableProfile(
-      requester,
       postPaginatorProvider,
       id,
       account,

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/cache/storage/MastodonProfileEntity.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/cache/storage/MastodonProfileEntity.kt
@@ -94,7 +94,7 @@ internal constructor(
       EDITABLE_TYPE ->
         toMastodonEditableProfile(requester, avatarLoaderProvider, dao, postPaginatorProvider)
       FOLLOWABLE_TYPE ->
-        toMastodonFollowableProfile(requester, avatarLoaderProvider, dao, postPaginatorProvider)
+        toMastodonFollowableProfile(avatarLoaderProvider, dao, postPaginatorProvider)
       else -> throw IllegalStateException("Unknown profile entity type: $type.")
     }
   }
@@ -139,7 +139,6 @@ internal constructor(
   /**
    * Converts this [MastodonProfileEntity] into a [MastodonFollowableProfile].
    *
-   * @param requester [Requester] by which a request to change the follow status is performed.
    * @param avatarLoaderProvider [ImageLoader.Provider] that provides the [ImageLoader] by which the
    *   [MastodonFollowableProfile]'s avatar will be loaded from a [URI].
    * @param dao [MastodonProfileEntityDao] that will select the persisted
@@ -149,7 +148,6 @@ internal constructor(
    *   [MastodonFollowableProfile]'s [Post]s will be provided.
    */
   private suspend fun toMastodonFollowableProfile(
-    requester: Requester,
     avatarLoaderProvider: SomeImageLoaderProvider<URI>,
     dao: MastodonProfileEntityDao,
     postPaginatorProvider: MastodonProfilePostPaginator.Provider
@@ -161,7 +159,6 @@ internal constructor(
     val follow = Follow.of(checkNotNull(follow))
     val uri = URI(uri)
     return MastodonFollowableProfile(
-      requester,
       postPaginatorProvider,
       id,
       account,

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/type/followable/MastodonFollowService.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/type/followable/MastodonFollowService.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2024 Orcinus
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package br.com.orcinus.orca.core.mastodon.feed.profile.type.followable
+
+import br.com.orcinus.orca.core.feed.profile.type.followable.Follow
+import br.com.orcinus.orca.core.feed.profile.type.followable.FollowService
+import br.com.orcinus.orca.core.mastodon.instance.requester.Requester
+import br.com.orcinus.orca.core.mastodon.instance.requester.authentication.authenticated
+
+/**
+ * [FollowService] which communicates with the Mastodon API in order to toggle a [Follow] status.
+ *
+ * @property requester [Requester] by which the HTTP requests are sent.
+ */
+class MastodonFollowService(private val requester: Requester) : FollowService() {
+  override suspend fun toggle(profileID: String, follow: Follow) {
+    requester
+      .authenticated()
+      .post({
+        path("api")
+          .path("v1")
+          .path("accounts")
+          .path(profileID)
+          .run {
+            when (follow.toggled()) {
+              Follow.Public.following(),
+              Follow.Private.requested(),
+              Follow.Private.following() -> path("follow")
+              else -> path("unfollow")
+            }
+          }
+          .build()
+      })
+  }
+}

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/type/followable/MastodonFollowableProfile.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/type/followable/MastodonFollowableProfile.kt
@@ -22,8 +22,6 @@ import br.com.orcinus.orca.core.feed.profile.type.followable.Follow
 import br.com.orcinus.orca.core.feed.profile.type.followable.FollowableProfile
 import br.com.orcinus.orca.core.mastodon.feed.profile.MastodonProfile
 import br.com.orcinus.orca.core.mastodon.feed.profile.MastodonProfilePostPaginator
-import br.com.orcinus.orca.core.mastodon.instance.requester.Requester
-import br.com.orcinus.orca.core.mastodon.instance.requester.authentication.authenticated
 import br.com.orcinus.orca.std.image.SomeImageLoader
 import br.com.orcinus.orca.std.markdown.Markdown
 import java.net.URI
@@ -31,13 +29,11 @@ import java.net.URI
 /**
  * [MastodonProfile] that can be followed.
  *
- * @property requester [Requester] by which a request to change the follow status is performed.
  * @property postPaginatorProvider [MastodonProfilePostPaginator.Provider] by which a
  *   [MastodonProfilePostPaginator] for paginating through the [MastodonProfile]'s [Post]s will be
  *   provided.
  */
 internal class MastodonFollowableProfile<T : Follow>(
-  private val requester: Requester,
   private val postPaginatorProvider: MastodonProfilePostPaginator.Provider,
   override val id: String,
   override val account: Account,
@@ -60,24 +56,4 @@ internal class MastodonFollowableProfile<T : Follow>(
     followingCount,
     uri
   ),
-  FollowableProfile<T>() {
-  override suspend fun onChangeFollowTo(follow: T) {
-    requester
-      .authenticated()
-      .post({
-        path("api")
-          .path("v1")
-          .path("accounts")
-          .path(id)
-          .run {
-            when (follow) {
-              Follow.Public.following(),
-              Follow.Private.requested(),
-              Follow.Private.following() -> path("follow")
-              else -> path("unfollow")
-            }
-          }
-          .build()
-      })
-  }
-}
+  FollowableProfile<T>()

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/instance/ContextualMastodonInstance.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/instance/ContextualMastodonInstance.kt
@@ -45,6 +45,7 @@ import br.com.orcinus.orca.platform.cache.Cache
 import br.com.orcinus.orca.platform.cache.Fetcher
 import br.com.orcinus.orca.std.image.ImageLoader
 import br.com.orcinus.orca.std.image.SomeImageLoaderProvider
+import br.com.orcinus.orca.std.injector.Injector
 import java.net.URI
 
 /**
@@ -81,7 +82,7 @@ internal class ContextualMastodonInstance(
     MastodonProfilePostPaginator.Provider {
       MastodonProfilePostPaginator(
         context,
-        requester,
+        requester = Injector.get(),
         actorProvider,
         commentPaginatorProvider::provide,
         imageLoaderProvider,
@@ -97,7 +98,7 @@ internal class ContextualMastodonInstance(
     MastodonCommentPaginator.Provider {
       MastodonCommentPaginator(
         context,
-        requester,
+        requester = Injector.get(),
         actorProvider,
         profilePostPaginatorProvider,
         imageLoaderProvider,
@@ -109,7 +110,7 @@ internal class ContextualMastodonInstance(
   private val postFetcher =
     MastodonPostFetcher(
       context,
-      requester,
+      requester = Injector.get(),
       actorProvider,
       profilePostPaginatorProvider,
       commentPaginatorProvider,
@@ -123,7 +124,7 @@ internal class ContextualMastodonInstance(
   private val feedPostPaginator =
     MastodonFeedPaginator(
       context,
-      requester,
+      requester = Injector.get(),
       actorProvider,
       profilePostPaginatorProvider,
       commentPaginatorProvider,
@@ -132,12 +133,17 @@ internal class ContextualMastodonInstance(
 
   /** [MastodonProfileFetcher] by which [MastodonProfile]s will be fetched from the API. */
   private val profileFetcher =
-    MastodonProfileFetcher(context, requester, imageLoaderProvider, profilePostPaginatorProvider)
+    MastodonProfileFetcher(
+      context,
+      requester = Injector.get(),
+      imageLoaderProvider,
+      profilePostPaginatorProvider
+    )
 
   /** [MastodonProfileStorage] that will store fetched [MastodonProfile]s. */
   private val profileStorage =
     MastodonProfileStorage(
-      requester,
+      requester = Injector.get(),
       imageLoaderProvider,
       profilePostPaginatorProvider,
       database.profileEntityDao
@@ -154,7 +160,7 @@ internal class ContextualMastodonInstance(
   private val profileSearchResultsFetcher =
     MastodonProfileSearchResultsFetcher(
       context,
-      requester,
+      requester = Injector.get(),
       imageLoaderProvider,
       profilePostPaginatorProvider
     )
@@ -176,7 +182,7 @@ internal class ContextualMastodonInstance(
   private val postStorage =
     MastodonPostStorage(
       context,
-      requester,
+      requester = Injector.get(),
       profileCache,
       profilePostPaginatorProvider,
       database.postEntityDao,

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/instance/MastodonInstance.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/instance/MastodonInstance.kt
@@ -19,9 +19,6 @@ import br.com.orcinus.orca.core.auth.Authenticator
 import br.com.orcinus.orca.core.auth.Authorizer
 import br.com.orcinus.orca.core.instance.Instance
 import br.com.orcinus.orca.core.instance.domain.Domain
-import br.com.orcinus.orca.core.mastodon.instance.requester.Logger
-import br.com.orcinus.orca.core.mastodon.instance.requester.Requester
-import io.ktor.client.engine.cio.CIO
 import io.ktor.client.request.HttpRequest
 import io.ktor.http.URLBuilder
 import io.ktor.http.Url
@@ -42,8 +39,4 @@ internal constructor(final override val domain: Domain, internal val authorizer:
   Instance<S>() {
   /** [Url] to which routes will be appended when [HttpRequest]s are sent. */
   internal val url = URLBuilder().apply { set(scheme = "https", host = "$domain") }.build()
-
-  /** [Requester] by which requests are performed. */
-  internal open val requester =
-    Requester(Logger.Android, baseURI = domain.uri, clientEngineFactory = CIO)
 }

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/instance/MastodonInstanceProvider.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/instance/MastodonInstanceProvider.kt
@@ -57,7 +57,7 @@ class MastodonInstanceProvider(
   private val instance by lazy {
     ContextualMastodonInstance(
       context,
-      MastodonAuthorizationViewModel.getInstanceDomain(context),
+      MastodonAuthorizationViewModel.getDomain(context),
       authorizer,
       authenticator,
       actorProvider,

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/instance/requester/Logger.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/instance/requester/Logger.kt
@@ -28,7 +28,7 @@ import io.ktor.client.statement.request
 import io.ktor.http.isSuccess
 
 /** Logs messages with different severity levels. */
-internal abstract class Logger {
+abstract class Logger @InternalRequesterApi internal constructor() {
   /** [Logger] that forwards logs to the Android [Log]. */
   object Android : Logger() {
     /** Tag by which sent logs will be tagged. */
@@ -49,7 +49,7 @@ internal abstract class Logger {
    * @param clientConfig [HttpClientConfig] whose [HttpResponse]s will be logged.
    */
   @InternalRequesterApi
-  fun start(clientConfig: HttpClientConfig<*>) {
+  internal fun start(clientConfig: HttpClientConfig<*>) {
     clientConfig.ResponseObserver {
       val message = it.format()
       val logging = if (it.status.isSuccess()) ::info else ::error
@@ -80,7 +80,7 @@ internal abstract class Logger {
    * itself.
    */
   @InternalRequesterApi
-  suspend fun HttpResponse.format(): String {
+  internal suspend fun HttpResponse.format(): String {
     val requestContent = request.content
     val requestFormDataParamsAsString =
       if (requestContent is FormDataContent) " (${requestContent.formData})" else ""

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/instance/requester/Requester.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/instance/requester/Requester.kt
@@ -26,6 +26,7 @@ import io.ktor.client.HttpClient
 import io.ktor.client.HttpClientConfig
 import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.engine.HttpClientEngineFactory
+import io.ktor.client.engine.cio.CIO
 import io.ktor.client.plugins.HttpRequestRetry
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.request.HttpRequestBuilder
@@ -64,7 +65,8 @@ import kotlinx.serialization.json.JsonNamingStrategy
  * @see get
  * @see post
  */
-internal open class Requester(
+open class Requester
+internal constructor(
   @get:InternalRequesterApi internal val logger: Logger,
   @get:InternalRequesterApi internal val baseURI: URI,
   @get:InternalRequesterApi internal val clientEngineFactory: HttpClientEngineFactory<*>
@@ -83,7 +85,7 @@ internal open class Requester(
    *
    * @property headers [Headers] that have been appended.
    */
-  open class Configuration
+  internal open class Configuration
   @InternalRequesterApi
   constructor(@get:InternalRequesterApi val headers: Headers) {
     /**
@@ -222,7 +224,7 @@ internal open class Requester(
    * @param route Builds the route from the [baseURI] to which the request will be sent.
    * @param config Additionally configures the request.
    */
-  suspend fun delete(
+  internal suspend fun delete(
     route: HostedURLBuilder.() -> URI,
     config: Configuration.Builder.() -> Unit = Configuration.noOpBuild
   ): HttpResponse {
@@ -235,7 +237,7 @@ internal open class Requester(
    * @param route Builds the route from the [baseURI] to which the request will be sent.
    * @param config Additionally configures the request.
    */
-  suspend fun get(
+  internal suspend fun get(
     route: HostedURLBuilder.() -> URI,
     config: Configuration.Builder.() -> Unit = Configuration.noOpBuild
   ): HttpResponse {
@@ -248,7 +250,7 @@ internal open class Requester(
    * @param route Builds the route from the [baseURI] to which the request will be sent.
    * @param config Additionally configures the request.
    */
-  suspend fun post(
+  internal suspend fun post(
     route: HostedURLBuilder.() -> URI,
     config: Configuration.UrlEncoded.Builder.() -> Unit = Configuration.noOpBuild
   ): HttpResponse {
@@ -262,7 +264,7 @@ internal open class Requester(
    * @param form `multipart/form-data`-encoded parts to be added as headers.
    * @param config Additionally configures the request.
    */
-  suspend fun post(
+  internal suspend fun post(
     route: HostedURLBuilder.() -> URI,
     form: List<PartData>,
     config: Configuration.Builder.() -> Unit = Configuration.noOpBuild
@@ -397,5 +399,15 @@ internal open class Requester(
   companion object {
     /** Lambda in which a request being built isn't modified. */
     private val noOpRequestBuild: HttpRequestBuilder.() -> Unit = {}
+
+    /**
+     * Creates a [Requester].
+     *
+     * @param baseURI [URI] from which routes are constructed.
+     */
+    @JvmStatic
+    fun create(baseURI: URI): Requester {
+      return Requester(Logger.Android, baseURI, clientEngineFactory = CIO)
+    }
   }
 }

--- a/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/instance/SampleMastodonInstance.kt
+++ b/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/instance/SampleMastodonInstance.kt
@@ -19,33 +19,24 @@ import br.com.orcinus.orca.core.auth.AuthenticationLock
 import br.com.orcinus.orca.core.auth.Authenticator
 import br.com.orcinus.orca.core.auth.Authorizer
 import br.com.orcinus.orca.core.instance.domain.Domain
-import br.com.orcinus.orca.core.mastodon.instance.requester.ClientResponseProvider
-import br.com.orcinus.orca.core.mastodon.instance.requester.NoOpLogger
-import br.com.orcinus.orca.core.mastodon.instance.requester.Requester
-import br.com.orcinus.orca.core.mastodon.instance.requester.createHttpClientEngineFactory
 import br.com.orcinus.orca.core.sample.feed.SampleFeedProvider
 import br.com.orcinus.orca.core.sample.feed.profile.SampleProfileProvider
 import br.com.orcinus.orca.core.sample.feed.profile.post.SamplePostProvider
 import br.com.orcinus.orca.core.sample.feed.profile.post.content.SampleTermMuter
 import br.com.orcinus.orca.core.sample.feed.profile.search.SampleProfileSearcher
 import br.com.orcinus.orca.core.sample.instance.domain.sample
-import br.com.orcinus.orca.ext.uri.URIBuilder
 import br.com.orcinus.orca.platform.core.image.sample
 import br.com.orcinus.orca.std.image.compose.ComposableImageLoader
-import io.ktor.client.request.HttpRequest
 
 /**
- * [MastodonInstance] with sample structures and whose [requester] responds OK to each sent
- * [HttpRequest].
+ * [MastodonInstance] with sample structures.
  *
  * @param authorizer [Authorizer] with which the user will be authorized.
- * @property clientResponseProvider Defines how the [requester] to an [HttpRequest].
  */
 internal class SampleMastodonInstance(
   authorizer: Authorizer,
   override val authenticator: Authenticator,
-  override val authenticationLock: AuthenticationLock<Authenticator>,
-  private val clientResponseProvider: ClientResponseProvider
+  override val authenticationLock: AuthenticationLock<Authenticator>
 ) : MastodonInstance<Authorizer, Authenticator>(Domain.sample, authorizer) {
   override val profileProvider = SampleProfileProvider()
   override val profileSearcher = SampleProfileSearcher(profileProvider)
@@ -56,11 +47,5 @@ internal class SampleMastodonInstance(
       postProvider,
       SampleTermMuter(),
       ComposableImageLoader.Provider.sample
-    )
-  override val requester =
-    Requester(
-      NoOpLogger,
-      baseURI = URIBuilder.url().scheme("https").host("orca.orcinus.com.br").path("app").build(),
-      createHttpClientEngineFactory(clientResponseProvider)
     )
 }

--- a/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/instance/SampleMastodonInstanceProvider.kt
+++ b/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/instance/SampleMastodonInstanceProvider.kt
@@ -19,9 +19,6 @@ import br.com.orcinus.orca.core.auth.AuthenticationLock
 import br.com.orcinus.orca.core.auth.Authenticator
 import br.com.orcinus.orca.core.auth.Authorizer
 import br.com.orcinus.orca.core.instance.InstanceProvider
-import br.com.orcinus.orca.core.mastodon.instance.requester.ClientResponseProvider
-import io.ktor.client.HttpClient
-import io.ktor.client.request.HttpRequest
 
 /**
  * [InstanceProvider] that provides a [SampleMastodonInstance].
@@ -30,13 +27,11 @@ import io.ktor.client.request.HttpRequest
  * @property authenticator [Authenticator] through which authentication can be done.
  * @property authenticationLock [AuthenticationLock] by which features can be locked or unlocked by
  *   an authentication "wall".
- * @property clientResponseProvider Defines how the [HttpClient] to an [HttpRequest].
  */
 internal class SampleMastodonInstanceProvider(
   private val authorizer: Authorizer,
   private val authenticator: Authenticator,
-  private val authenticationLock: AuthenticationLock<Authenticator>,
-  private val clientResponseProvider: ClientResponseProvider
+  private val authenticationLock: AuthenticationLock<Authenticator>
 ) : InstanceProvider {
   /**
    * [SampleMastodonInstance] to be provided.
@@ -44,7 +39,7 @@ internal class SampleMastodonInstanceProvider(
    * @see provide
    */
   private val instance by lazy {
-    SampleMastodonInstance(authorizer, authenticator, authenticationLock, clientResponseProvider)
+    SampleMastodonInstance(authorizer, authenticator, authenticationLock)
   }
 
   override fun provide(): SampleMastodonInstance {

--- a/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/instance/requester/HttpClientEngineFactory.extensions.kt
+++ b/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/instance/requester/HttpClientEngineFactory.extensions.kt
@@ -16,7 +16,6 @@
 package br.com.orcinus.orca.core.mastodon.instance.requester
 
 import io.ktor.client.engine.HttpClientEngine
-import io.ktor.client.engine.HttpClientEngineConfig
 import io.ktor.client.engine.HttpClientEngineFactory
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.MockEngineConfig
@@ -34,30 +33,9 @@ import io.ktor.client.statement.HttpResponse
 internal fun createHttpClientEngineFactory(
   responseProvider: ClientResponseProvider
 ): HttpClientEngineFactory<MockEngineConfig> {
-  @Suppress("USELESS_CAST")
-  return createHttpClientEngineFactory(
-    { MockEngine { with(responseProvider) { provide(it) } } } as () -> MockEngine
-  )
-}
-
-/**
- * Creates an [HttpClientEngineFactory] that produces the [engine].
- *
- * @param T [HttpClientEngineConfig] with which the [engine] is configured.
- * @param engine Returns [HttpClientEngine] to be created by the [HttpClientEngineFactory] when it's
- *   requested to produce a new one.
- * @throws ClassCastException If the [engine]'s configuration isn't of type [T].
- * @see HttpClientEngine.config
- * @see HttpClientEngineFactory.create
- */
-@InternalRequesterApi
-@Throws(ClassCastException::class)
-internal fun <T : HttpClientEngineConfig> createHttpClientEngineFactory(
-  engine: () -> HttpClientEngine
-): HttpClientEngineFactory<T> {
-  return object : HttpClientEngineFactory<T> {
-    override fun create(block: T.() -> Unit): HttpClientEngine {
-      return engine().apply { @Suppress("UNCHECKED_CAST") (config as T).block() }
+  return object : HttpClientEngineFactory<MockEngineConfig> {
+    override fun create(block: MockEngineConfig.() -> Unit): HttpClientEngine {
+      return MockEngine { with(responseProvider) { provide(it) } }.apply { config.block() }
     }
   }
 }

--- a/core/sample/src/main/java/br/com/orcinus/orca/core/sample/feed/profile/SampleProfileProvider.kt
+++ b/core/sample/src/main/java/br/com/orcinus/orca/core/sample/feed/profile/SampleProfileProvider.kt
@@ -17,9 +17,7 @@ package br.com.orcinus.orca.core.sample.feed.profile
 
 import br.com.orcinus.orca.core.feed.profile.Profile
 import br.com.orcinus.orca.core.feed.profile.ProfileProvider
-import br.com.orcinus.orca.core.feed.profile.type.followable.Follow
 import br.com.orcinus.orca.core.sample.feed.profile.type.editable.replacingOnceBy
-import br.com.orcinus.orca.core.sample.feed.profile.type.followable.SampleFollowableProfile
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
@@ -84,22 +82,6 @@ class SampleProfileProvider : ProfileProvider() {
    */
   internal fun add(vararg profiles: Profile) {
     profilesFlow.value += profiles
-  }
-
-  /**
-   * Updates the follow status of the [Profile] whose ID is equal the given [id].
-   *
-   * @param id The [Profile]'s ID.
-   * @param follow [Follow] status to update the follow status to.
-   * @throws ProfileProvider.NonexistentProfileException If no [Profile] with such an ID exists.
-   * @see SampleFollowableProfile.follow
-   * @see SampleFollowableProfile.id
-   */
-  @Throws(NonexistentProfileException::class)
-  internal suspend fun <T : Follow> updateFollow(id: String, follow: T) {
-    update(id) {
-      @Suppress("UNCHECKED_CAST") (this as SampleFollowableProfile<T>).copy(follow = follow)
-    }
   }
 
   /**

--- a/core/sample/src/main/java/br/com/orcinus/orca/core/sample/feed/profile/type/followable/SampleFollowService.kt
+++ b/core/sample/src/main/java/br/com/orcinus/orca/core/sample/feed/profile/type/followable/SampleFollowService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023–2024 Orcinus
+ * Copyright © 2024 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -13,18 +13,19 @@
  * not, see https://www.gnu.org/licenses.
  */
 
-package br.com.orcinus.orca.feature.profiledetails
+package br.com.orcinus.orca.core.sample.feed.profile.type.followable
 
-import br.com.orcinus.orca.core.feed.profile.ProfileProvider
-import br.com.orcinus.orca.core.feed.profile.post.PostProvider
+import br.com.orcinus.orca.core.feed.profile.type.followable.Follow
 import br.com.orcinus.orca.core.feed.profile.type.followable.FollowService
-import br.com.orcinus.orca.std.injector.module.Inject
-import br.com.orcinus.orca.std.injector.module.Module
-import br.com.orcinus.orca.std.injector.module.injection.Injection
+import br.com.orcinus.orca.core.sample.feed.profile.SampleProfileProvider
 
-abstract class ProfileDetailsModule(
-  @Inject internal val profileProvider: Injection<ProfileProvider>,
-  @Inject internal val followService: Injection<FollowService>,
-  @Inject internal val postProvider: Injection<PostProvider>,
-  @Inject internal val boundary: Injection<ProfileDetailsBoundary>
-) : Module()
+/** [FollowService] that toggles the [Follow] status of a [SampleFollowableProfile] in memory. */
+class SampleFollowService(private val profileProvider: SampleProfileProvider) : FollowService() {
+  @Throws(ClassCastException::class)
+  override suspend fun toggle(profileID: String, follow: Follow) {
+    profileProvider.update(profileID) {
+      @Suppress("UNCHECKED_CAST")
+      (this as SampleFollowableProfile<Follow>).copy(follow = follow.toggled())
+    }
+  }
+}

--- a/core/sample/src/main/java/br/com/orcinus/orca/core/sample/feed/profile/type/followable/SampleFollowableProfile.kt
+++ b/core/sample/src/main/java/br/com/orcinus/orca/core/sample/feed/profile/type/followable/SampleFollowableProfile.kt
@@ -40,8 +40,4 @@ internal data class SampleFollowableProfile<T : Follow>(
   override val followingCount: Int
 ) :
   Profile by SampleProfile(postProvider, delegate, bio, followerCount, followingCount),
-  FollowableProfile<T>() {
-  override suspend fun onChangeFollowTo(follow: T) {
-    provider.updateFollow(id, follow)
-  }
-}
+  FollowableProfile<T>()

--- a/core/sample/src/test/java/br/com/orcinus/orca/core/sample/feed/profile/Asserter.extensions.kt
+++ b/core/sample/src/test/java/br/com/orcinus/orca/core/sample/feed/profile/Asserter.extensions.kt
@@ -19,6 +19,7 @@ import br.com.orcinus.orca.core.feed.profile.post.Author
 import br.com.orcinus.orca.core.feed.profile.type.followable.Follow
 import br.com.orcinus.orca.core.sample.feed.profile.post.SamplePostProvider
 import br.com.orcinus.orca.core.sample.feed.profile.post.createSample
+import br.com.orcinus.orca.core.sample.feed.profile.type.followable.SampleFollowService
 import br.com.orcinus.orca.core.sample.feed.profile.type.followable.SampleFollowableProfile
 import br.com.orcinus.orca.core.sample.test.image.NoOpSampleImageLoader
 import br.com.orcinus.orca.std.markdown.Markdown
@@ -31,7 +32,7 @@ import kotlin.test.assertEquals
  * @param before [Follow] status before the toggle.
  * @param after [Follow] status after the toggle.
  * @see SampleFollowableProfile.follow
- * @see SampleFollowableProfile.toggleFollow
+ * @see SampleFollowService.toggle
  */
 internal suspend fun <T : Follow> assertTogglingEquals(after: T, before: T) {
   val matchingAfter = Follow.requireVisibilityMatch(before, after)
@@ -48,7 +49,8 @@ internal suspend fun <T : Follow> assertTogglingEquals(after: T, before: T) {
       followerCount = 0,
       followingCount = 0
     )
+  val followService = SampleFollowService(profileProvider)
   profileProvider.add(profile)
-  profile.toggleFollow()
+  followService.toggle(profile.id, profile.follow)
   assertEquals(matchingAfter, profileProvider.provideCurrent<SampleFollowableProfile<T>>().follow)
 }

--- a/core/sample/src/test/java/br/com/orcinus/orca/core/sample/feed/profile/SampleProfileProviderTests.kt
+++ b/core/sample/src/test/java/br/com/orcinus/orca/core/sample/feed/profile/SampleProfileProviderTests.kt
@@ -142,29 +142,6 @@ internal class SampleProfileProviderTests {
   }
 
   @Test
-  fun updatesFollow() {
-    runTest {
-      val profileProvider = SampleProfileProvider()
-      val postProvider = SamplePostProvider()
-      val profileDelegate = Author.createRamboSample(NoOpSampleImageLoader.Provider)
-      val profile =
-        SampleFollowableProfile(
-          profileProvider,
-          postProvider,
-          profileDelegate,
-          bio = Markdown.empty,
-          Follow.Private.unfollowed(),
-          followerCount = 0,
-          followingCount = 0
-        )
-      profileProvider.add(profile)
-      profileProvider.updateFollow(profile.id, Follow.Private.requested())
-      val follow = profileProvider.provideCurrent<SampleFollowableProfile<Follow.Private>>().follow
-      assertThat(follow).isEqualTo(Follow.Private.requested())
-    }
-  }
-
-  @Test
   fun updates() {
     runTest {
       val profileProvider = SampleProfileProvider()

--- a/core/sample/src/test/java/br/com/orcinus/orca/core/sample/feed/profile/type/followable/SampleFollowServiceTests.kt
+++ b/core/sample/src/test/java/br/com/orcinus/orca/core/sample/feed/profile/type/followable/SampleFollowServiceTests.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2024 Orcinus
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package br.com.orcinus.orca.core.sample.feed.profile.type.followable
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.prop
+import br.com.orcinus.orca.core.feed.profile.type.followable.Follow
+import br.com.orcinus.orca.core.feed.profile.type.followable.FollowableProfile
+import br.com.orcinus.orca.core.sample.instance.SampleInstance
+import br.com.orcinus.orca.core.sample.test.image.NoOpSampleImageLoader
+import kotlin.test.Test
+import kotlinx.coroutines.test.runTest
+
+internal class SampleFollowServiceTests {
+  @Test
+  fun toggles() {
+    val profileProvider =
+      SampleInstance.Builder.create(NoOpSampleImageLoader.Provider)
+        .withDefaultProfiles()
+        .build()
+        .profileProvider
+    val getProfile = { profileProvider.provideCurrent<FollowableProfile<Follow.Public>>() }
+    val untoggledFollowProfile = getProfile()
+    runTest {
+      SampleFollowService(profileProvider)
+        .toggle(untoggledFollowProfile.id, untoggledFollowProfile.follow)
+    }
+    assertThat(getProfile())
+      .prop(FollowableProfile<*>::follow)
+      .isEqualTo(untoggledFollowProfile.follow.toggled())
+  }
+}

--- a/core/src/main/java/br/com/orcinus/orca/core/feed/profile/type/followable/Follow.kt
+++ b/core/src/main/java/br/com/orcinus/orca/core/feed/profile/type/followable/Follow.kt
@@ -195,7 +195,7 @@ abstract class Follow private constructor() : Serializable {
   }
 
   /** Provides the [Follow] status that's contrary to this one. */
-  internal abstract fun toggled(): Follow
+  @InternalCoreApi abstract fun toggled(): Follow
 
   /** Provides the [Follow] status that succeeds this one. */
   internal abstract fun next(): Follow?

--- a/core/src/main/java/br/com/orcinus/orca/core/feed/profile/type/followable/FollowService.kt
+++ b/core/src/main/java/br/com/orcinus/orca/core/feed/profile/type/followable/FollowService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023–2024 Orcinus
+ * Copyright © 2024 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -16,12 +16,19 @@
 package br.com.orcinus.orca.core.feed.profile.type.followable
 
 import br.com.orcinus.orca.core.InternalCoreApi
-import br.com.orcinus.orca.core.feed.profile.Profile
+import br.com.orcinus.orca.core.auth.actor.Actor
 
-/** [Profile] whose [follow] status can be toggled. */
-abstract class FollowableProfile<T : Follow> @InternalCoreApi constructor() : Profile {
-  /** Current [Follow] status. */
-  abstract val follow: T
-
-  companion object
+/**
+ * Service by which the [Follow] status of a [FollowableProfile] in relation to another is changed.
+ */
+abstract class FollowService @InternalCoreApi constructor() {
+  /**
+   * Toggles the [Follow] status of the currently authenticated [Actor] regarding the specified
+   * [FollowableProfile].
+   *
+   * @param profileID ID of the [FollowableProfile] to follow, request to follow or unfollow.
+   * @see FollowableProfile.follow
+   * @see FollowableProfile.id
+   */
+  abstract suspend fun toggle(profileID: String, follow: Follow)
 }

--- a/core/src/test/java/br/com/orcinus/orca/core/CoreTests.kt
+++ b/core/src/test/java/br/com/orcinus/orca/core/CoreTests.kt
@@ -17,6 +17,7 @@ package br.com.orcinus.orca.core
 
 import com.lemonappdev.konsist.api.Konsist.scopeFromProject
 import com.lemonappdev.konsist.api.declaration.KoClassDeclaration
+import com.lemonappdev.konsist.api.declaration.KoFunctionDeclaration
 import com.lemonappdev.konsist.api.ext.list.constructors
 import com.lemonappdev.konsist.api.provider.KoKDocProvider
 import com.lemonappdev.konsist.api.provider.modifier.KoCompanionModifierProvider
@@ -53,9 +54,10 @@ internal class CoreTests {
   fun areFunctionalClassesTested() {
     val functionalClasses =
       scope.classes().filter { `class` ->
-        `class`.hasFunction { function ->
-          !function.hasNameMatching(Regex("equals|hashCode|toString"))
-        }
+        `class`
+          .functions(includeLocal = false)
+          .filterNot(KoFunctionDeclaration::hasAbstractModifier)
+          .any { function -> !function.hasNameMatching(Regex("equals|hashCode|toString")) }
       }
     if (functionalClasses.isNotEmpty()) {
       val testScope = scopeFromProject(MODULE_NAME, sourceSetName = "test")

--- a/feature/profile-details-test/src/main/java/br/com/orcinus/orca/feature/profiledetails/test/UnnavigableProfileDetailsModule.kt
+++ b/feature/profile-details-test/src/main/java/br/com/orcinus/orca/feature/profiledetails/test/UnnavigableProfileDetailsModule.kt
@@ -21,6 +21,7 @@ import br.com.orcinus.orca.core.feed.profile.post.Post
 import br.com.orcinus.orca.core.feed.profile.post.PostProvider
 import br.com.orcinus.orca.core.sample.feed.profile.SampleProfileProvider
 import br.com.orcinus.orca.core.sample.feed.profile.post.SamplePostProvider
+import br.com.orcinus.orca.core.sample.feed.profile.type.followable.SampleFollowService
 import br.com.orcinus.orca.feature.profiledetails.ProfileDetailsBoundary
 import br.com.orcinus.orca.feature.profiledetails.ProfileDetailsModule
 import br.com.orcinus.orca.std.injector.module.injection.immediateInjectionOf
@@ -37,10 +38,12 @@ import br.com.orcinus.orca.std.injector.module.injection.lazyInjectionOf
  */
 class UnnavigableProfileDetailsModule(
   profileProvider: SampleProfileProvider,
+  followService: SampleFollowService,
   postProvider: SamplePostProvider
 ) :
   ProfileDetailsModule(
     immediateInjectionOf<ProfileProvider>(profileProvider),
+    immediateInjectionOf(followService),
     immediateInjectionOf<PostProvider>(postProvider),
     lazyInjectionOf { NoOpProfileDetailsBoundary }
   )

--- a/feature/profile-details/src/androidTest/java/br/com/orcinus/orca/feature/profiledetails/ProfileDetailsFragmentTests.kt
+++ b/feature/profile-details/src/androidTest/java/br/com/orcinus/orca/feature/profiledetails/ProfileDetailsFragmentTests.kt
@@ -18,6 +18,7 @@ package br.com.orcinus.orca.feature.profiledetails
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.junit4.createEmptyComposeRule
 import br.com.orcinus.orca.core.feed.profile.type.editable.EditableProfile
+import br.com.orcinus.orca.core.sample.feed.profile.type.followable.SampleFollowService
 import br.com.orcinus.orca.core.sample.instance.SampleInstance
 import br.com.orcinus.orca.feature.profiledetails.navigation.BackwardsNavigationState
 import br.com.orcinus.orca.feature.profiledetails.test.UnnavigableProfileDetailsModule
@@ -39,9 +40,10 @@ internal class ProfileDetailsFragmentTests {
       .withDefaultPosts()
       .build()
   private val profileProvider = instance.profileProvider
+  private val followService = SampleFollowService(profileProvider)
   private val injectorRule = InjectorTestRule {
     register<ProfileDetailsModule>(
-      UnnavigableProfileDetailsModule(profileProvider, instance.postProvider)
+      UnnavigableProfileDetailsModule(profileProvider, followService, instance.postProvider)
     )
   }
   private val composeRule = createEmptyComposeRule()

--- a/feature/profile-details/src/main/java/br/com/orcinus/orca/feature/profiledetails/Profile.extensions.kt
+++ b/feature/profile-details/src/main/java/br/com/orcinus/orca/feature/profiledetails/Profile.extensions.kt
@@ -17,6 +17,8 @@ package br.com.orcinus.orca.feature.profiledetails
 
 import br.com.orcinus.orca.autos.colors.Colors
 import br.com.orcinus.orca.core.feed.profile.Profile
+import br.com.orcinus.orca.core.feed.profile.type.followable.Follow
+import br.com.orcinus.orca.core.feed.profile.type.followable.FollowService
 import br.com.orcinus.orca.feature.profiledetails.conversion.ProfileConverterFactory
 import kotlinx.coroutines.CoroutineScope
 
@@ -25,12 +27,15 @@ import kotlinx.coroutines.CoroutineScope
  *
  * @param coroutineScope [CoroutineScope] through which converted [Profile]-related suspending will
  *   be performed.
+ * @param followService [FollowService] by which the [Follow] status can be toggled.
  * @param colors [Colors] by which visuals can be colored.
+ * @see Follow.toggled
  */
 internal fun Profile.toProfileDetails(
   coroutineScope: CoroutineScope,
+  followService: FollowService,
   colors: Colors
 ): ProfileDetails {
-  val details = ProfileConverterFactory.create(coroutineScope).convert(this, colors)
+  val details = ProfileConverterFactory.create(coroutineScope, followService).convert(this, colors)
   return requireNotNull(details)
 }

--- a/feature/profile-details/src/main/java/br/com/orcinus/orca/feature/profiledetails/ProfileDetails.kt
+++ b/feature/profile-details/src/main/java/br/com/orcinus/orca/feature/profiledetails/ProfileDetails.kt
@@ -57,6 +57,8 @@ import br.com.orcinus.orca.composite.timeline.post.time.RelativeTimeProvider
 import br.com.orcinus.orca.composite.timeline.post.time.rememberRelativeTimeProvider
 import br.com.orcinus.orca.core.feed.profile.account.Account
 import br.com.orcinus.orca.core.feed.profile.type.editable.EditableProfile
+import br.com.orcinus.orca.core.sample.feed.profile.SampleProfileProvider
+import br.com.orcinus.orca.core.sample.feed.profile.type.followable.SampleFollowService
 import br.com.orcinus.orca.core.sample.instance.SampleInstance
 import br.com.orcinus.orca.feature.profiledetails.navigation.BackwardsNavigationState
 import br.com.orcinus.orca.feature.profiledetails.navigation.NavigationButton
@@ -187,13 +189,15 @@ internal sealed class ProfileDetails : Serializable {
       @Composable
       get() {
         val coroutineScope = rememberCoroutineScope()
+        val profileProvider = SampleProfileProvider()
+        val followService = SampleFollowService(profileProvider)
         return SampleInstance.Builder.create(ComposableImageLoader.Provider.sample)
           .withDefaultProfiles()
           .withDefaultPosts()
           .build()
           .profileProvider
           .provideCurrent<EditableProfile>()
-          .toProfileDetails(coroutineScope, AutosTheme.colors)
+          .toProfileDetails(coroutineScope, followService, AutosTheme.colors)
       }
   }
 }

--- a/feature/profile-details/src/main/java/br/com/orcinus/orca/feature/profiledetails/ProfileDetailsFragment.kt
+++ b/feature/profile-details/src/main/java/br/com/orcinus/orca/feature/profiledetails/ProfileDetailsFragment.kt
@@ -39,6 +39,7 @@ class ProfileDetailsFragment internal constructor() : ComposableFragment() {
       ProfileDetailsViewModel.createFactory(
         application,
         module.profileProvider(),
+        module.followService(),
         module.postProvider(),
         id,
         onLinkClick = boundary::navigateTo,

--- a/feature/profile-details/src/main/java/br/com/orcinus/orca/feature/profiledetails/ProfileDetailsViewModel.kt
+++ b/feature/profile-details/src/main/java/br/com/orcinus/orca/feature/profiledetails/ProfileDetailsViewModel.kt
@@ -25,6 +25,7 @@ import br.com.orcinus.orca.composite.timeline.post.figure.gallery.disposition.Di
 import br.com.orcinus.orca.composite.timeline.post.toPostPreviewFlow
 import br.com.orcinus.orca.core.feed.profile.ProfileProvider
 import br.com.orcinus.orca.core.feed.profile.post.PostProvider
+import br.com.orcinus.orca.core.feed.profile.type.followable.FollowService
 import br.com.orcinus.orca.ext.coroutines.await
 import br.com.orcinus.orca.ext.coroutines.flatMapEach
 import br.com.orcinus.orca.ext.coroutines.notifier.notifierFlow
@@ -52,6 +53,7 @@ internal class ProfileDetailsViewModel
 private constructor(
   application: Application,
   private val profileProvider: ProfileProvider,
+  private val followService: FollowService,
   private val postProvider: PostProvider,
   coroutineDispatcher: CoroutineDispatcher,
   private val id: String,
@@ -75,7 +77,9 @@ private constructor(
     get() = getApplication<Application>()
 
   val detailsLoadableFlow =
-    profileFlow.map { it.toProfileDetails(coroutineScope, colors) }.loadable(coroutineScope)
+    profileFlow
+      .map { it.toProfileDetails(coroutineScope, followService, colors) }
+      .loadable(coroutineScope)
 
   @OptIn(ExperimentalCoroutinesApi::class)
   val postPreviewsLoadableFlow =
@@ -120,6 +124,7 @@ private constructor(
     fun createFactory(
       application: Application,
       profileProvider: ProfileProvider,
+      followService: FollowService,
       postProvider: PostProvider,
       id: String,
       onLinkClick: (URI) -> Unit,
@@ -130,6 +135,7 @@ private constructor(
           ProfileDetailsViewModel(
             application,
             profileProvider,
+            followService,
             postProvider,
             Dispatchers.Main.immediate,
             id,

--- a/feature/profile-details/src/main/java/br/com/orcinus/orca/feature/profiledetails/conversion/ProfileConverterFactory.kt
+++ b/feature/profile-details/src/main/java/br/com/orcinus/orca/feature/profiledetails/conversion/ProfileConverterFactory.kt
@@ -16,6 +16,8 @@
 package br.com.orcinus.orca.feature.profiledetails.conversion
 
 import br.com.orcinus.orca.core.feed.profile.Profile
+import br.com.orcinus.orca.core.feed.profile.type.followable.Follow
+import br.com.orcinus.orca.core.feed.profile.type.followable.FollowService
 import br.com.orcinus.orca.feature.profiledetails.conversion.converter.DefaultProfileConverter
 import br.com.orcinus.orca.feature.profiledetails.conversion.converter.EditableProfileConverter
 import br.com.orcinus.orca.feature.profiledetails.conversion.converter.followable.FollowableProfileConverter
@@ -28,10 +30,12 @@ internal object ProfileConverterFactory {
    *
    * @param coroutineScope [CoroutineScope] through which converted [Profile]-related suspending
    *   will be performed.
+   * @param followService [FollowService] by which the [Follow] status can be toggled.
+   * @see Follow.toggled
    */
-  fun create(coroutineScope: CoroutineScope): ProfileConverter {
+  fun create(coroutineScope: CoroutineScope, followService: FollowService): ProfileConverter {
     val defaultConverter = DefaultProfileConverter(next = null)
     val editableConverter = EditableProfileConverter(next = defaultConverter)
-    return FollowableProfileConverter(coroutineScope, next = editableConverter)
+    return FollowableProfileConverter(coroutineScope, followService, next = editableConverter)
   }
 }

--- a/feature/profile-details/src/main/java/br/com/orcinus/orca/feature/profiledetails/conversion/converter/followable/FollowableProfileConverter.kt
+++ b/feature/profile-details/src/main/java/br/com/orcinus/orca/feature/profiledetails/conversion/converter/followable/FollowableProfileConverter.kt
@@ -19,6 +19,7 @@ import br.com.orcinus.orca.autos.colors.Colors
 import br.com.orcinus.orca.composite.timeline.text.annotated.toAnnotatedString
 import br.com.orcinus.orca.core.feed.profile.Profile
 import br.com.orcinus.orca.core.feed.profile.type.followable.Follow
+import br.com.orcinus.orca.core.feed.profile.type.followable.FollowService
 import br.com.orcinus.orca.core.feed.profile.type.followable.FollowableProfile
 import br.com.orcinus.orca.feature.profiledetails.ProfileDetails
 import br.com.orcinus.orca.feature.profiledetails.conversion.ProfileConverter
@@ -30,9 +31,12 @@ import kotlinx.coroutines.launch
  *
  * @param coroutineScope [CoroutineScope] through which converted [Profile]'s [Follow] status toggle
  *   will be performed.
+ * @param followService [FollowService] by which the [Follow] status can be toggled.
+ * @see Follow.toggled
  */
 internal class FollowableProfileConverter(
   private val coroutineScope: CoroutineScope,
+  private val followService: FollowService,
   override val next: ProfileConverter?
 ) : ProfileConverter() {
   override fun onConvert(profile: Profile, colors: Colors): ProfileDetails? {
@@ -46,7 +50,7 @@ internal class FollowableProfileConverter(
         profile.uri,
         profile.follow.toStatus()
       ) {
-        coroutineScope.launch { profile.toggleFollow() }
+        coroutineScope.launch { followService.toggle(profile.id, profile.follow) }
       }
     } else {
       null

--- a/feature/profile-details/src/test/java/br/com/orcinus/orca/feature/profiledetails/ProfileDetailsFragmentTests.kt
+++ b/feature/profile-details/src/test/java/br/com/orcinus/orca/feature/profiledetails/ProfileDetailsFragmentTests.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.test.junit4.createEmptyComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import br.com.orcinus.orca.core.feed.profile.type.followable.FollowableProfile
+import br.com.orcinus.orca.core.sample.feed.profile.type.followable.SampleFollowService
 import br.com.orcinus.orca.core.sample.instance.SampleInstance
 import br.com.orcinus.orca.feature.profiledetails.navigation.BackwardsNavigationState
 import br.com.orcinus.orca.feature.profiledetails.test.UnnavigableProfileDetailsModule
@@ -40,11 +41,16 @@ internal class ProfileDetailsFragmentTests {
     SampleInstance.Builder.create(ComposableImageLoader.Provider.sample)
       .withDefaultProfiles()
       .build()
+  private val followService = SampleFollowService(instance.profileProvider)
 
   @get:Rule
   val injectorRule = InjectorTestRule {
     register<ProfileDetailsModule>(
-      UnnavigableProfileDetailsModule(instance.profileProvider, instance.postProvider)
+      UnnavigableProfileDetailsModule(
+        instance.profileProvider,
+        followService,
+        instance.postProvider
+      )
     )
   }
   @get:Rule val composeRule = createEmptyComposeRule()
@@ -53,7 +59,7 @@ internal class ProfileDetailsFragmentTests {
   fun unfollowsFollowedProfileWhenClickingActionButton() {
     val profile = instance.profileProvider.provideCurrent<FollowableProfile<*>>()
     if (!profile.follow.isFollowingType) {
-      runTest { profile.toggleFollow() }
+      runTest { followService.toggle(profile.id, profile.follow) }
     }
     launchFragmentInNavigationContainer {
         ProfileDetailsFragment(

--- a/feature/profile-details/src/test/java/br/com/orcinus/orca/feature/profiledetails/conversion/ProfileConverterFactoryTests.kt
+++ b/feature/profile-details/src/test/java/br/com/orcinus/orca/feature/profiledetails/conversion/ProfileConverterFactoryTests.kt
@@ -20,6 +20,7 @@ import assertk.assertions.isEqualTo
 import br.com.orcinus.orca.autos.colors.Colors
 import br.com.orcinus.orca.core.feed.profile.type.editable.EditableProfile
 import br.com.orcinus.orca.core.feed.profile.type.followable.FollowableProfile
+import br.com.orcinus.orca.core.sample.feed.profile.type.followable.SampleFollowService
 import br.com.orcinus.orca.core.sample.instance.SampleInstance
 import br.com.orcinus.orca.feature.profiledetails.ProfileDetails
 import br.com.orcinus.orca.feature.profiledetails.createSample
@@ -39,8 +40,12 @@ internal class ProfileConverterFactoryTests {
         .withDefaultProfiles()
         .build()
         .profileProvider
+    val followService = SampleFollowService(profileProvider)
     val defaultProfile = ProfileDetails.Default.getSampleDelegateProfile(profileProvider)
-    assertThat(ProfileConverterFactory.create(coroutineScope).convert(defaultProfile, Colors.LIGHT))
+    assertThat(
+        ProfileConverterFactory.create(coroutineScope, followService)
+          .convert(defaultProfile, Colors.LIGHT)
+      )
       .isEqualTo(ProfileDetails.Default.createSample(profileProvider, defaultProfile))
   }
 
@@ -51,9 +56,11 @@ internal class ProfileConverterFactoryTests {
         .withDefaultProfiles()
         .build()
         .profileProvider
+    val followService = SampleFollowService(profileProvider)
     val editableProfile = profileProvider.provideCurrent<EditableProfile>()
     assertThat(
-        ProfileConverterFactory.create(coroutineScope).convert(editableProfile, Colors.LIGHT)
+        ProfileConverterFactory.create(coroutineScope, followService)
+          .convert(editableProfile, Colors.LIGHT)
       )
       .isEqualTo(ProfileDetails.Editable.createSample(profileProvider))
   }
@@ -65,10 +72,11 @@ internal class ProfileConverterFactoryTests {
         .withDefaultProfiles()
         .build()
         .profileProvider
+    val followService = SampleFollowService(profileProvider)
     val followableProfile = profileProvider.provideCurrent<FollowableProfile<*>>()
     val onStatusToggle = {}
     assertThat(
-        ProfileConverterFactory.create(coroutineScope)
+        ProfileConverterFactory.create(coroutineScope, followService)
           .convert(followableProfile, Colors.LIGHT)
           .let { it as ProfileDetails.Followable }
           .copy(onStatusToggle = onStatusToggle)

--- a/feature/profile-details/src/test/java/br/com/orcinus/orca/feature/profiledetails/conversion/converter/followable/FollowableProfileConverterTests.kt
+++ b/feature/profile-details/src/test/java/br/com/orcinus/orca/feature/profiledetails/conversion/converter/followable/FollowableProfileConverterTests.kt
@@ -22,6 +22,7 @@ import br.com.orcinus.orca.autos.colors.Colors
 import br.com.orcinus.orca.core.feed.profile.Profile
 import br.com.orcinus.orca.core.feed.profile.type.editable.EditableProfile
 import br.com.orcinus.orca.core.feed.profile.type.followable.FollowableProfile
+import br.com.orcinus.orca.core.sample.feed.profile.type.followable.SampleFollowService
 import br.com.orcinus.orca.core.sample.instance.SampleInstance
 import br.com.orcinus.orca.feature.profiledetails.ProfileDetails
 import br.com.orcinus.orca.feature.profiledetails.createSample
@@ -34,15 +35,16 @@ import org.junit.Assert.assertNull
 
 internal class FollowableProfileConverterTests {
   private val coroutineScope = TestScope()
-  private val converter = FollowableProfileConverter(coroutineScope, next = null)
+  private val profileProvider =
+    SampleInstance.Builder.create(ComposableImageLoader.Provider.sample)
+      .withDefaultProfiles()
+      .build()
+      .profileProvider
+  private val followService = SampleFollowService(profileProvider)
+  private val converter = FollowableProfileConverter(coroutineScope, followService, next = null)
 
   @Test
   fun convertsFollowableProfile() {
-    val profileProvider =
-      SampleInstance.Builder.create(ComposableImageLoader.Provider.sample)
-        .withDefaultProfiles()
-        .build()
-        .profileProvider
     val onStatusToggle = {}
     assertThat(
         converter


### PR DESCRIPTION
Removes interaction between two users from the profile entity and moves it to a service, [`FollowService`](https://github.com/orcinusbr/orca-android/blob/7b040e56c755ab397c26ed1f11fe86c4fc423620/core/src/main/java/br/com/orcinus/orca/core/feed/profile/type/followable/FollowService.kt).