### PR TITLE
Remove filler from popup search text field

### DIFF
--- a/composite/timeline/src/main/java/br/com/orcinus/orca/composite/timeline/search/Searchable.kt
+++ b/composite/timeline/src/main/java/br/com/orcinus/orca/composite/timeline/search/Searchable.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Orcinus
+ * Copyright © 2024–2025 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -25,7 +25,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.DpOffset
@@ -43,8 +42,6 @@ import br.com.orcinus.orca.platform.autos.theme.MultiThemePreview
 /**
  * Layout that can replace a slot by a [SearchTextField].
  *
- * @param fillerColor [Color] by which the container that fills the space previously occupied by the
- *   content replaced by the [SearchTextField] is colored.
  * @param modifier [Modifier] applied to the underlying [Box].
  * @param searchTextFieldOffset Amount in both axes by which the [SearchTextField] is offset.
  * @param searchTextFieldPadding Space to surround the [SearchTextField] with.
@@ -52,7 +49,6 @@ import br.com.orcinus.orca.platform.autos.theme.MultiThemePreview
  */
 @Composable
 fun Searchable(
-  fillerColor: Color,
   modifier: Modifier = Modifier,
   searchTextFieldOffset: DpOffset = DpOffset.Zero,
   searchTextFieldPadding: PaddingValues = Unpadded,
@@ -61,43 +57,11 @@ fun Searchable(
   val isReplaceableComposedState = remember { mutableStateOf(false) }
 
   Box(modifier.testTag(ContentTag)) {
-    remember(content, fillerColor) {
-        SearchableScope(
-          searchTextFieldOffset,
-          searchTextFieldPadding,
-          isReplaceableComposedState,
-          fillerColor
-        )
+    remember(content) {
+        SearchableScope(searchTextFieldOffset, searchTextFieldPadding, isReplaceableComposedState)
       }
       .content()
   }
-}
-
-/**
- * Layout that can replace a slot by a [SearchTextField].
- *
- * This overload is stateless by default and is intended for previewing and testing purposes only.
- *
- * @param modifier [Modifier] applied to the underlying [Box].
- * @param searchTextFieldOffset Amount in both axes by which the [SearchTextField] is offset.
- * @param searchTextFieldPadding Space to surround the [SearchTextField] with.
- * @param content Content to be shown.
- */
-@Composable
-@VisibleForTesting
-internal fun Searchable(
-  modifier: Modifier = Modifier,
-  searchTextFieldOffset: DpOffset = DpOffset.Zero,
-  searchTextFieldPadding: PaddingValues = Unpadded,
-  content: @Composable SearchableScope.() -> Unit
-) {
-  Searchable(
-    fillerColor = Color.Transparent,
-    modifier,
-    searchTextFieldOffset,
-    searchTextFieldPadding,
-    content
-  )
 }
 
 /** Preview of a [Searchable]. */

--- a/composite/timeline/src/test/java/br/com/orcinus/orca/composite/timeline/search/SearchableTests.kt
+++ b/composite/timeline/src/test/java/br/com/orcinus/orca/composite/timeline/search/SearchableTests.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Orcinus
+ * Copyright © 2024–2025 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -242,49 +242,6 @@ internal class SearchableTests {
         }
       }
     }
-  }
-
-  @Test
-  fun showsFillerWhenSearchTextFieldIsShown() {
-    composeRule
-      .apply {
-        setContent {
-          AutosTheme {
-            Searchable {
-              Replaceable()
-
-              DisposableEffect(Unit) {
-                show()
-                onDispose {}
-              }
-            }
-          }
-        }
-      }
-      .onFiller()
-      .assertExists()
-  }
-
-  @Test
-  fun removesFillerWhenSearchTextFieldIsDismissed() {
-    composeRule
-      .apply {
-        setContent {
-          AutosTheme {
-            Searchable {
-              Replaceable()
-
-              DisposableEffect(Unit) {
-                show()
-                dismiss()
-                onDispose {}
-              }
-            }
-          }
-        }
-      }
-      .onFiller()
-      .assertDoesNotExist()
   }
 
   @Test

--- a/composite/timeline/src/test/java/br/com/orcinus/orca/composite/timeline/search/SemanticsNodeInteractionsProvider.extensions.kt
+++ b/composite/timeline/src/test/java/br/com/orcinus/orca/composite/timeline/search/SemanticsNodeInteractionsProvider.extensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Orcinus
+ * Copyright © 2024–2025 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -22,9 +22,4 @@ import androidx.compose.ui.test.onNodeWithTag
 /** [SemanticsNodeInteraction] of a [Searchable]'s content. */
 internal fun SemanticsNodeInteractionsProvider.onContent(): SemanticsNodeInteraction {
   return onNodeWithTag(ContentTag)
-}
-
-/** [SemanticsNodeInteraction] of a [Searchable]'s [SearchableScope.Filler]. */
-internal fun SemanticsNodeInteractionsProvider.onFiller(): SemanticsNodeInteraction {
-  return onNodeWithTag(SearchableScope.FillerTag)
 }

--- a/composite/timeline/src/test/java/br/com/orcinus/orca/composite/timeline/search/SemanticsNodeInteractionsProviderExtensionsTests.kt
+++ b/composite/timeline/src/test/java/br/com/orcinus/orca/composite/timeline/search/SemanticsNodeInteractionsProviderExtensionsTests.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Orcinus
+ * Copyright © 2024–2025 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -16,7 +16,6 @@
 package br.com.orcinus.orca.composite.timeline.search
 
 import androidx.compose.material3.Text
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import br.com.orcinus.orca.platform.autos.theme.AutosTheme
@@ -35,26 +34,5 @@ internal class SemanticsNodeInteractionsProviderExtensionsTests {
       .apply { setContent { AutosTheme { Searchable { Text("🧊") } } } }
       .onContent()
       .assertIsDisplayed()
-  }
-
-  @Test
-  fun findsFiller() {
-    composeRule
-      .apply {
-        setContent {
-          AutosTheme {
-            Searchable {
-              Replaceable {
-                DisposableEffect(Unit) {
-                  show()
-                  onDispose {}
-                }
-              }
-            }
-          }
-        }
-      }
-      .onFiller()
-      .assertExists()
   }
 }

--- a/feature/feed/src/main/java/br/com/orcinus/orca/feature/feed/Feed.kt
+++ b/feature/feed/src/main/java/br/com/orcinus/orca/feature/feed/Feed.kt
@@ -158,7 +158,6 @@ private fun Feed(
   modifier: Modifier = Modifier
 ) {
   Searchable(
-    TopAppBarDefaults.idleContainerColor,
     modifier,
     searchTextFieldOffset =
       DpOffset(x = 0.dp, y = WindowInsets.systemBars.top + SearchTextFieldDefaults.spacing * 2),
@@ -170,7 +169,7 @@ private fun Feed(
     val timelineTopContentPadding by
       animateDpAsState(
         searchTextFieldHeight.`if`(isSearching) {
-          this + WindowInsets.systemBars.top + SearchTextFieldDefaults.spacing * 2
+          this + WindowInsets.systemBars.top + SearchTextFieldDefaults.spacing
         },
         replacementAnimationSpec(),
         label = "Timeline top content padding"


### PR DESCRIPTION
A composable was laid out behind the [`SearchTextFieldPopup`](https://github.com/orcinusbr/orca-android/blob/36dab0876433263a59b5f7631eac9463299faffd/composite/timeline/src/main/java/br/com/orcinus/orca/composite/timeline/search/field/SearchTextFieldPopup.kt#L782) which tended to temporarily overlap with the posts displayed in the feed. Honestly, I do not remember why I decided to render it in the first place, but it does not seem to be necessary anymore.

<img src="https://github.com/user-attachments/assets/811ace9f-5cb6-4122-ac32-38a72273bc79" width="391" />
<img src="https://github.com/user-attachments/assets/9b288e99-5f6d-45c3-9a14-0ea8ce22a685" width="391" />

