### PR TITLE
Fix crash on successful sign-in/feed loading

### DIFF
--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/pagination/MastodonPostPaginator.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/pagination/MastodonPostPaginator.kt
@@ -194,7 +194,7 @@ internal abstract class MastodonPostPaginator<T : Any>(
             } as (HostedURLBuilder.() -> URI)?
             ?: initialRouter
 
-        Pagination(page, coroutineScope.async { authenticatedRequester.post(router) })
+        Pagination(page, coroutineScope.async { authenticatedRequester.get(router) })
       }
       .filterNotNull()
       .onEach(::onWillPaginate)

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/pagination/MastodonPostPaginator.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/pagination/MastodonPostPaginator.kt
@@ -230,7 +230,7 @@ internal abstract class MastodonPostPaginator<T : Any>(
       "constructor has an implicit dependency on the authentication lock injected into the core " +
       "module that is expected to have been registered."
   )
-  constructor() : this(Injector.from<CoreModule>().authenticationLock(), GlobalScope)
+  constructor() : this(Injector.from<CoreModule>().authenticationLock(), GlobalScope + Job())
 
   init {
     @OptIn(InternalCoroutinesApi::class)

--- a/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/pagination/MastodonPostPaginatorScope.kt
+++ b/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/pagination/MastodonPostPaginatorScope.kt
@@ -31,6 +31,7 @@ import io.ktor.client.engine.mock.respond
 import io.ktor.client.statement.request
 import io.ktor.http.Headers
 import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
 import io.ktor.http.LinkHeader
 import io.ktor.http.toURI
 import java.net.URI
@@ -252,7 +253,7 @@ internal sealed class MastodonPostPaginatorScope(
  */
 @OptIn(ExperimentalContracts::class)
 internal fun runMastodonPostPaginatorTest(
-  onRequest: (page: Int, route: URI) -> Unit = { _, _ -> },
+  onRequest: (method: HttpMethod, page: Int, route: URI) -> Unit = { _, _, _ -> },
   previous: Routes.(page: Int) -> RouteSpec? = { this.previous },
   next: Routes.(page: Int) -> RouteSpec? = { this.next },
   body: suspend MastodonPostPaginatorScope.() -> Unit
@@ -262,7 +263,7 @@ internal fun runMastodonPostPaginatorTest(
   runAuthenticatedRequesterTest({ requestData ->
     val page = paginatorScope.initialPage
     val route = requestData.url.toURI()
-    onRequest(page, route)
+    onRequest(requestData.method, page, route)
     respond(
       content = "",
       headers =

--- a/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/pagination/MastodonPostPaginatorScopeTests.kt
+++ b/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/pagination/MastodonPostPaginatorScopeTests.kt
@@ -42,7 +42,7 @@ internal class MastodonPostPaginatorScopeTests {
   @Test
   fun callsCallbackOnEachRequest() {
     var responseCount = 0
-    runMastodonPostPaginatorTest({ _, _ -> responseCount++ }) {
+    runMastodonPostPaginatorTest({ _, _, _ -> responseCount++ }) {
       paginateToAndAwait(256)
       assertThat(responseCount, name = "responseCount").isEqualTo(countPagesOrThrow(0, 256))
     }
@@ -53,7 +53,7 @@ internal class MastodonPostPaginatorScopeTests {
     val targetPage = 256
     var isPaginatingBackwards = false
     var lastBackwardsPage = Pages.NONE
-    runMastodonPostPaginatorTest({ page, route ->
+    runMastodonPostPaginatorTest({ _, page, route ->
       if (lastBackwardsPage != Pages.NONE && lastBackwardsPage != 1) {
         assertThat(route, name = "route")
           .prop(URI::getQuery)
@@ -82,7 +82,7 @@ internal class MastodonPostPaginatorScopeTests {
 
   @Test
   fun increasesPageQueryParameterOnNextRouteByDefault() {
-    runMastodonPostPaginatorTest({ page, route ->
+    runMastodonPostPaginatorTest({ _, page, route ->
       if (page > 0) {
         assertThat(route, name = "route")
           .prop(URI::getQuery)

--- a/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/pagination/MastodonPostPaginatorTests.kt
+++ b/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/pagination/MastodonPostPaginatorTests.kt
@@ -23,10 +23,22 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.isInstanceOf
 import assertk.assertions.isNotNull
 import assertk.assertions.prop
+import br.com.orcinus.orca.core.feed.profile.post.Post
 import br.com.orcinus.orca.core.mastodon.feed.profile.post.pagination.page.Pages
+import br.com.orcinus.orca.core.mastodon.feed.profile.post.pagination.type.KTypeCreator
+import br.com.orcinus.orca.core.mastodon.feed.profile.post.pagination.type.kTypeCreatorOf
+import br.com.orcinus.orca.core.mastodon.instance.requester.authentication.runAuthenticatedRequesterTest
+import br.com.orcinus.orca.core.module.CoreModule
+import br.com.orcinus.orca.core.sample.feed.profile.post.content.SampleTermMuter
+import br.com.orcinus.orca.core.sample.instance.SampleInstanceProvider
+import br.com.orcinus.orca.core.sample.test.image.NoOpSampleImageLoader
+import br.com.orcinus.orca.ext.uri.url.HostedURLBuilder
+import br.com.orcinus.orca.std.injector.Injector
+import br.com.orcinus.orca.std.injector.module.injection.lazyInjectionOf
 import java.net.URI
 import kotlin.test.Test
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.DelicateCoroutinesApi
 
 internal class MastodonPostPaginatorTests {
   @Test
@@ -95,4 +107,31 @@ internal class MastodonPostPaginatorTests {
         assertFailure { awaitItem() }.cause().isNotNull().isInstanceOf<CancellationException>()
       }
     }
+
+  @Test
+  fun canPaginateInTheGlobalScope() = runAuthenticatedRequesterTest {
+    Injector.register(
+      CoreModule(
+        lazyInjectionOf { SampleInstanceProvider(NoOpSampleImageLoader.Provider) },
+        lazyInjectionOf { it },
+        lazyInjectionOf { SampleTermMuter() }
+      )
+    )
+
+    @OptIn(DelicateCoroutinesApi::class) @Suppress("DEPRECATION")
+    object : MastodonPostPaginator<Any>(), KTypeCreator<Any> by kTypeCreatorOf() {
+        override val requester = this@runAuthenticatedRequesterTest.requester
+
+        override fun HostedURLBuilder.buildInitialRoute() = build()
+
+        override fun Any.toPosts() = emptyList<Post>()
+      }
+      .paginateTo(0)
+      .test {
+        awaitItem()
+        awaitComplete()
+      }
+
+    Injector.unregister<CoreModule>()
+  }
 }

--- a/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/pagination/MastodonPostPaginatorTests.kt
+++ b/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/pagination/MastodonPostPaginatorTests.kt
@@ -35,6 +35,7 @@ import br.com.orcinus.orca.core.sample.test.image.NoOpSampleImageLoader
 import br.com.orcinus.orca.ext.uri.url.HostedURLBuilder
 import br.com.orcinus.orca.std.injector.Injector
 import br.com.orcinus.orca.std.injector.module.injection.lazyInjectionOf
+import io.ktor.http.HttpMethod
 import java.net.URI
 import kotlin.test.Test
 import kotlinx.coroutines.CancellationException
@@ -62,9 +63,15 @@ internal class MastodonPostPaginatorTests {
   }
 
   @Test
+  fun sendsAGetRequestUponPagination() =
+    runMastodonPostPaginatorTest({ method, _, _ -> assertThat(method).isEqualTo(HttpMethod.Get) }) {
+      paginateToAndAwait(0)
+    }
+
+  @Test
   fun paginatesToInitialRoute() {
     lateinit var requestRoute: URI
-    runMastodonPostPaginatorTest({ _, route -> requestRoute = route }) {
+    runMastodonPostPaginatorTest({ _, _, route -> requestRoute = route }) {
       paginateToAndAwait(0)
       assertThat(::routes).prop(Routes::initial).transform("matches") { it matches requestRoute }
     }


### PR DESCRIPTION
#386 introduced new problems: whenever paginating, a `POST` request was sent on each page instead of a `GET` one; also, these were performed in the [global coroutine scope](https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines/-global-scope/) and the completion of its job was being awaited — even though it does not have any.

Both these issues resulted, altogether, in a crash.