### PR TITLE
Fix infinite pagination

### DIFF
--- a/core/mastodon/build.gradle.kts
+++ b/core/mastodon/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023–2024 Orcinus
+ * Copyright © 2023–2025 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -18,6 +18,7 @@ plugins {
   alias(libs.plugins.android.maps.secrets)
   alias(libs.plugins.buildconfig)
   alias(libs.plugins.kotlin.android)
+  alias(libs.plugins.kotlin.atomicfu)
   alias(libs.plugins.kotlin.compose)
   alias(libs.plugins.kotlin.serialization)
   alias(libs.plugins.kotlin.symbolProcessor)
@@ -73,6 +74,7 @@ dependencies {
   implementation(libs.android.constraintLayout.compose)
   implementation(libs.android.fragment.ktx)
   implementation(libs.android.room.ktx)
+  implementation(libs.kotlin.atomicfu)
   implementation(libs.kotlin.reflect)
   implementation(libs.ktor.client.cio)
   implementation(libs.ktor.client.core)

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/pagination/MastodonPostPaginator.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/pagination/MastodonPostPaginator.kt
@@ -356,9 +356,9 @@ internal abstract class MastodonPostPaginator<T : Any>(private val coroutineScop
 
   /**
    * Returns the amount of pages included in the given range. Differs from the `countPagesOrThrow`
-   * methods in that no validations are performed: because [paginateTo] coerces both values, it is
-   * presupposed that the pages are natural [Int]s and, thus, no [Pages.InvalidException]s are
-   * thrown.
+   * methods in that no validations are performed: because [paginateTo] passes in an always-valid
+   * [initialPage] and validates the target one by itself, it is presupposed that the pages are
+   * natural [Int]s and, thus, no [Pages.InvalidException]s are thrown.
    *
    * @param initialPage Page from which pagination would start (inclusive).
    * @param targetPage Last page in the range (inclusive).

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/pagination/MastodonPostPaginator.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/pagination/MastodonPostPaginator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023–2024 Orcinus
+ * Copyright © 2023–2025 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -15,128 +15,265 @@
 
 package br.com.orcinus.orca.core.mastodon.feed.profile.post.pagination
 
+import androidx.annotation.EmptySuper
+import androidx.annotation.VisibleForTesting
 import br.com.orcinus.orca.core.feed.profile.post.Post
+import br.com.orcinus.orca.core.mastodon.feed.profile.post.pagination.page.Page
+import br.com.orcinus.orca.core.mastodon.feed.profile.post.pagination.page.Pages
 import br.com.orcinus.orca.core.mastodon.feed.profile.post.pagination.type.KTypeCreator
 import br.com.orcinus.orca.core.mastodon.feed.profile.post.pagination.type.kTypeCreatorOf
 import br.com.orcinus.orca.core.mastodon.instance.requester.Requester
 import br.com.orcinus.orca.core.mastodon.instance.requester.authentication.authenticated
 import br.com.orcinus.orca.ext.uri.url.HostedURLBuilder
+import br.com.orcinus.orca.std.markdown.style.`if`
 import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.request
 import io.ktor.http.LinkHeader
 import io.ktor.http.toURI
 import java.net.URI
-import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.atomicfu.atomic
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.InternalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.buffer
-import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.scan
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.runningFold
+import kotlinx.coroutines.flow.shareIn
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.job
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.plus
+
+/** `rel` parameter of the route to the previous page linked in the header of a response. */
+internal inline val @Suppress("UnusedReceiverParameter") LinkHeader.Rel.Previous
+  get() = "prev"
 
 /**
- * Requests and paginates through [Post]s.
+ * Paginates through [Post]s.
  *
- * Mastodon API's pagination starts from an initial route and is performed subsequently by sending a
- * `GET` HTTP request to one of the links that are included as headers of the previous response. For
- * more information, refer to the
+ * Mastodon API pagination starts from an initial router and is performed subsequently by sending a
+ * `GET` HTTP request to one of the links that are included as headers of the previous
+ * responseDeferred. For more information, refer to the
  * [official documentation](https://docs.joinmastodon.org/api/guidelines/#pagination).
  *
+ * ##### Definition of page
+ *
+ * In the documentation and throughout the source, "page" is simply denoted as a natural [Int]
+ * index. The term does not refer to a [List] of [Post]s, but to such index through which such a
+ * [List] can be fetched via an HTTP request to the Mastodon API.
+ *
+ * ##### Definition of pagination
+ *
+ * Conceptually, pagination is p₀ = 0, p₀ → λⁿ pₙ — in either increasing or decreasing order, where
+ * p₀, pₙ ∈ ℕ, with p₀ as the initial page and pₙ as the target one. Each iteration emits the
+ * [Post]s in the respective page to a [Flow] when and while it is collected.
+ *
+ * ##### Coldness
+ *
+ * A call to [paginateTo] does not paginate; rather, it merely returns the [Flow] to which the
+ * [Post]s in each page will be emitted _when_ and _while_ collected, _scheduling_ a pagination
+ * operation based on the target page. After the initial collection, all pagination requests are
+ * executed while collection is taking place.
+ *
+ * This behavior prevents performing pagination when there is no one listening to the emitted
+ * [Post]s (that is: no [FlowCollector]s collecting the returned [Flow]), which would, otherwise,
+ * result in missed pages; thus, incomplete emissions; and potential waste of resources by HTTP
+ * requests whose responses are unconsumed.
+ *
+ * E. g.,
+ * ```kotlin
+ * paginateTo(1)
+ * println("Requested, but not collected.")
+ * var page = 0
+ * paginateTo(2).collect { posts: List<Post> -> println("Collected at page ${page++}: $posts") }
+ * ```
+ *
+ * When requesting for the first time (`paginateTo(1)`), the returned [Flow] is not collected. If it
+ * was hot instead of cold, pagination would have been performed right away, and the [Flow] returned
+ * by the second request (`paginateTo(2)`) would only emit the [Post]s in page 2, given that the
+ * current page would already be 1 due to the previous preemptive pagination. Running it would,
+ * then, result in the printing of
+ *
+ * ```
+ * Requested, but not collected.
+ * Collected at page 0: […]
+ * ```
+ *
+ * (which is also misleading: the page of the collected [Post]s is not 0, but 2).
+ *
+ * With it being cold, however, it results in
+ *
+ * ```
+ * Requested, but not collected.
+ * Collected at page 0: […]
+ * Collected at page 1: […]
+ * Collected at page 2: […]
+ * ```
+ *
+ * To subsequent [FlowCollector]s, the [Post]s in the current page (2) and all other ones in pages
+ * to which pagination is further requested are emitted.
+ *
+ * ##### DTO-to-[Post]s conversions
+ *
  * An instance of this class also acts as a [KTypeCreator] because of its generic nature: since its
- * type argument cannot be reified (at least not as of Kotlin 1.9.21), the [HttpResponse] needs to
- * know how to actually convert the received payload into a [T]. This tends to result in a somewhat
- * manual process if there are, for example, type arguments that need to be passed in; otherwise,
- * this behavior can simply be delegated to a default [KTypeCreator], obtainable through the
- * [kTypeCreatorOf] creator method.
+ * type argument [T] cannot be reified (at least not as of Kotlin 2.0.0), the [HttpResponse] needs
+ * to know how to actually convert the received payload into a [T]. This tends to result in a
+ * somewhat manual process if there are, for example, type arguments that need to be passed in;
+ * otherwise, this behavior can simply be delegated to a default [KTypeCreator], obtainable through
+ * the [kTypeCreatorOf] factory method.
  *
  * @param T DTO that is returned by the API.
+ * @property coroutineScope [CoroutineScope] in which paginations are performed and their respective
+ *   HTTP requests for fetching the [Post]s in the page are sent.
+ * @see buildInitialRoute
  */
-internal abstract class MastodonPostPaginator<T : Any> : KTypeCreator<T> {
-  /** [MutableSharedFlow] with the index of the page that's the current one. */
-  private val pageFlow =
-    MutableSharedFlow<Int>(replay = 2, onBufferOverflow = BufferOverflow.DROP_OLDEST).apply {
-      tryEmit(0)
-    }
+internal abstract class MastodonPostPaginator<T : Any>(private val coroutineScope: CoroutineScope) :
+  KTypeCreator<T> {
+  /** [Requester] by which HTTP requests that require authentication can be performed. */
+  private val authenticatedRequester by lazy { requester.authenticated() }
 
-  /** Page at which the [Post]s lastly emitted to the [postsFlow] are. */
-  private val currentPage
-    get() = pageFlow.replayCache.last()
+  /**
+   * Workaround for the inability to reference the initial router builder method which is, at the
+   * same time, a member and an extension. Since it does not depend on the response to a previous
+   * request, allows for the instantiation of a single router instead of one for each
+   * [FlowCollector] of [postsFlow].
+   *
+   * @see HostedURLBuilder.buildInitialRoute
+   * @see createSubsequentRouter
+   */
+  private val initialRouter: HostedURLBuilder.() -> URI = { buildInitialRoute() }
+
+  /**
+   * Receives each page sent upon pagination.
+   *
+   * A rendezvous [Channel] is preferred over a [SharedFlow] because the latter employs conflation,
+   * preventing slow collections from receiving all emitted values and allowing them only to receive
+   * the latest ones. This is an issue specifically for pagination in which pₙ ≠ p₀, since each page
+   * in the range is sent immediately, one after another.
+   */
+  private val currentPageChannel = Channel<Int>()
+
+  /** Page set upon pagination; essentially, p₀. */
+  private var currentPage by atomic(Pages.NONE)
+
+  /** [Flow] to which [Post]s obtained from pagination are emitted. */
+  private val postsFlow =
+    currentPageChannel
+      .receiveAsFlow()
+      .onEach(Pages::validate)
+      .catch { cause -> cause.takeUnless { it is Pages.InvalidException }?.let { throw it } }
+      .runningFold<_, Pagination?>(null) { previousPagination, currentPage ->
+        @Suppress("UNCHECKED_CAST")
+        val router =
+          previousPagination
+            ?.let { createSubsequentRouter(previousPagination, currentPage) }
+            .`if`({ this === Unrouted }) {
+              return@runningFold null
+            } as (HostedURLBuilder.() -> URI)?
+            ?: initialRouter
+
+        Pagination(currentPage, coroutineScope.async { authenticatedRequester.post(router) })
+      }
+      .filterNotNull()
+      .onEach(::onWillPaginate)
+      .map { it.responseDeferred.await().body(this@MastodonPostPaginator).toPosts() }
+      .shareIn(coroutineScope + Job(), SharingStarted.Eagerly)
 
   /** [Requester] by which requests will be performed. */
   protected abstract val requester: Requester
 
-  /** [Flow] to which the [Post]s within the current page are emitted. */
-  private val postsFlow =
-    pageFlow
-      .scan(null as Pair<Int, HttpResponse>?) { previous, currentPage ->
-        currentPage to
-          requester
-            .authenticated()
-            .get({
-              previous?.let { (previousPage, previousResponse) ->
-                /**
-                 * Obtains one of the [URI]s present in the link header of the response to the
-                 * previous request.
-                 *
-                 * @param rel Description of the relationship between the current page and the one
-                 *   whose [URI] will be obtained. According to the Mastodon API documentation as of
-                 *   v1, can be either `"prev"` or [LinkHeader.Rel.Next].
-                 * @throws IllegalStateException If the previous response does not have the related
-                 *   link header.
-                 */
-                @Throws(IllegalStateException::class)
-                fun getLinkedURI(rel: String): URI {
-                  return previousResponse.headers
-                    .filterIsLink()
-                    .find { it.parameter(LinkHeader.Parameters.Rel) == rel }
-                    ?.uri
-                    ?.let(::URI)
-                    ?: error("Header with \"$rel\" link was not included in the previous response.")
-                }
-
-                /** Obtains the [URI] to which a request would simply perform a refresh. */
-                fun getRefreshURI(): URI {
-                  return previousResponse.request.url.toURI()
-                }
-
-                if (currentPage < previousPage) {
-                  getLinkedURI("prev")
-                } else if (currentPage == previousPage) {
-                  getRefreshURI()
-                } else {
-                  getLinkedURI(LinkHeader.Rel.Next)
-                }
-              }
-                ?: buildInitialRoute()
-            })
-      }
-      .drop(1)
-      .filterNotNull()
-      .map { (_, response) -> response.body(this).toPosts() }
-      .buffer(Channel.RENDEZVOUS)
+  /** Page from which the next pagination will start. */
+  @VisibleForTesting
+  inline val initialPage
+    @Page get() = if (currentPage == Pages.NONE) 0 else currentPage
 
   /**
-   * Iterates from the current page to the given one.
+   * Denotes that no router was linked in the previous response to a request for obtaining posts in
+   * a given page. Allows, primarily, for distinguishing between whether the initial router should
+   * be returned or that nothing be done due to the absence of such linked router.
    *
-   * @param page Page until which pagination should be performed.
-   * @throws IndexOutOfBoundsException If the [page] is negative.
+   * @see initialRouter
+   * @see createSubsequentRouter
    */
-  @Throws(IndexOutOfBoundsException::class)
-  suspend fun paginateTo(page: Int): Flow<List<Post>> {
-    if (page < 0) {
-      throw IndexOutOfBoundsException("Cannot paginate to a negative page ($page).")
+  @Suppress("RemoveEmptyClassBody") private object Unrouted {}
+
+  /** [MastodonPostPaginator] that shares [Post]s emitted upon pagination in the [GlobalScope]. */
+  @DelicateCoroutinesApi
+  @Deprecated(
+    "Specify the coroutine scope in which the flow containing the paginated posts is shared."
+  )
+  constructor() : this(GlobalScope)
+
+  init {
+    @OptIn(InternalCoroutinesApi::class)
+    coroutineScope.coroutineContext.job.invokeOnCompletion(onCancelling = true) {
+      currentPageChannel.close(it)
+      currentPage = Pages.NONE
     }
-    while (page < currentPage) {
-      val previousPage = currentPage.dec()
-      pageFlow.emit(previousPage)
+  }
+
+  /**
+   * Requests an iteration from the initial page to the given one.
+   *
+   * @param page Page to which pagination should be inclusively performed.
+   * @throws Pages.InvalidException If the [page] is invalid.
+   * @see Pages.validate
+   */
+  @Throws(Pages.InvalidException::class)
+  fun paginateTo(@Page page: Int): Flow<List<Post>> {
+    Pages.validate(page)
+    return channelFlow {
+      val initialPage = this@MastodonPostPaginator.initialPage
+      val pages = if (initialPage <= page) initialPage..page else initialPage downTo page
+      val pageCount = countPages(initialPage, targetPage = pages.last)
+      coroutineScope {
+        launch { postsFlow.take(pageCount).collect(::send) }
+        launch { pages.forEach { setPage(it) } }
+      }
     }
-    while (page > currentPage) {
-      val nextPage = currentPage.inc()
-      pageFlow.emit(nextPage)
-    }
-    return postsFlow
+  }
+
+  /**
+   * Returns the amount of pages included in the given range.
+   *
+   * @param targetPage Last page in the range (inclusive).
+   * @throws Pages.InvalidException If the [targetPage] is invalid.
+   * @see Pages.validate
+   */
+  @Throws(Pages.InvalidException::class)
+  @VisibleForTesting
+  fun countPagesOrThrow(@Page targetPage: Int): Int {
+    Pages.validate(targetPage)
+    return countPages(initialPage, targetPage)
+  }
+
+  /**
+   * Returns the amount of pages included in the given range.
+   *
+   * @param initialPage Page from which pagination would start (inclusive).
+   * @param targetPage Last page in the range (inclusive).
+   * @throws Pages.InvalidException If either page is invalid.
+   * @see Pages.validate
+   */
+  @Throws(Pages.InvalidException::class)
+  @VisibleForTesting
+  fun countPagesOrThrow(@Page initialPage: Int, @Page targetPage: Int): Int {
+    Pages.validate(initialPage)
+    Pages.validate(targetPage)
+    return countPages(initialPage, targetPage)
   }
 
   /** Creates an [URI] to which the initial request should be sent. */
@@ -144,4 +281,89 @@ internal abstract class MastodonPostPaginator<T : Any> : KTypeCreator<T> {
 
   /** Converts the DTO returned by the API into [Post]s. */
   protected abstract fun T.toPosts(): List<Post>
+
+  /**
+   * Callback called whenever pagination will be performed.
+   *
+   * @param pagination Metadata of the pagination to be performed.
+   */
+  @EmptySuper protected open suspend fun onWillPaginate(pagination: Pagination) = Unit
+
+  /**
+   * Produces a router preceded by another one. The returned value might be [Unrouted], which would
+   * denote either that the start/final page has been reached or that the Mastodon API erroneously
+   * did not provide the previous/next router — with the first scenario being the most empirically
+   * common.
+   *
+   * @param previousPagination Determines, alongside the [currentPage], the router that will be
+   *   returned for providing the [URI] (one of the linked ones, that of the previous response when
+   *   a refresh has been requested or neither) to `GET` to next.
+   * @param currentPage Page at which which we currently are, to be compared with the previous one.
+   *   Passing it in as a parameter rather than calling the getter of the instance variable (whose
+   *   value is atomic) prevents unnecessary synchronization.
+   * @see initialRouter
+   */
+  private suspend fun createSubsequentRouter(
+    previousPagination: Pagination,
+    currentPage: Int
+  ): Any {
+    /**
+     * Produces a router based on one of the [URI]s linked in the response to the previous request.
+     * May be [Unrouted], which would indicate that either the starting/final page has been reached
+     * or Mastodon has erroneously _not_ provided the previous/next router (although the latter
+     * seems empirically uncommon).
+     *
+     * @param rel Description of the relationship between the current page and the one whose router
+     *   will be obtained. According to the Mastodon API documentation as of v1, can be either
+     *   [LinkHeader.Rel.Previous] or [LinkHeader.Rel.Next].
+     */
+    suspend fun createLinkedRouter(rel: String) =
+      previousPagination.responseDeferred
+        .await()
+        .headers
+        .filterIsLink()
+        .find { it.parameter(LinkHeader.Parameters.Rel) == rel }
+        ?.uri
+        ?.let<_, HostedURLBuilder.() -> URI> { { URI(it) } }
+        ?: Unrouted
+
+    /** Produces a router for performing a refresh. */
+    suspend fun createRefreshRouter(): HostedURLBuilder.() -> URI {
+      val response = previousPagination.responseDeferred.await()
+      return { response.request.url.toURI() }
+    }
+
+    return if (currentPage < previousPagination.page) {
+      createLinkedRouter(LinkHeader.Rel.Previous)
+    } else if (currentPage == previousPagination.page) {
+      createRefreshRouter()
+    } else {
+      createLinkedRouter(LinkHeader.Rel.Next)
+    }
+  }
+
+  /**
+   * Sets [page] as the current one by changing the atomic property and sending it to the [Channel].
+   *
+   * @param page Page to be set.
+   * @see currentPage
+   * @see currentPageChannel
+   */
+  private suspend fun setPage(@Page page: Int) {
+    currentPageChannel.send(page)
+    currentPage = page
+  }
+
+  /**
+   * Returns the amount of pages included in the given range. Differs from the `countPagesOrThrow`
+   * methods in that no validations are performed: because [paginateTo] coerces both values, it is
+   * presupposed that the pages are natural [Int]s and, thus, no [Pages.InvalidException]s are
+   * thrown.
+   *
+   * @param initialPage Page from which pagination would start (inclusive).
+   * @param targetPage Last page in the range (inclusive).
+   * @see Pages.validate
+   */
+  private fun countPages(@Page initialPage: Int, @Page targetPage: Int) =
+    if (initialPage == targetPage) 1 else initialPage + targetPage + 1
 }

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/pagination/Pagination.java
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/pagination/Pagination.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2025 Orcinus
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package br.com.orcinus.orca.core.mastodon.feed.profile.post.pagination;
+
+import androidx.annotation.NonNull;
+import br.com.orcinus.orca.core.feed.profile.post.Post;
+import br.com.orcinus.orca.core.mastodon.feed.profile.post.pagination.page.Page;
+import br.com.orcinus.orca.core.mastodon.feed.profile.post.pagination.page.Pages;
+import io.ktor.client.statement.HttpResponse;
+import kotlinx.coroutines.Deferred;
+
+/**
+ * Association of a deferred response received for a request for fetching {@link Post}s in a given
+ * page and such page itself.
+ *
+ * @param page Page in which the request will be sent. May be invalid — the constructor of this
+ *     class does not validate it; its validation is expected to have been performed previously by
+ *     the caller.
+ * @param responseDeferred Deferred {@link HttpResponse} with the DTOs of the {@link Post}s at the
+ *     {@link #page}.
+ * @see Pages#validate(int)
+ */
+record Pagination(@Page int page, @NonNull Deferred<HttpResponse> responseDeferred) {}

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/pagination/page/Page.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/pagination/page/Page.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2025 Orcinus
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package br.com.orcinus.orca.core.mastodon.feed.profile.post.pagination.page
+
+import androidx.annotation.IntRange
+
+/**
+ * Denotes that an [Int] is or is expected to be a valid page.
+ *
+ * @see Pages.validate
+ */
+@IntRange(from = 0)
+@Target(AnnotationTarget.PROPERTY_GETTER, AnnotationTarget.VALUE_PARAMETER)
+internal annotation class Page

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/pagination/page/Pages.java
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/pagination/page/Pages.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright © 2025 Orcinus
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package br.com.orcinus.orca.core.mastodon.feed.profile.post.pagination.page;
+
+/** Utilities for pages. */
+public class Pages {
+  /**
+   * Marker that denotes an unset page. It is not a valid page itself — passing it as a parameter to
+   * {@link #validate(int)} throws an {@link InvalidException}; rather, it merely indicates that a
+   * page has not yet been defined.
+   */
+  public static final int NONE = -1;
+
+  /** {@link IllegalArgumentException} thrown when a page is invalid. */
+  public static class InvalidException extends IllegalArgumentException {
+    /**
+     * Constructs an {@link InvalidException}.
+     *
+     * @param message The detail message.
+     */
+    InvalidException(final String message) {
+      super(message);
+    }
+  }
+
+  /** {@link InvalidException} thrown when a page is negative. */
+  public static class NegativeException extends InvalidException {
+    /**
+     * Constructs a {@link NegativeException}.
+     *
+     * @param page The negative page.
+     */
+    NegativeException(final int page) {
+      super("Page cannot be negative (" + name(page) + ").");
+    }
+  }
+
+  /**
+   * Creates an instance of this class.
+   *
+   * <p>This class serves as a collection of static utilities and, thus, shall not be constructed.
+   */
+  private Pages() {}
+
+  /**
+   * Ensures that the given integer is a valid page.
+   *
+   * @param page Page whose validity will be checked.
+   * @throws NegativeException If the page is negative.
+   */
+  public static void validate(final int page) throws NegativeException {
+    if (page < 0) {
+      throw new NegativeException(page);
+    }
+  }
+
+  /**
+   * Provides a readable name for the given page in case it is a marker (i. e., {@link #NONE});
+   * otherwise, returns its {@link String} representation.
+   */
+  private static String name(final int page) {
+    String name = String.valueOf(page);
+    if (page == NONE) {
+      name = "NONE";
+    }
+    return name;
+  }
+}

--- a/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/pagination/Flows.kt
+++ b/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/pagination/Flows.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2025 Orcinus
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package br.com.orcinus.orca.core.mastodon.feed.profile.post.pagination
+
+import app.cash.turbine.TurbineTestContext
+
+/**
+ * When awaiting an item that does not get emitted, Turbine throws an [Exception] of its own,
+ * shadowing the actual one which was originally thrown — the cause. This method circumvents such
+ * behavior, throwing such cause in case an unexpected event (absence of emission, error or
+ * completion) occurs.
+ *
+ * @param T Item to be awaited.
+ * @see TurbineTestContext.awaitItem
+ */
+@Throws
+internal suspend fun <T> TurbineTestContext<T>.awaitItemOrThrowCause() =
+  try {
+    awaitItem()
+  } catch (error: AssertionError) {
+    throw checkNotNull(error.cause)
+  }

--- a/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/pagination/FlowsTests.kt
+++ b/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/pagination/FlowsTests.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2025 Orcinus
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package br.com.orcinus.orca.core.mastodon.feed.profile.post.pagination
+
+import app.cash.turbine.test
+import assertk.assertFailure
+import assertk.assertions.hasMessage
+import kotlin.test.Test
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+
+internal class FlowsTests {
+  @Test
+  fun awaitsItem() = runTest {
+    flowOf(0).test {
+      awaitItemOrThrowCause()
+      awaitComplete()
+    }
+  }
+
+  @Test
+  fun throwsCauseWhenAwaitingForAnItemAndAnExceptionIsThrown() {
+    val exception = Exception("🃏")
+    runTest {
+      assertFailure { flow<Nothing> { throw exception }.test { awaitItemOrThrowCause<Nothing>() } }
+        .hasMessage(exception.message)
+    }
+  }
+}

--- a/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/pagination/MastodonPostPaginatorScope.kt
+++ b/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/pagination/MastodonPostPaginatorScope.kt
@@ -225,19 +225,12 @@ internal sealed class MastodonPostPaginatorScope(
   /**
    * Creates a route that succeeds the initial one.
    *
-   * @param page Page for which the route to be created is.
-   * @throws Pages.InvalidException If the [page] is invalid.
+   * @param page Page for which the route to be created is. It is implied to be a valid one; thus,
+   *   it is not validated.
    * @see Pages.validate
    */
-  @Throws(Pages.InvalidException::class)
-  private fun createNextRouteAt(@Page page: Int): URI {
-    Pages.validate(page)
-    return HostedURLBuilder.from(requester.baseURI)
-      .path("next")
-      .query()
-      .parameter("page", "$page")
-      .build()
-  }
+  private fun createNextRouteAt(@Page page: Int) =
+    HostedURLBuilder.from(requester.baseURI).path("next").query().parameter("page", "$page").build()
 }
 
 /**

--- a/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/pagination/MastodonPostPaginatorScope.kt
+++ b/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/pagination/MastodonPostPaginatorScope.kt
@@ -1,0 +1,283 @@
+/*
+ * Copyright © 2025 Orcinus
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package br.com.orcinus.orca.core.mastodon.feed.profile.post.pagination
+
+import app.cash.turbine.test
+import br.com.orcinus.orca.core.feed.profile.post.Post
+import br.com.orcinus.orca.core.mastodon.feed.profile.post.pagination.page.Page
+import br.com.orcinus.orca.core.mastodon.feed.profile.post.pagination.page.Pages
+import br.com.orcinus.orca.core.mastodon.feed.profile.post.pagination.type.KTypeCreator
+import br.com.orcinus.orca.core.mastodon.feed.profile.post.pagination.type.kTypeCreatorOf
+import br.com.orcinus.orca.core.mastodon.instance.requester.RequesterTestScope
+import br.com.orcinus.orca.core.mastodon.instance.requester.authentication.AuthenticatedRequester
+import br.com.orcinus.orca.core.mastodon.instance.requester.authentication.runAuthenticatedRequesterTest
+import br.com.orcinus.orca.ext.uri.url.HostedURLBuilder
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.statement.request
+import io.ktor.http.Headers
+import io.ktor.http.HttpHeaders
+import io.ktor.http.LinkHeader
+import io.ktor.http.toURI
+import java.net.URI
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+
+/** [RouteSpec] from which both the header and the route are obtainable. */
+private abstract class InternalRouteSpec : RouteSpec() {
+  /** `rel` parameter of the header. If `null`, the [header] is also `null`. */
+  protected abstract val rel: String?
+
+  override fun matches(route: URI) = route() == route
+
+  override fun toString() = "RouteSpec(route=${route()})"
+
+  /** Specified route as it currently is. If `null`, the [header] is also `null`. */
+  abstract fun route(): URI?
+
+  /** Header linking to the specified route. `null` if either the [rel] or the [route] is `null`. */
+  fun header(): LinkHeader? {
+    val rel = rel
+    val route = route()
+    return if (rel != null && route != null) LinkHeader("$route", rel) else null
+  }
+}
+
+/** Single implementation of [Routes]. */
+private data class RoutesImpl(
+  override val initial: InternalRouteSpec,
+  override val previous: InternalRouteSpec?,
+  override val current: InternalRouteSpec?,
+  override val next: InternalRouteSpec?
+) :
+  Routes(),
+  Map<String, InternalRouteSpec?> by LinkedHashMap<String, InternalRouteSpec?>(
+      /* initialCapacity = */ 4
+    )
+    .apply({
+      set(RoutesImpl::initial.name, initial)
+      set(RoutesImpl::previous.name, previous)
+      set(RoutesImpl::current.name, current)
+      set(RoutesImpl::next.name, next)
+    })
+
+/**
+ * Single implementation of [MastodonPostPaginatorScope].
+ *
+ * @param requesterScope [RequesterTestScope] in which the [Post]s of each page are shared. Also
+ *   acts as a delegate of this class' [CoroutineScope]-like subclassed functionality.
+ */
+private class MastodonPostPaginatorScopeImpl(
+  requesterScope: RequesterTestScope<AuthenticatedRequester>
+) : MastodonPostPaginatorScope(requesterScope)
+
+/** Specification of a route. */
+internal sealed class RouteSpec {
+  /**
+   * Returns whether the given [route] matches this specification.
+   *
+   * @param route Route to match against.
+   */
+  abstract infix fun matches(route: URI): Boolean
+
+  /**
+   * Amount of times pagination HTTP requests sent to a route matching this specification have been
+   * responded to.
+   *
+   * @see matches
+   */
+  abstract fun hitCount(): Int
+}
+
+/** Collection of route specifications. */
+internal sealed class Routes {
+  /** Specification of the route to which the first pagination request is sent. */
+  abstract val initial: RouteSpec
+
+  /**
+   * Specification of the route to which a pagination request prior to the most recent one has been
+   * sent.
+   */
+  abstract val previous: RouteSpec?
+
+  /** Specification of the route to which the last pagination has been performed. */
+  abstract val current: RouteSpec?
+
+  /**
+   * Specification of the route to which pagination requests that succeed the initial one are sent.
+   */
+  abstract val next: RouteSpec?
+}
+
+/**
+ * Scope in which [MastodonPostPaginator]-specific tests can be run. Alongside the runner method,
+ * offers facilities for performing pagination, providing responses to HTTP requests and counting
+ * those sent to a specific route, which allows for ensuring behavior correctness of such class.
+ *
+ * @property requesterScope [RequesterTestScope] in which the [Post]s of each page are shared. Also
+ *   acts as a delegate of this class' [CoroutineScope]-like subclassed functionality.
+ * @see runMastodonPostPaginatorTest
+ */
+internal sealed class MastodonPostPaginatorScope(
+  private val requesterScope: RequesterTestScope<AuthenticatedRequester>
+) :
+  MastodonPostPaginator<Any>(coroutineScope = requesterScope),
+  KTypeCreator<Any> by kTypeCreatorOf(),
+  CoroutineScope by requesterScope,
+  AutoCloseable {
+  /** Routes associated to the amount of requests sent to them. */
+  private val requestCounting = hashMapOf<URI, Int>()
+
+  /** Most recent route to which pagination has been performed. */
+  private var currentRoute: URI? = null
+
+  /** Route of the page to which the first pagination is performed. */
+  private inline val initialRoute
+    get() = HostedURLBuilder.from(requester.baseURI).buildInitialRoute()
+
+  /** Route to which a pagination request has been sent prior to the most recent one. */
+  private inline val previousRoute: URI?
+    get() =
+      when (val initialPage = initialPage) {
+        0 -> null
+        1 -> initialRoute
+        else -> createNextRouteAt(initialPage - 1)
+      }
+
+  /** Page of the next pagination. */
+  private inline val nextPage
+    get() = initialPage + 1
+
+  /** Route of the page to which subsequent pagination is performed by default. */
+  private inline val nextRoute: URI
+    get() = createNextRouteAt(nextPage)
+
+  final override val requester = requesterScope.requester
+
+  /** Route specification collection available from this [MastodonPostPaginatorScope]. */
+  val routes: Routes =
+    RoutesImpl(
+      RouteSpecImpl(::initialRoute, rel = null),
+      RouteSpecImpl(::previousRoute, LinkHeader.Rel.Previous),
+      RouteSpecImpl(::currentRoute, rel = null),
+      RouteSpecImpl(::nextRoute, LinkHeader.Rel.Next)
+    )
+
+  /**
+   * Single implementation of [RouteSpec].
+   *
+   * @property route Obtains the specified route as it currently is.
+   * @property rel `rel` parameter of the header. If `null`, the [header] is also `null`.
+   */
+  private inner class RouteSpecImpl(private val route: () -> URI?, override val rel: String?) :
+    InternalRouteSpec() {
+    override fun route() = route.invoke()
+
+    override fun hitCount() =
+      with(requestCounting) { filterKeys(::matches).mapNotNull { (route, _) -> get(route) } }.sum()
+  }
+
+  final override fun HostedURLBuilder.buildInitialRoute() = requesterScope.route(this)
+
+  final override fun Any.toPosts() = emptyList<Post>()
+
+  final override suspend fun onWillPaginate(pagination: Pagination) {
+    val route = pagination.responseDeferred.await().request.url.toURI()
+    currentRoute = route
+    requestCounting.compute(route) { _, requestCount -> requestCount?.inc() ?: 1 }
+  }
+
+  /**
+   * Paginates from the initial page to the given target one, suspending until the pagination
+   * finishes.
+   *
+   * @param page Page until which pagination should be inclusively performed.
+   * @throws AssertionError If the backing [Flow] emits less than `countPagesOrThrow(page)` [List]s,
+   *   completes abruptly or throws.
+   * @throws Pages.InvalidException If the [page] is invalid.
+   * @see Pages.validate
+   */
+  @Throws(AssertionError::class, Pages.InvalidException::class)
+  suspend fun paginateToAndAwait(@Page page: Int) {
+    paginateTo(page).test {
+      repeat(countPagesOrThrow(page)) { awaitItem() }
+      awaitComplete()
+    }
+  }
+
+  override fun close() = requestCounting.clear()
+
+  /**
+   * Creates a route that succeeds the initial one.
+   *
+   * @param page Page for which the route to be created is.
+   * @throws Pages.InvalidException If the [page] is invalid.
+   * @see Pages.validate
+   */
+  @Throws(Pages.InvalidException::class)
+  private fun createNextRouteAt(@Page page: Int): URI {
+    Pages.validate(page)
+    return HostedURLBuilder.from(requester.baseURI)
+      .path("next")
+      .query()
+      .parameter("page", "$page")
+      .build()
+  }
+}
+
+/**
+ * Runs a [MastodonPostPaginator] test.
+ *
+ * @param onRequest Callback called for each pagination whenever a request is performed, before it
+ *   is responded to.
+ * @param previous Produces the route to which a request is sent when paginating backwards.
+ * @param next Produces the route to which a request is sent when paginating forward.
+ * @param body Actual testing on the instantiated [MastodonPostPaginator].
+ */
+@OptIn(ExperimentalContracts::class)
+internal fun runMastodonPostPaginatorTest(
+  onRequest: (page: Int, route: URI) -> Unit = { _, _ -> },
+  previous: Routes.(page: Int) -> RouteSpec? = { this.previous },
+  next: Routes.(page: Int) -> RouteSpec? = { this.next },
+  body: suspend MastodonPostPaginatorScope.() -> Unit
+) {
+  contract { callsInPlace(body, InvocationKind.EXACTLY_ONCE) }
+  lateinit var paginatorScope: MastodonPostPaginatorScopeImpl
+  runAuthenticatedRequesterTest({ requestData ->
+    val page = paginatorScope.initialPage
+    val route = requestData.url.toURI()
+    onRequest(page, route)
+    respond(
+      content = "",
+      headers =
+        Headers.build {
+          with(paginatorScope.routes as RoutesImpl) {
+              copy(
+                previous = previous(page) as InternalRouteSpec?,
+                next = next(page) as InternalRouteSpec?
+              )
+            }
+            .mapValues { (_, routeSpec) -> routeSpec?.header() }
+            .forEach { (_, header) -> header?.let { append(HttpHeaders.Link, "$header") } }
+        }
+    )
+  }) {
+    paginatorScope = MastodonPostPaginatorScopeImpl(requesterScope = this)
+    paginatorScope.use { it.body() }
+  }
+}

--- a/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/pagination/MastodonPostPaginatorScopeTests.kt
+++ b/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/pagination/MastodonPostPaginatorScopeTests.kt
@@ -1,0 +1,125 @@
+/*
+ * Copyright © 2025 Orcinus
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package br.com.orcinus.orca.core.mastodon.feed.profile.post.pagination
+
+import app.cash.turbine.test
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotNull
+import assertk.assertions.isZero
+import assertk.assertions.prop
+import java.net.URI
+import kotlin.test.Test
+
+internal class MastodonPostPaginatorScopeTests {
+  @Test
+  fun runsBodyOnce() {
+    var bodyRunCount = 0
+    runMastodonPostPaginatorTest { bodyRunCount++ }
+    assertThat(bodyRunCount, name = "bodyRunCount").isEqualTo(1)
+  }
+
+  @Test
+  fun paginatesAndAwaits() = runMastodonPostPaginatorTest {
+    paginateToAndAwait(2_048)
+    assertThat(initialPage).isEqualTo(2_048)
+  }
+
+  @Test
+  fun callsCallbackOnEachRequest() {
+    var responseCount = 0
+    runMastodonPostPaginatorTest({ _, _ -> responseCount++ }) {
+      paginateToAndAwait(256)
+      assertThat(responseCount, name = "responseCount").isEqualTo(countPagesOrThrow(0, 256))
+    }
+  }
+
+  @Test
+  fun decreasesPageQueryParameterOnPreviousRouteByDefault() {
+    var remainingForwardsPageCount = 256
+    var remainingBackwardsPageCount = remainingForwardsPageCount
+    runMastodonPostPaginatorTest({ _, route ->
+      if (remainingForwardsPageCount == 0 && remainingBackwardsPageCount > 0) {
+        assertThat(route, name = "route")
+          .prop(URI::getQuery)
+          .isNotNull()
+          .transform("split") { query -> query.split('=') }
+          .prop(List<String>::last)
+          .prop(String::toInt)
+          .isEqualTo(remainingBackwardsPageCount - 1)
+      }
+    }) {
+      val unidirectionalPageCount = countPagesOrThrow(remainingForwardsPageCount)
+      paginateTo(remainingForwardsPageCount).test {
+        repeat(unidirectionalPageCount) {
+          awaitItemOrThrowCause()
+          remainingForwardsPageCount--
+        }
+        awaitComplete()
+      }
+      paginateTo(0).test {
+        repeat(unidirectionalPageCount) {
+          awaitItemOrThrowCause()
+          remainingBackwardsPageCount--
+        }
+        awaitComplete()
+      }
+    }
+  }
+
+  @Test
+  fun increasesPageQueryParameterOnNextRouteByDefault() {
+    runMastodonPostPaginatorTest({ page, route ->
+      if (page > 0) {
+        assertThat(route, name = "route")
+          .prop(URI::getQuery)
+          .isNotNull()
+          .transform("split") { query -> query.split('=') }
+          .prop(List<String>::last)
+          .prop(String::toInt)
+          .isEqualTo(page)
+      }
+    }) {
+      paginateTo(2).test {
+        repeat(countPagesOrThrow(2)) { awaitItemOrThrowCause() }
+        awaitComplete()
+      }
+    }
+  }
+
+  @Test
+  fun initialRouteHasNoHitsByDefault() = runMastodonPostPaginatorTest {
+    assertThat(::routes).prop(Routes::initial).prop(RouteSpec::hitCount).isZero()
+  }
+
+  @Test
+  fun previousRouteHasNoHitsByDefault() = runMastodonPostPaginatorTest {
+    assertThat(::routes).prop(Routes::previous).isNotNull().prop(RouteSpec::hitCount).isZero()
+  }
+
+  @Test
+  fun nextRouteHasNoHitsByDefault() = runMastodonPostPaginatorTest {
+    assertThat(::routes).prop(Routes::next).isNotNull().prop(RouteSpec::hitCount).isZero()
+  }
+
+  @Test
+  fun countsResponses() = runMastodonPostPaginatorTest {
+    repeat(256) { paginateToAndAwait(0) }
+    assertThat(::routes).prop(Routes::initial).prop(RouteSpec::hitCount).isEqualTo(256)
+    repeat(256) { paginateToAndAwait(1) }
+    assertThat(::routes).prop(Routes::current).isNotNull().prop(RouteSpec::hitCount).isEqualTo(256)
+  }
+}

--- a/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/pagination/page/PagesTests.kt
+++ b/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/pagination/page/PagesTests.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2025 Orcinus
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package br.com.orcinus.orca.core.mastodon.feed.profile.post.pagination.page
+
+import assertk.assertFailure
+import assertk.assertions.isInstanceOf
+import assertk.assertions.messageContains
+import kotlin.test.Test
+
+internal class PagesTests {
+  @Test
+  fun negativePageIsInvalid() {
+    assertFailure { Pages.validate(-2) }.isInstanceOf<Pages.NegativeException>()
+  }
+
+  @Test
+  fun noneMarkerIsInvalid() {
+    assertFailure { Pages.validate(Pages.NONE) }.isInstanceOf<Pages.InvalidException>()
+  }
+
+  @Test
+  fun throwsMentioningNoneMarkerWhenValidatingIt() =
+    assertFailure { Pages.validate(Pages.NONE) }.messageContains(Pages::NONE.name)
+
+  @Test fun pageZeroIsValid() = Pages.validate(0)
+
+  @Test fun positivePageIsValid() = Pages.validate(1)
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -53,6 +53,7 @@ coil-compose = { group = "io.coil-kt", name = "coil-compose", version = "2.4.0" 
 junit = { group = "junit", name = "junit", version = "4.13.2" }
 jsoup = { group = "org.jsoup", name = "jsoup", version = "1.16.2" }
 konsist = { group = "com.lemonappdev", name = "konsist", version = "0.16.0" }
+kotlin-atomicfu = { group = "org.jetbrains.kotlinx", name = "atomicfu", version.ref = "kotlin-atomicfu" }
 kotlin-compiler-embeddable = { group = "org.jetbrains.kotlin", name = "kotlin-compiler-embeddable", version.ref = "kotlin" }
 kotlin-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "kotlin-coroutines" }
 kotlin-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlin-coroutines" }
@@ -84,7 +85,7 @@ robolectric = { group = "org.robolectric", name = "robolectric", version = "4.14
 slf4j = { group = "org.slf4j", name = "slf4j-api", version = "2.0.7" }
 spotless = { group = "com.diffplug.spotless", name = "spotless-plugin-gradle", version.ref = "spotless" }
 time4j = { group = "net.time4j", name = "time4j-android", version = "4.8-2021a" }
-turbine = { group = "app.cash.turbine", name = "turbine", version = "1.0.0" }
+turbine = { group = "app.cash.turbine", name = "turbine", version = "1.2.0" }
 zoomable = { group = "net.engawapg.lib", name = "zoomable", version = "1.6.0-beta2" }
 
 [plugins]
@@ -93,6 +94,7 @@ android-library = { id = "com.android.library", version.ref = "android-plugin" }
 android-maps-secrets = { id = "com.google.android.libraries.mapsplatform.secrets-gradle-plugin", version = "2.0.1" }
 buildconfig = { id = "com.github.gmazzo.buildconfig", version = "3.1.0" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+kotlin-atomicfu = { id = "org.jetbrains.kotlinx.atomicfu", version.ref = "kotlin-atomicfu" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-lombok = { id = "org.jetbrains.kotlin.plugin.lombok", version.ref = "kotlin" }
@@ -125,6 +127,7 @@ android-test-espresso = "3.5.0"
 assertk = "0.28.1"
 java = "17"
 kotlin = "2.0.0"
+kotlin-atomicfu = "0.27.0"
 kotlin-coroutines = "1.8.0"
 kotlin-symbolProcessor = "2.0.0-1.0.22"
 ktor = "2.3.2"

--- a/proguard-rules.pro
+++ b/proguard-rules.pro
@@ -17,17 +17,12 @@
 
 -dontobfuscate
 -dontwarn androidx.compose.runtime.internal.ComposableFunction2
--keep public class br.com.orcinus.orca.** { *; }
+-keep class br.com.orcinus.orca.** { *; }
 -keep public final class lombok.Generated
 -keep public final class lombok.NonNull
 -keepclassmembers final class * implements android.os.Parcelable {
   #noinspection ShrinkerUnresolvedReference
 
   public static final android.os.Parcelable$Creator CREATOR;
-}
--keepclassmembers class br.com.orcinus.orca.core.mastodon.notification.** { *; }
--keepclassmembers class br.com.orcinus.orca.platform.autos.kit.input.text.composition.ErrorDelegate {
-  java.lang.CharSequence getError();
-  void toggle(java.lang.CharSequence);
 }
 -keepclassmembers public enum net.time4j.** { public static final **[] values(); }


### PR DESCRIPTION
Fixes a bug which made pagination continue indefinitely ([or crash!](https://github.com/orcinusbr/orca-android/blob/fd5d6153ac1da2ebb9440d3c79a1cec796f5d704/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/pagination/MastodonPostPaginator.kt#L96)) when requesting posts in a page after the current one when the current one was the last one — since there were no more pages, pagination would often restart and begin from the first one, until the last one was reached, repeating this cycle. Basically, paginators were acting like a [circular queue](https://en.wikipedia.org/wiki/Circular_buffer).

Such issue occurred because each page was folded into an HTTP response (that is: accumulated and used to send a request that would receive a response) and the route of the request from which such response derived was obtained based on the response of the previous page. If the link to the next page was not included in the header of the current response (because we were on the last page), it was incorrectly presumed that the current page was the first one; thus, the request defaulted to being sent to the initial route.

Concisely:

<p align="center">
paginateTo(pₙ) → λ⁰, …, λⁿ, where if ¬∃ λⁿ⁺¹, incorrectly assume λ⁰
</p>

The solution was to differentiate between when we are, in fact, at the first page and when the current page is the last one. In order to do that, producing a router — a lambda which creates a route — for the request to be sent next can result in either a `(HostedURLBuilder.() -> URI)?` or _unrouted_. Therefore, there are three states instead of the previously assumed two:

1. `null`: Denotes that there is no previous page; this is the first one;
2. `HostedURLBuilder.() -> URI` (non-null): Denotes that there is a previous page; this is a subsequent one; or
3. [`Unrouted`](https://github.com/orcinusbr/orca-android/blob/31f1cb9e3dfd5198fc05ec311bf172db4dcbd9c1/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/pagination/MastodonPostPaginator.kt#L211): Either way, there is no next page; nothing should be done because there is nowhere to paginate to.