### PR TITLE
Load sized images

### DIFF
--- a/composite/timeline/src/main/java/br/com/orcinus/orca/composite/timeline/avatar/Avatar.kt
+++ b/composite/timeline/src/main/java/br/com/orcinus/orca/composite/timeline/avatar/Avatar.kt
@@ -101,15 +101,15 @@ enum class Avatar {
    */
   protected abstract val form: Form.PerCorner
 
+  /** [Shape] of an avatar of this size. */
+  internal inline val shape: Shape
+    get() = form.asShape
+
   /**
    * Starting amount of density-dependent pixels that compose both the width and the height of the
    * avatar.
    */
-  internal abstract val sizeThreshold: Dp
-
-  /** [Shape] of an avatar of this size. */
-  internal inline val shape: Shape
-    get() = form.asShape
+  abstract val sizeThreshold: Dp
 
   /**
    * Resizes and clips the [drawable] based on this specific avatar size.

--- a/feature/composer/src/main/java/br/com/orcinus/orca/feature/composer/Composer.kt
+++ b/feature/composer/src/main/java/br/com/orcinus/orca/feature/composer/Composer.kt
@@ -49,6 +49,7 @@ import br.com.orcinus.orca.feature.composer.ui.Toolbar
 import br.com.orcinus.orca.platform.autos.iconography.asImageVector
 import br.com.orcinus.orca.platform.autos.kit.action.button.icon.HoverableIconButton
 import br.com.orcinus.orca.platform.autos.kit.input.text.composition.CompositionTextField
+import br.com.orcinus.orca.platform.autos.kit.input.text.composition.Units
 import br.com.orcinus.orca.platform.autos.kit.input.text.composition.interop.CompositionTextFieldValue
 import br.com.orcinus.orca.platform.autos.kit.input.text.composition.interop.drawableStateOf
 import br.com.orcinus.orca.platform.autos.kit.input.text.composition.interop.proxy
@@ -109,7 +110,9 @@ private fun Composer(
   }
 
   LaunchedEffect(avatarLoader) {
-    avatarLoader?.load()?.asDrawable()?.let { avatarDrawable = Avatar.SMALL.transform(context, it) }
+    avatarLoader?.load()?.asDrawable(Units.dp(context, Avatar.SMALL.sizeThreshold.value))?.let {
+      avatarDrawable = Avatar.SMALL.transform(context, it)
+    }
   }
 
   Scaffold(

--- a/platform/core/src/main/java/br/com/orcinus/orca/platform/core/image/SampleAndroidImageLoader.kt
+++ b/platform/core/src/main/java/br/com/orcinus/orca/platform/core/image/SampleAndroidImageLoader.kt
@@ -18,14 +18,11 @@ package br.com.orcinus.orca.platform.core.image
 import android.content.Context
 import android.graphics.drawable.Drawable
 import androidx.annotation.Discouraged
-import androidx.compose.foundation.Image
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.painterResource
-import androidx.core.content.ContextCompat
 import br.com.orcinus.orca.core.sample.image.SampleImageSource
 import br.com.orcinus.orca.std.image.android.AndroidImageLoader
+import br.com.orcinus.orca.std.image.android.LocalImageLoader
 import br.com.orcinus.orca.std.image.compose.async.AsyncImageLoader
 import java.lang.ref.WeakReference
 import java.util.Objects
@@ -70,17 +67,7 @@ private constructor(
 
   override fun hashCode() = Objects.hash(contextRef, source)
 
-  override fun load() =
-    createImage()
-      .asDrawable { contextRef.get()?.let { ContextCompat.getDrawable(it, source.resourceID) } }
-      .asComposable { modifier, contentDescription, shape, contentScale ->
-        Image(
-          painterResource(source.resourceID),
-          contentDescription,
-          modifier.clip(shape),
-          contentScale = contentScale
-        )
-      }
+  override fun load() = LocalImageLoader.load(contextRef, source.resourceID)
 }
 
 /**


### PR DESCRIPTION
Adds `width` and `height` parameters to [`AndroidImage.asDrawable()`](https://github.com/orcinusbr/orca-android/blob/4822088ce5f4f4a653bf57538f6ffa3710a87da9/std/image/android/src/main/java/br/com/orcinus/orca/std/image/android/AndroidImageLoader.kt#L249), which allows for downscaling images loaded locally or asynchronously that would otherwise be fetched in dimensions larger than the size in which they are drawn.

For example,

```kotlin
AndroidImageLoader.Provider.createSample(context)
  .provide(AuthorImageSource.Default)
  .asDrawable()
```

would load the underlying bitmap at its full resolution. Now, the size is required to be specified in order to save resources. In the case of that image, it could be done as

```kotlin
AndroidImageLoader.Provider.createSample(context)
  .provide(AuthorImageSource.Default)
  .asDrawable(width = Units.dp(context, 24f), height = Units.dp(context, 24f))
```

or

```kotlin
AndroidImageLoader.Provider.createSample(context)
  .provide(AuthorImageSource.Default)
  .asDrawable(size = Units.dp(context, 24f))
```