### PR TITLE
Upgrade target SDK to 35

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright © 2023–2024 Orcinus
+  ~ Copyright © 2023–2025 Orcinus
   ~
   ~ This program is free software: you can redistribute it and/or modify it under the terms of the
   ~ GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -21,7 +21,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/icon_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.Autos">
+        android:theme="@style/Theme.Autos.Default">
         <activity
             android:name=".activity.MainOrcaActivity"
             android:exported="true"

--- a/composite/timeline/src/main/java/br/com/orcinus/orca/composite/timeline/search/Searchable.kt
+++ b/composite/timeline/src/main/java/br/com/orcinus/orca/composite/timeline/search/Searchable.kt
@@ -17,6 +17,7 @@ package br.com.orcinus.orca.composite.timeline.search
 
 import androidx.annotation.VisibleForTesting
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
@@ -27,6 +28,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.DpOffset
+import br.com.orcinus.orca.composite.timeline.search.field.Unpadded
 import br.com.orcinus.orca.platform.autos.iconography.asImageVector
 import br.com.orcinus.orca.platform.autos.kit.action.button.icon.HoverableIconButton
 import br.com.orcinus.orca.platform.autos.kit.input.text.SearchTextField
@@ -43,18 +46,29 @@ import br.com.orcinus.orca.platform.autos.theme.MultiThemePreview
  * @param fillerColor [Color] by which the container that fills the space previously occupied by the
  *   content replaced by the [SearchTextField] is colored.
  * @param modifier [Modifier] applied to the underlying [Box].
+ * @param searchTextFieldOffset Amount in both axes by which the [SearchTextField] is offset.
+ * @param searchTextFieldPadding Space to surround the [SearchTextField] with.
  * @param content Content to be shown.
  */
 @Composable
 fun Searchable(
   fillerColor: Color,
   modifier: Modifier = Modifier,
+  searchTextFieldOffset: DpOffset = DpOffset.Zero,
+  searchTextFieldPadding: PaddingValues = Unpadded,
   content: @Composable SearchableScope.() -> Unit
 ) {
   val isReplaceableComposedState = remember { mutableStateOf(false) }
 
   Box(modifier.testTag(ContentTag)) {
-    remember(content, fillerColor) { SearchableScope(isReplaceableComposedState, fillerColor) }
+    remember(content, fillerColor) {
+        SearchableScope(
+          searchTextFieldOffset,
+          searchTextFieldPadding,
+          isReplaceableComposedState,
+          fillerColor
+        )
+      }
       .content()
   }
 }
@@ -65,14 +79,25 @@ fun Searchable(
  * This overload is stateless by default and is intended for previewing and testing purposes only.
  *
  * @param modifier [Modifier] applied to the underlying [Box].
+ * @param searchTextFieldOffset Amount in both axes by which the [SearchTextField] is offset.
+ * @param searchTextFieldPadding Space to surround the [SearchTextField] with.
  * @param content Content to be shown.
  */
 @Composable
+@VisibleForTesting
 internal fun Searchable(
   modifier: Modifier = Modifier,
+  searchTextFieldOffset: DpOffset = DpOffset.Zero,
+  searchTextFieldPadding: PaddingValues = Unpadded,
   content: @Composable SearchableScope.() -> Unit
 ) {
-  Searchable(fillerColor = Color.Transparent, modifier, content)
+  Searchable(
+    fillerColor = Color.Transparent,
+    modifier,
+    searchTextFieldOffset,
+    searchTextFieldPadding,
+    content
+  )
 }
 
 /** Preview of a [Searchable]. */

--- a/composite/timeline/src/main/java/br/com/orcinus/orca/composite/timeline/search/SearchableScope.kt
+++ b/composite/timeline/src/main/java/br/com/orcinus/orca/composite/timeline/search/SearchableScope.kt
@@ -22,6 +22,7 @@ import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.SizeTransform
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.FastOutLinearInEasing
+import androidx.compose.animation.core.FiniteAnimationSpec
 import androidx.compose.animation.core.VectorConverter
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.keyframes
@@ -34,9 +35,7 @@ import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.statusBars
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.MutableState
@@ -47,14 +46,12 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.composed
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.geometry.isUnspecified
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.layout
 import androidx.compose.ui.layout.onSizeChanged
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
@@ -65,7 +62,6 @@ import br.com.orcinus.orca.composite.timeline.search.field.SearchTextFieldPopup
 import br.com.orcinus.orca.core.feed.profile.Profile
 import br.com.orcinus.orca.core.feed.profile.search.ProfileSearchResult
 import br.com.orcinus.orca.platform.autos.kit.input.text.SearchTextField
-import br.com.orcinus.orca.platform.autos.kit.input.text.SearchTextFieldDefaults
 import com.jeanbarrossilva.loadable.list.ListLoadable
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -74,6 +70,8 @@ import kotlinx.coroutines.launch
 /**
  * Scope of a [Searchable] in which the [SearchTextField] can be either shown or dismissed.
  *
+ * @param searchTextFieldOffset Amount in both axes by which the [SearchTextField] is offset.
+ * @param searchTextFieldPadding Space to surround the [SearchTextField] with.
  * @property isReplaceableComposedState [MutableState] whose [Boolean] determines whether the
  *   content to be replaced by the [SearchTextField] is currently composed.
  * @property fillerColor [Color] by which the container that fills the space previously occupied by
@@ -81,6 +79,8 @@ import kotlinx.coroutines.launch
  */
 class SearchableScope
 internal constructor(
+  private val searchTextFieldOffset: DpOffset,
+  private val searchTextFieldPadding: PaddingValues,
   private val isReplaceableComposedState: MutableState<Boolean>,
   private val fillerColor: Color
 ) {
@@ -130,8 +130,20 @@ internal constructor(
       )
 
   /**
+   * Creates a [FiniteAnimationSpec] with which the content to be replaced is animated in and out
+   * based on whether search is currently being performed — that is, the [SearchTextField] is
+   * displayed. Should also be applied to any other animation derived from such transition.
+   *
+   * @param T Value to be animated.
+   * @see Replaceable
+   */
+  fun <T> replacementAnimationSpec() = internalReplacementAnimationSpec<T>()
+
+  /**
    * Displays either the [content] or the [SearchTextField] that presents results for the query when
-   * it is requested to be shown.
+   * it is requested to be shown. Such replacement by one composable or the other transitions with
+   * an animation specified by the [internalReplacementAnimationSpec], which should be applied to
+   * all animations derived from this change.
    *
    * @param query Content to be looked up.
    * @param onQueryChange Lambda invoked whenever the [query] changes.
@@ -149,7 +161,6 @@ internal constructor(
     modifier: Modifier = Modifier,
     content: @Composable () -> Unit
   ) {
-    val density = LocalDensity.current
     val coroutineScope = rememberCoroutineScope()
 
     ReplaceableCompositionReporterEffect()
@@ -165,11 +176,8 @@ internal constructor(
             onDidDismiss = ::dismiss,
             modifier.resultSearchTextFieldHeightReporter(coroutineScope).fillMaxWidth(),
             Alignment.TopCenter,
-            DpOffset(
-              x = 0.dp,
-              y = with(density) { WindowInsets.statusBars.height } + SearchTextFieldDefaults.spacing
-            ),
-            PaddingValues(horizontal = SearchTextFieldDefaults.spacing)
+            searchTextFieldOffset,
+            searchTextFieldPadding
           )
         } else {
           ResultSearchTextFieldLayoutHeightResetEffect(coroutineScope)
@@ -186,7 +194,9 @@ internal constructor(
 
   /**
    * Displays either the [content] or the [SearchTextField] that presents results for the query when
-   * it is requested to be shown.
+   * it is requested to be shown. Such replacement by one composable or the other transitions with
+   * an animation specified by the [internalReplacementAnimationSpec], which should be applied to
+   * all animations derived from this change.
    *
    * This overload is stateless by default and is intended for previewing and testing purposes only.
    *
@@ -263,14 +273,23 @@ internal constructor(
       modifier,
       transitionSpec = {
         slideInVertically(
-          tween(
-            AccordionBaselineAnimationDurationInMilliseconds,
-            delayMillis = if (targetState) 16 else 0
+          internalReplacementAnimationSpec(
+            delayInMilliseconds =
+              if (targetState) {
+                16
+              } else {
+                0
+              }
           )
         ) {
           if (targetState) it / 2 else -it / 4
-        } + fadeIn(tween(AccordionBaselineAnimationDurationInMilliseconds)) togetherWith
-          slideOutVertically() + fadeOut(tween(durationMillis = 32)) using
+        } + fadeIn(replacementAnimationSpec()) togetherWith
+          slideOutVertically(replacementAnimationSpec()) +
+            fadeOut(
+              internalReplacementAnimationSpec(
+                durationInMilliseconds = AccordionBaselineAnimationDurationInMilliseconds / 2
+              )
+            ) using
           SizeTransform(clip = false) { _, targetSize ->
             keyframes {
               IntSize(targetSize.width, targetSize.height) at
@@ -286,6 +305,22 @@ internal constructor(
   }
 
   /**
+   * Creates a [FiniteAnimationSpec] with which the content to be replaced by a [SearchTextField] is
+   * animated in and out. Should also be applied to any other animation derived from such
+   * transition; to do so, call the public variant of this method without parameters.
+   *
+   * @param T Value to be animated.
+   * @param durationInMilliseconds Duration of the animation in milliseconds.
+   * @param delayInMilliseconds Time in milliseconds to be awaited before the animation starts.
+   * @see Replaceable
+   * @see replacementAnimationSpec
+   */
+  private fun <T> internalReplacementAnimationSpec(
+    durationInMilliseconds: Int = AccordionBaselineAnimationDurationInMilliseconds,
+    delayInMilliseconds: Int = 0
+  ): FiniteAnimationSpec<T> = tween<T>(durationInMilliseconds, delayInMilliseconds)
+
+  /**
    * Considers the [Composable] to which this [Modifier] is applied a [SearchTextField] and assigns
    * its height to [searchTextFieldHeight] at each change to it so that the overlaid content can be
    * properly padded/spaced.
@@ -297,16 +332,11 @@ internal constructor(
     coroutineScope: CoroutineScope
   ): Modifier {
     return if (searchTextFieldHeight == 0.dp) {
-      composed {
-        val defaultSpacing = SearchTextFieldDefaults.spacing
-        layout { measurable, constraints ->
-          val placeable = measurable.measure(constraints)
-          val height = placeable.height
-          coroutineScope.launch {
-            searchTextFieldHeightAnimatable.animateTo(height.toDp() + defaultSpacing * 2)
-          }
-          layout(placeable.width, height) { placeable.place(x = 0, y = 0) }
-        }
+      layout { measurable, constraints ->
+        val placeable = measurable.measure(constraints)
+        val height = placeable.height
+        coroutineScope.launch { searchTextFieldHeightAnimatable.animateTo(height.toDp()) }
+        layout(placeable.width, height) { placeable.place(x = 0, y = 0) }
       }
     } else {
       this
@@ -341,13 +371,7 @@ internal constructor(
         visible = isSearching,
         Modifier.testTag(FillerTag),
         EnterTransition.None,
-        exit =
-          fadeOut(
-            tween(
-              durationMillis = AccordionBaselineAnimationDurationInMilliseconds,
-              delayMillis = AccordionBaselineAnimationDurationInMilliseconds
-            )
-          ),
+        exit = fadeOut(replacementAnimationSpec()),
         label = "Filler"
       ) {
         Canvas(Modifier) { drawRect(fillerColor, Offset.Zero, fillerPeakSize) }
@@ -385,7 +409,7 @@ internal constructor(
      * for.
      */
     @Suppress("ConstPropertyName")
-    private const val AccordionBaselineAnimationDurationInMilliseconds = 128
+    private const val AccordionBaselineAnimationDurationInMilliseconds = 64
 
     /** Tag that identifies a [Searchable]'s [Filler] for testing purposes. */
     @Suppress("ConstPropertyName") internal const val FillerTag = "searchable-filler"

--- a/composite/timeline/src/main/java/br/com/orcinus/orca/composite/timeline/search/WindowInsets.kt
+++ b/composite/timeline/src/main/java/br/com/orcinus/orca/composite/timeline/search/WindowInsets.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Orcinus
+ * Copyright © 2025 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -16,15 +16,10 @@
 package br.com.orcinus.orca.composite.timeline.search
 
 import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.ui.unit.Density
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 
-/** Calculates the height of these [WindowInsets] in [Dp]s. */
-context(Density)
-
-internal inline val WindowInsets.height: Dp
-  get() {
-    val top = getTop(this@Density)
-    val bottom = getBottom(this@Density)
-    return (maxOf(top, bottom) - minOf(top, bottom)).toDp()
-  }
+/** Obtains the top space of these [WindowInsets] in [Dp]s. */
+inline val WindowInsets.top
+  @Composable get() = with(LocalDensity.current) { getTop(this).toDp() }

--- a/composite/timeline/src/test/java/br/com/orcinus/orca/composite/timeline/search/SearchableTests.kt
+++ b/composite/timeline/src/test/java/br/com/orcinus/orca/composite/timeline/search/SearchableTests.kt
@@ -40,7 +40,6 @@ import br.com.orcinus.orca.composite.timeline.test.search.field.onResultCard
 import br.com.orcinus.orca.core.feed.profile.account.Account
 import br.com.orcinus.orca.core.feed.profile.search.ProfileSearchResult
 import br.com.orcinus.orca.core.sample.feed.profile.account.sample
-import br.com.orcinus.orca.platform.autos.kit.input.text.SearchTextFieldDefaults
 import br.com.orcinus.orca.platform.autos.test.kit.input.text.onSearchTextField
 import br.com.orcinus.orca.platform.autos.theme.AutosTheme
 import br.com.orcinus.orca.platform.core.sample
@@ -439,16 +438,12 @@ internal class SearchableTests {
           val textStyle = LocalTextStyle.current
           val fontSizeInDp =
             remember(density, textStyle) { with(density) { textStyle.fontSize.toDp() } }
-          val searchTextFieldSpacing = SearchTextFieldDefaults.spacing
 
           Replaceable()
 
           DisposableEffect(Unit) {
             show()
-            onDispose {
-              assertThat(searchTextFieldLayoutHeight)
-                .isGreaterThanOrEqualTo(fontSizeInDp + searchTextFieldSpacing * 4)
-            }
+            onDispose { assertThat(searchTextFieldHeight).isGreaterThanOrEqualTo(fontSizeInDp) }
           }
         }
       }

--- a/feature/feed/src/main/java/br/com/orcinus/orca/feature/feed/Feed.kt
+++ b/feature/feed/src/main/java/br/com/orcinus/orca/feature/feed/Feed.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023–2024 Orcinus
+ * Copyright © 2023–2025 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -169,8 +169,8 @@ private fun Feed(
     val contentBlurRadius by contentBlurRadiusAsState
     val timelineTopContentPadding by
       animateDpAsState(
-        (WindowInsets.systemBars.top + searchTextFieldHeight).`if`(isSearching) {
-          this + SearchTextFieldDefaults.spacing * 2
+        searchTextFieldHeight.`if`(isSearching) {
+          this + WindowInsets.systemBars.top + SearchTextFieldDefaults.spacing * 2
         },
         replacementAnimationSpec(),
         label = "Timeline top content padding"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 #
-# Copyright © 2023–2024 Orcinus
+# Copyright © 2023–2025 Orcinus
 #
 # This program is free software: you can redistribute it and/or modify it under the terms of the
 # GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -80,7 +80,7 @@ mockito = { group = "org.mockito", name = "mockito-core", version = "5.12.0" }
 mockk = { group = "io.mockk", name = "mockk-android", version = "1.13.11" }
 openTest4J = { group = "org.opentest4j", name = "opentest4j", version = "1.3.0" }
 paginate = { group = "com.chrynan.paginate", name = "paginate-core", version = "0.3.0" }
-robolectric = { group = "org.robolectric", name = "robolectric", version = "4.13" }
+robolectric = { group = "org.robolectric", name = "robolectric", version = "4.14.1" }
 slf4j = { group = "org.slf4j", name = "slf4j-api", version = "2.0.7" }
 spotless = { group = "com.diffplug.spotless", name = "spotless-plugin-gradle", version.ref = "spotless" }
 time4j = { group = "net.time4j", name = "time4j-android", version = "4.8-2021a" }
@@ -120,7 +120,7 @@ android-ndk = "28.0.12674087"
 android-plugin = "8.7.3"
 android-room = "2.6.1"
 android-sdk-min = "28"
-android-sdk-target = "34"
+android-sdk-target = "35"
 android-test-espresso = "3.5.0"
 assertk = "0.28.1"
 java = "17"

--- a/platform/autos/src/main/java/br/com/orcinus/orca/platform/autos/kit/input/text/composition/CompositionTextField.kt
+++ b/platform/autos/src/main/java/br/com/orcinus/orca/platform/autos/kit/input/text/composition/CompositionTextField.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Orcinus
+ * Copyright © 2024–2025 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -69,7 +69,7 @@ constructor(
     setPadding(getSpacing(context))
     compoundDrawablePadding = getSpacing(context)
     gravity = Gravity.TOP
-    setTextAppearance(context, R.style.Theme_Orca_Typography_BodyMedium)
+    setTextAppearance(context, R.style.Theme_Autos_Default_Typography_BodyMedium)
   }
 
   override fun onDraw(canvas: Canvas) {

--- a/platform/autos/src/main/res/values-v35/themes.xml
+++ b/platform/autos/src/main/res/values-v35/themes.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright © 2025 Orcinus
+  ~
+  ~ This program is free software: you can redistribute it and/or modify it under the terms of the
+  ~ GNU General Public License as published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+  ~ without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+  ~ the GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License along with this program. If
+  ~ not, see https://www.gnu.org/licenses.
+  -->
+
+<resources>
+    <style
+        name="Theme.Autos"
+        parent="Theme.Autos.Default">
+        <item name="android:navigationBarColor" />
+        <item name="android:statusBarColor" />
+    </style>
+</resources>

--- a/platform/autos/src/main/res/values/shapes.xml
+++ b/platform/autos/src/main/res/values/shapes.xml
@@ -1,6 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
-  ~ Copyright © 2023–2024 Orcinus
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright © 2023–2025 Orcinus
   ~
   ~ This program is free software: you can redistribute it and/or modify it under the terms of the
   ~ GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -21,19 +20,19 @@
     <fraction name="smallShapeCornerSize">100%</fraction>
 
     <style
-        name="Theme.Orca.Shapes.Large"
+        name="Theme.Autos.Default.Shapes.Large"
         parent="ShapeAppearance.Material3.Corner.Small">
         <item name="cornerSize">@dimen/largeShapeCornerSize</item>
     </style>
 
     <style
-        name="Theme.Orca.Shapes.Medium"
+        name="Theme.Autos.Default.Shapes.Medium"
         parent="ShapeAppearance.Material3.Corner.Medium">
         <item name="cornerSize">@dimen/mediumShapeCornerSize</item>
     </style>
 
     <style
-        name="Theme.Orca.Shapes.Small"
+        name="Theme.Autos.Default.Shapes.Small"
         parent="ShapeAppearance.Material3.Corner.Large">
         <item name="cornerSize">@fraction/smallShapeCornerSize</item>
     </style>

--- a/platform/autos/src/main/res/values/themes.xml
+++ b/platform/autos/src/main/res/values/themes.xml
@@ -1,5 +1,5 @@
-<!--
-  ~ Copyright © 2023-2024 Orcinus
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright © 2023–2025 Orcinus
   ~
   ~ This program is free software: you can redistribute it and/or modify it under the terms of the
   ~ GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -32,10 +32,11 @@
     <color name="surfaceContent">@color/secondary</color>
     <color name="tertiary">#AFAFAF</color>
 
-    <style name="Theme.Autos" parent="Theme.Material3.DayNight.NoActionBar">
+    <style
+        name="Theme.Autos.Default"
+        parent="Theme.Material3.DayNight.NoActionBar">
         <item name="android:colorBackground">@color/backgroundContainer</item>
         <item name="android:fontFamily">@font/rubik</item>
-        <item name="android:navigationBarColor">@android:color/transparent</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="android:textColorHint">@color/tertiary</item>
         <item name="android:textColorLink">@color/link</item>
@@ -59,22 +60,26 @@
         <item name="colorSurface">@color/surfaceContainer</item>
         <item name="colorSurfaceVariant">@color/placeholder</item>
         <item name="shapeCornerFamily">rounded</item>
-        <item name="shapeAppearanceCornerExtraLarge">@style/Theme.Orca.Shapes.Large</item>
-        <item name="shapeAppearanceCornerExtraSmall">@style/Theme.Orca.Shapes.Small</item>
-        <item name="shapeAppearanceCornerLarge">@style/Theme.Orca.Shapes.Large</item>
+        <item name="shapeAppearanceCornerExtraLarge">@style/Theme.Autos.Default.Shapes.Large</item>
+        <item name="shapeAppearanceCornerExtraSmall">@style/Theme.Autos.Default.Shapes.Small</item>
+        <item name="shapeAppearanceCornerLarge">@style/Theme.Autos.Default.Shapes.Large</item>
         <item name="shapeAppearanceCornerMedium">
             @style/ShapeAppearance.Material3.Corner.Medium
         </item>
-        <item name="shapeAppearanceCornerSmall">@style/Theme.Orca.Shapes.Small</item>
-        <item name="textAppearanceBodyLarge">@style/Theme.Orca.Typography.BodyLarge</item>
-        <item name="textAppearanceBodyMedium">@style/Theme.Orca.Typography.BodyMedium</item>
-        <item name="textAppearanceBodySmall">@style/Theme.Orca.Typography.BodySmall</item>
-        <item name="textAppearanceHeadlineLarge">@style/Theme.Orca.Typography.HeadlineLarge</item>
-        <item name="textAppearanceHeadlineMedium">@style/Theme.Orca.Typography.HeadlineMedium</item>
-        <item name="textAppearanceHeadlineSmall">@style/Theme.Orca.Typography.HeadlineSmall</item>
-        <item name="textAppearanceLabelLarge">@style/Theme.Orca.Typography.LabelLarge</item>
-        <item name="textAppearanceLabelMedium">@style/Theme.Orca.Typography.LabelMedium</item>
-        <item name="textAppearanceTitleLarge">@style/Theme.Orca.Typography.TitleLarge</item>
-        <item name="textAppearanceTitleSmall">@style/Theme.Orca.Typography.TitleSmall</item>
+        <item name="shapeAppearanceCornerSmall">@style/Theme.Autos.Default.Shapes.Small</item>
+        <item name="textAppearanceBodyLarge">@style/Theme.Autos.Default.Typography.BodyLarge</item>
+        <item name="textAppearanceBodyMedium">@style/Theme.Autos.Default.Typography.BodyMedium</item>
+        <item name="textAppearanceBodySmall">@style/Theme.Autos.Default.Typography.BodySmall</item>
+        <item name="textAppearanceHeadlineLarge">@style/Theme.Autos.Default.Typography.HeadlineLarge</item>
+        <item name="textAppearanceHeadlineMedium">@style/Theme.Autos.Default.Typography.HeadlineMedium</item>
+        <item name="textAppearanceHeadlineSmall">@style/Theme.Autos.Default.Typography.HeadlineSmall</item>
+        <item name="textAppearanceLabelLarge">@style/Theme.Autos.Default.Typography.LabelLarge</item>
+        <item name="textAppearanceLabelMedium">@style/Theme.Autos.Default.Typography.LabelMedium</item>
+        <item name="textAppearanceTitleLarge">@style/Theme.Autos.Default.Typography.TitleLarge</item>
+        <item name="textAppearanceTitleSmall">@style/Theme.Autos.Default.Typography.TitleSmall</item>
     </style>
+
+    <style
+        name="Theme.Autos"
+        parent="Theme.Autos.Default" />
 </resources>

--- a/platform/autos/src/main/res/values/typography.xml
+++ b/platform/autos/src/main/res/values/typography.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright © 2023-2024 Orcinus
+  ~ Copyright © 2023–2025 Orcinus
   ~
   ~ This program is free software: you can redistribute it and/or modify it under the terms of the
   ~ GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -24,14 +24,14 @@
     <integer name="font_weight_black">900</integer>
 
     <style
-        name="Theme.Orca.Typography.HeadlineLarge"
+        name="Theme.Autos.Default.Typography.HeadlineLarge"
         parent="TextAppearance.Material3.HeadlineLarge">
         <item name="android:textColor">@color/backgroundContent</item>
         <item name="android:textFontWeight">@integer/font_weight_black</item>
     </style>
 
     <style
-        name="Theme.Orca.Typography.HeadlineMedium"
+        name="Theme.Autos.Default.Typography.HeadlineMedium"
         parent="TextAppearance.Material3.HeadlineMedium">
         <item name="android:textColor">@color/secondary</item>
         <item name="android:textFontWeight">@integer/font_weight_medium</item>
@@ -39,7 +39,7 @@
     </style>
 
     <style
-        name="Theme.Orca.Typography.HeadlineSmall"
+        name="Theme.Autos.Default.Typography.HeadlineSmall"
         parent="TextAppearance.Material3.HeadlineSmall">
         <item name="android:textColor">@color/secondary</item>
         <item name="android:textSize">18sp</item>
@@ -47,14 +47,14 @@
     </style>
 
     <style
-        name="Theme.Orca.Typography.TitleLarge"
+        name="Theme.Autos.Default.Typography.TitleLarge"
         parent="TextAppearance.Material3.TitleLarge">
         <item name="android:textSize">16sp</item>
         <item name="android:textFontWeight">@integer/font_weight_extra_bold</item>
     </style>
 
     <style
-        name="Theme.Orca.Typography.TitleSmall"
+        name="Theme.Autos.Default.Typography.TitleSmall"
         parent="TextAppearance.Material3.TitleSmall">
         <item name="android:textColor">@color/secondary</item>
         <item name="android:textSize">16sp</item>
@@ -62,32 +62,32 @@
     </style>
 
     <style
-        name="Theme.Orca.Typography.BodyLarge"
+        name="Theme.Autos.Default.Typography.BodyLarge"
         parent="TextAppearance.Material3.BodyLarge">
         <item name="android:textFontWeight">@integer/font_weight_bold</item>
     </style>
 
     <style
-        name="Theme.Orca.Typography.BodyMedium"
+        name="Theme.Autos.Default.Typography.BodyMedium"
         parent="TextAppearance.Material3.BodyMedium">
         <item name="android:textSize">14sp</item>
     </style>
 
     <style
-        name="Theme.Orca.Typography.BodySmall"
+        name="Theme.Autos.Default.Typography.BodySmall"
         parent="TextAppearance.Material3.BodySmall">
         <item name="android:textColor">@color/secondary</item>
         <item name="android:textFontWeight">@integer/font_weight_medium</item>
     </style>
 
     <style
-        name="Theme.Orca.Typography.LabelLarge"
+        name="Theme.Autos.Default.Typography.LabelLarge"
         parent="TextAppearance.Material3.LabelLarge">
         <item name="android:textFontWeight">@integer/font_weight_bold</item>
     </style>
 
     <style
-        name="Theme.Orca.Typography.LabelMedium"
+        name="Theme.Autos.Default.Typography.LabelMedium"
         parent="TextAppearance.Material3.LabelMedium">
         <item name="android:textSize">14sp</item>
     </style>


### PR DESCRIPTION
Upgrades the Android SDK targeted by Orca from 34 (UpsideDownCake) to 35 (VanillaIceCream), which introduces some changes to the system bars — more specifically status and navigation ones. As of such API level, requesting to color them is a no-op: calling [`Window.setStatusBarColor(Int)`](https://developer.android.com/reference/android/view/Window#setStatusBarColor(int)) or [`Window.setNavigationBarColor(Int)`](https://developer.android.com/reference/android/view/Window#setNavigationBarColor(int)) does nothing.

This affects the [`SearchTextFieldPopup`](https://github.com/orcinusbr/orca-android/blob/1c41b7f887dc83cc5b8acc99cc3bf61d4445e78f/composite/timeline/src/main/java/br/com/orcinus/orca/composite/timeline/search/field/SearchTextFieldPopup.kt#L782), given that the [`Feed`](https://github.com/orcinusbr/orca-android/blob/1c41b7f887dc83cc5b8acc99cc3bf61d4445e78f/feature/feed/src/main/java/br/com/orcinus/orca/feature/feed/Feed.kt#L145) by which it is shown was padded based on the status bars, preventing the popup's scrim from encompassing the entire viewport and forcing it to change the alpha of the status bars' color instead to produce a fullscreen-like look. Now that edge-to-edge is enforced by the system and coloring these bars through the aforementioned methods is not possible, such padding has been removed from the [`Feed`](https://github.com/orcinusbr/orca-android/blob/1c41b7f887dc83cc5b8acc99cc3bf61d4445e78f/feature/feed/src/main/java/br/com/orcinus/orca/feature/feed/Feed.kt#L145) (as have been the calls to those methods).

[`Theme.Autos`](https://github.com/orcinusbr/orca-android/blob/1c41b7f887dc83cc5b8acc99cc3bf61d4445e78f/platform/autos/src/main/res/values/themes.xml#L35) has also been slightly modified for this specific OS version: given that these bars' colors cannot be set from now on, their style specs have been undone.