### PR TITLE
Fix inconsistent application of deprecated scaffold's modifier

### DIFF
--- a/platform/autos/src/main/java/br/com/orcinus/orca/platform/autos/kit/scaffold/Scaffold.kt
+++ b/platform/autos/src/main/java/br/com/orcinus/orca/platform/autos/kit/scaffold/Scaffold.kt
@@ -102,7 +102,7 @@ fun Scaffold(
     snackbarPresenter,
     bottom
   ) {
-    remember(::ScaffoldScope).content().value()
+    remember(::ScaffoldScope).content().Value()
   }
 }
 

--- a/platform/autos/src/main/java/br/com/orcinus/orca/platform/autos/kit/scaffold/scope/Content.kt
+++ b/platform/autos/src/main/java/br/com/orcinus/orca/platform/autos/kit/scaffold/scope/Content.kt
@@ -30,7 +30,7 @@ abstract class Content internal constructor() {
   protected abstract val modifier: Modifier
 
   /** [Composable] to be shown. */
-  internal abstract val value: @Composable () -> Unit
+  protected abstract val value: @Composable () -> Unit
 
   /** [Content] that is displayed all by itself. */
   internal class Expanded(
@@ -43,4 +43,10 @@ abstract class Content internal constructor() {
     override val modifier: Modifier,
     override val value: @Composable () -> Unit
   ) : Content()
+
+  /** [value] with the [modifier] applied to it. */
+  @Composable
+  internal fun Value() {
+    Box(modifier) { value() }
+  }
 }

--- a/platform/autos/src/test/java/br/com/orcinus/orca/platform/autos/kit/scaffold/scope/ContentTests.kt
+++ b/platform/autos/src/test/java/br/com/orcinus/orca/platform/autos/kit/scaffold/scope/ContentTests.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2024 Orcinus
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package br.com.orcinus.orca.platform.autos.kit.scaffold.scope
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onChild
+import androidx.compose.ui.test.onRoot
+import kotlin.test.Test
+import org.junit.Rule
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+internal class ContentTests {
+  @get:Rule val composeRule = createComposeRule()
+
+  @Test
+  fun expandedValueIsModified() {
+    composeRule
+      .apply { setContent { Content.Expanded(Modifier.testTag("content")) {}.Value() } }
+      .onRoot()
+      .onChild()
+      .assert(hasTestTag("content"))
+  }
+
+  @Test
+  fun navigableValueIsModified() {
+    composeRule
+      .apply { setContent { Content.Expanded(Modifier.testTag("content")) {}.Value() } }
+      .onRoot()
+      .onChild()
+      .assert(hasTestTag("content"))
+  }
+}


### PR DESCRIPTION
The modifier wasn't being applied to its content.

<img src="https://github.com/user-attachments/assets/f96b8953-cc37-459e-afad-593d6902af40" width="256" />
<img src="https://github.com/user-attachments/assets/19441b3e-c50e-4bc8-af13-8c6fbff23f1a" width="256" />
