### PR TITLE
Add extensions for functional programming

### DIFF
--- a/ext/functional/build.gradle.kts
+++ b/ext/functional/build.gradle.kts
@@ -1,0 +1,10 @@
+plugins {
+  alias(libs.plugins.kotlin.jvm)
+
+  `java-library`
+}
+
+dependencies {
+  testImplementation(libs.assertk)
+  testImplementation(libs.kotlin.test)
+}

--- a/ext/functional/src/main/java/br/com/orcinus/orca/ext/functional/Monads.kt
+++ b/ext/functional/src/main/java/br/com/orcinus/orca/ext/functional/Monads.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2025 Orcinus
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package br.com.orcinus.orca.ext.functional
+
+/**
+ * Transforms each element in the [Iterable] of this [Result] and combines the produced [Result]s
+ * into a single one. That which is returned by this method holds either all successful
+ * transformations or the [Exception] thrown by the first failing one.
+ *
+ * @param T Value resulted from this [Result].
+ * @param R Value resulted from a transformation.
+ * @param transform Transforms an element of the value of the receiver [Result] into another
+ *   [Result].
+ */
+inline fun <T, R> Result<Iterable<T>>.onEach(transform: (T) -> Result<R>) = flatMap { elements ->
+  runCatching { elements.map { element -> transform(element).getOrThrow() } }
+}
+
+/**
+ * Returns the [Result] resulted from the transformation in case it is not a failure; otherwise, the
+ * receiver one is cast to `Result<R>` and returned (which is safe because its successful value is
+ * nonexistent and, thus, unobtainable).
+ *
+ * @param T Value resulted from this [Result].
+ * @param R Value resulted from a transformation.
+ * @param transform Transforms the value of the receiver [Result] into another [Result].
+ */
+inline fun <T, R> Result<T>.flatMap(transform: (T) -> Result<R>) = map(transform).flatten()
+
+/**
+ * Returns the [Result] resulted from this one in case this one is not a failure; otherwise, this
+ * one is cast to `Result<R>` and returned (which is safe because its successful value is
+ * nonexistent and, thus, unobtainable).
+ *
+ * @param R Value resulted from the nested [Result].
+ */
+@Suppress("UNCHECKED_CAST") fun <R> Result<Result<R>>.flatten() = getOrDefault(this as Result<R>)
+
+/**
+ * Erases information about the successful value provided by this [Result] by converting it into a
+ * `Result<Unit>`. Intended for scenarios in which an internal context should not be leaked to
+ * consumers, functionally indicating to them only that obtaining the value _may_ throw.
+ */
+fun Result<*>.unit() = map {}

--- a/ext/functional/src/test/java/br/com/orcinus/orca/ext/functional/MonadsTests.kt
+++ b/ext/functional/src/test/java/br/com/orcinus/orca/ext/functional/MonadsTests.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright © 2025 Orcinus
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package br.com.orcinus.orca.ext.functional
+
+import assertk.assertThat
+import assertk.assertions.containsExactly
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFailure
+import assertk.assertions.isSameInstanceAs
+import assertk.assertions.isSuccess
+import assertk.assertions.prop
+import kotlin.test.Test
+
+internal class MonadsTests {
+  private val exception = Exception()
+
+  @Test
+  fun failsWhenJoiningEachElementOfAFailedIterableIntoASingleResult() =
+    assertThat(Result)
+      .transform("failure") { it.failure<List<Int>>(exception) }
+      .transform("onEach") { result -> result.onEach { n -> Result.success(n) } }
+      .isFailure()
+      .isSameInstanceAs(exception)
+
+  @Test
+  fun failsWhenJoiningEachElementOfAResultingIterableIntoASingleResultAndOneOfThemIsAFailure() =
+    assertThat(Result)
+      .transform("success") { it.success(listOf(1, 2, 3)) }
+      .transform("onEach") { result ->
+        result.onEach { n -> if (n % 2 != 0) Result.success(n) else Result.failure(exception) }
+      }
+      .isFailure()
+      .isSameInstanceAs(exception)
+
+  @Test
+  fun joinsEachElementOfAResultingIterableIntoASingleResult() =
+    assertThat(Result)
+      .transform("success") { it.success(listOf(1, 2, 3)) }
+      .transform("onEach") { result -> result.onEach { n -> Result.success(n * 2) } }
+      .isSuccess()
+      .containsExactly(2, 4, 6)
+
+  @Test
+  fun failsWhenFlatMappingAFailedValue() =
+    assertThat(Result)
+      .transform("failure") { it.failure<Result<Int>>(exception) }
+      .transform("flatMap") { it.flatMap { Result.success(0) } }
+      .isFailure()
+      .isSameInstanceAs(exception)
+
+  @Test
+  fun failsWhenFlatteningAFailedValue() =
+    assertThat(Result)
+      .transform("failure") { it.failure<Result<Any>>(exception) }
+      .prop(Result<Result<Any>>::flatten)
+      .isFailure()
+      .isSameInstanceAs(exception)
+
+  @Test
+  fun obtainsTheInnerFailureResultWhenGettingTheValueOfTheFlattenedReceiverOne() =
+    assertThat(Result)
+      .transform("success") { it.success(Result.failure<Any>(exception)) }
+      .prop(Result<Result<Any>>::flatten)
+      .isFailure()
+      .isSameInstanceAs(exception)
+
+  @Test
+  fun obtainsTheValueOfInnerResultWhenGettingThatOfTheFlattenedReceiverOne() =
+    assertThat(Result)
+      .transform("success") { it.success(Result.success(0)) }
+      .prop(Result<Result<Int>>::flatten)
+      .isSuccess()
+      .isEqualTo(0)
+
+  @Test
+  fun failsWhenConvertingAFailedValueIntoAResultOfUnit() =
+    assertThat(Result)
+      .transform("failure") { it.failure<Any>(exception) }
+      .prop(Result<Any>::unit)
+      .isFailure()
+      .isSameInstanceAs(exception)
+
+  @Test
+  fun convertsASuccessfulValueIntoAResultOfUnit() =
+    assertThat(Result)
+      .transform("success") { it.success(0) }
+      .prop(Result<Int>::unit)
+      .isSuccess()
+      .isSameInstanceAs(Unit)
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -37,6 +37,7 @@ include(
   ":core-module",
   ":core-test",
   ":ext:coroutines",
+  ":ext:functional",
   ":ext:grammar",
   ":ext:processing",
   ":ext:reflection",


### PR DESCRIPTION
Preparation for applying functional error handling to the core of Orca (instead of throwing exceptions, since Kotlin does not enforce catching exceptions as Java does).