### PR TITLE
Handle `AuthenticationLock` errors functionally

### DIFF
--- a/app/src/main/java/br/com/orcinus/orca/app/module/feature/profiledetails/MainProfileDetailsModule.kt
+++ b/app/src/main/java/br/com/orcinus/orca/app/module/feature/profiledetails/MainProfileDetailsModule.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023–2024 Orcinus
+ * Copyright © 2023–2025 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -16,6 +16,7 @@
 package br.com.orcinus.orca.app.module.feature.profiledetails
 
 import android.content.Context
+import br.com.orcinus.orca.core.auth.AuthenticationLock
 import br.com.orcinus.orca.core.mastodon.feed.profile.MastodonProfileProvider
 import br.com.orcinus.orca.core.mastodon.feed.profile.type.followable.MastodonFollowService
 import br.com.orcinus.orca.core.mastodon.instance.requester.Requester
@@ -28,7 +29,12 @@ import br.com.orcinus.orca.std.injector.module.injection.lazyInjectionOf
 internal class MainProfileDetailsModule(context: Context) :
   ProfileDetailsModule(
     lazyInjectionOf { profileProvider },
-    lazyInjectionOf { MastodonFollowService(Injector.get<Requester>(), profileProvider) },
+    lazyInjectionOf {
+      MastodonFollowService(
+        Injector.get<Requester<AuthenticationLock.FailedAuthenticationException>>(),
+        profileProvider
+      )
+    },
     lazyInjectionOf { Injector.from<CoreModule>().instanceProvider().provide().postProvider },
     lazyInjectionOf { MainProfileDetailsBoundary(context) }
   ) {

--- a/core-test/src/test/java/br/com/orcinus/core/test/auth/AuthenticationLockFactoryTests.kt
+++ b/core-test/src/test/java/br/com/orcinus/core/test/auth/AuthenticationLockFactoryTests.kt
@@ -39,7 +39,7 @@ internal class AuthenticationLockFactoryTests {
     val actorProvider = FixedActorProvider(Actor.Unauthenticated)
     val authenticationLock = AuthenticationLock(authorizer, actorProvider)
     runTest {
-      assertFailure { authenticationLock.scheduleUnlock {} }
+      assertFailure { authenticationLock.scheduleUnlock {}.getValueOrThrow() }
         .isNotNull()
         .isInstanceOf<AuthenticationLock.FailedAuthenticationException>()
         .prop(AuthenticationLock.FailedAuthenticationException::cause)
@@ -52,8 +52,8 @@ internal class AuthenticationLockFactoryTests {
     val authorizer = AuthorizerBuilder().build()
     val actor = Actor.Authenticated("id", "access-token", NoOpImageLoader)
     val actorProvider = InMemoryActorProvider().apply { remember(actor) }
-    AuthenticationLock(authorizer, actorProvider).scheduleUnlock {
-      assertThat(it).isSameInstanceAs(actor)
-    }
+    AuthenticationLock(authorizer, actorProvider)
+      .scheduleUnlock { assertThat(it).isSameInstanceAs(actor) }
+      .getValueOrThrow()
   }
 }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -21,6 +21,7 @@ plugins {
 }
 
 dependencies {
+  api(project(":std:func"))
   api(project(":std:image"))
   api(project(":std:markdown"))
   api(libs.kotlin.coroutines.core)
@@ -33,6 +34,7 @@ dependencies {
   testImplementation(project(":core:sample-test"))
   testImplementation(project(":core-test"))
   testImplementation(project(":ext:testing"))
+  testImplementation(project(":std:func-test"))
   testImplementation(libs.assertk.coroutines)
   testImplementation(libs.konsist)
   testImplementation(libs.kotlin.coroutines.test)

--- a/core/mastodon/build.gradle.kts
+++ b/core/mastodon/build.gradle.kts
@@ -96,6 +96,7 @@ dependencies {
   testImplementation(project(":platform:autos-test"))
   testImplementation(project(":platform:intents-test"))
   testImplementation(project(":platform:testing"))
+  testImplementation(project(":std:func-test"))
   testImplementation(project(":std:injector-test"))
   testImplementation(libs.assertk.coroutines)
   testImplementation(libs.kotlin.coroutines.test)

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/auth/authentication/MastodonAuthenticationToken.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/auth/authentication/MastodonAuthenticationToken.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023–2024 Orcinus
+ * Copyright © 2023–2025 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -40,19 +40,12 @@ internal data class MastodonAuthenticationToken(private val accessToken: String)
    * @param avatarLoaderProvider [ImageLoader.Provider] that provides the [ImageLoader] by which the
    *   avatar will be loaded from a [URI].
    */
-  suspend fun toActor(
-    requester: Requester,
-    avatarLoaderProvider: SomeImageLoaderProvider<URI>
-  ): Actor.Authenticated {
-    return toActor(
-      avatarLoaderProvider,
-      requester
-        .get({ path("api").path("v1").path("accounts").path("verify_credentials").build() }) {
-          headers { append(HttpHeaders.Authorization, "Bearer $accessToken") }
-        }
-        .body<MastodonAuthenticationVerification>()
-    )
-  }
+  suspend fun toActor(requester: Requester<*>, avatarLoaderProvider: SomeImageLoaderProvider<URI>) =
+    requester
+      .get({ path("api").path("v1").path("accounts").path("verify_credentials").build() }) {
+        headers { append(HttpHeaders.Authorization, "Bearer $accessToken") }
+      }
+      .map { toActor(avatarLoaderProvider, it.body<MastodonAuthenticationVerification>()) }
 
   /**
    * Converts this [MastodonAuthenticationToken] into an [authenticated][Actor.Authenticated]

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/MastodonFeedPaginator.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/MastodonFeedPaginator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023–2024 Orcinus
+ * Copyright © 2023–2025 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -37,7 +37,7 @@ import java.net.URI
  */
 internal class MastodonFeedPaginator(
   override val context: Context,
-  override val requester: Requester,
+  override val requester: Requester<*>,
   override val actorProvider: ActorProvider,
   private val profilePostPaginatorProvider: MastodonProfilePostPaginator.Provider,
   override val commentPaginatorProvider: MastodonCommentPaginator.Provider,

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/MastodonProfilePostPaginator.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/MastodonProfilePostPaginator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023–2024 Orcinus
+ * Copyright © 2023–2025 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -36,7 +36,7 @@ import java.net.URI
  */
 internal class MastodonProfilePostPaginator(
   override val context: Context,
-  override val requester: Requester,
+  override val requester: Requester<*>,
   override val actorProvider: ActorProvider,
   override val commentPaginatorProvider: MastodonCommentPaginator.Provider,
   override val imageLoaderProvider: SomeImageLoaderProvider<URI>,

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/cache/storage/MastodonProfileEntity.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/cache/storage/MastodonProfileEntity.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023–2024 Orcinus
+ * Copyright © 2023–2025 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -85,7 +85,7 @@ internal constructor(
    */
   @Throws(IllegalStateException::class)
   internal suspend fun toProfile(
-    requester: Requester,
+    requester: Requester<*>,
     avatarLoaderProvider: SomeImageLoaderProvider<URI>,
     dao: MastodonProfileEntityDao,
     postPaginatorProvider: MastodonProfilePostPaginator.Provider
@@ -112,7 +112,7 @@ internal constructor(
    *   [MastodonEditableProfile]'s [Post]s will be provided.
    */
   private suspend fun toMastodonEditableProfile(
-    requester: Requester,
+    requester: Requester<*>,
     avatarLoaderProvider: SomeImageLoaderProvider<URI>,
     dao: MastodonProfileEntityDao,
     postPaginatorProvider: MastodonProfilePostPaginator.Provider

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/cache/storage/MastodonProfileStorage.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/cache/storage/MastodonProfileStorage.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023–2024 Orcinus
+ * Copyright © 2023–2025 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -42,7 +42,7 @@ import kotlinx.coroutines.flow.first
  *   [Mastodon profile entities][MastodonProfileEntity].
  */
 internal class MastodonProfileStorage(
-  private val requester: Requester,
+  private val requester: Requester<*>,
   private val avatarLoaderProvider: SomeImageLoaderProvider<URI>,
   private val postPaginatorProvider: MastodonProfilePostPaginator.Provider,
   private val entityDao: MastodonProfileEntityDao

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/MastodonOwnedPost.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/MastodonOwnedPost.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023–2024 Orcinus
+ * Copyright © 2023–2025 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -15,6 +15,7 @@
 
 package br.com.orcinus.orca.core.mastodon.feed.profile.post
 
+import androidx.annotation.CheckResult
 import br.com.orcinus.orca.core.feed.profile.post.OwnedPost
 import br.com.orcinus.orca.core.mastodon.instance.requester.authentication.authenticated
 
@@ -25,9 +26,10 @@ import br.com.orcinus.orca.core.mastodon.instance.requester.authentication.authe
  */
 data class MastodonOwnedPost internal constructor(private val delegate: MastodonPost) :
   OwnedPost(delegate) {
-  override suspend fun remove() {
+  @CheckResult
+  override suspend fun remove() =
     delegate.requester
       .authenticated()
       .delete({ path("api").path("v1").path("statuses").path(id).build() })
-  }
+      .unit()
 }

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/MastodonPost.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/MastodonPost.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023–2024 Orcinus
+ * Copyright © 2023–2025 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -58,7 +58,7 @@ import java.time.ZonedDateTime
  */
 internal class MastodonPost(
   context: Context,
-  internal val requester: Requester,
+  internal val requester: Requester<*>,
   override val actorProvider: ActorProvider,
   profilePostPaginatorProvider: MastodonProfilePostPaginator.Provider,
   private val imageLoaderProvider: SomeImageLoaderProvider<URI>,

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/cache/storage/MastodonPostEntity.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/cache/storage/MastodonPostEntity.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023–2024 Orcinus
+ * Copyright © 2023–2025 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -106,7 +106,7 @@ internal data class MastodonPostEntity(
    */
   suspend fun toPost(
     context: Context,
-    requester: Requester,
+    requester: Requester<*>,
     profileCache: Cache<Profile>,
     dao: MastodonPostEntityDao,
     actorProvider: ActorProvider,

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/cache/storage/MastodonPostStorage.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/cache/storage/MastodonPostStorage.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023–2024 Orcinus
+ * Copyright © 2023–2025 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -63,7 +63,7 @@ import java.net.URI
  */
 internal class MastodonPostStorage(
   private val context: Context,
-  private val requester: Requester,
+  private val requester: Requester<*>,
   private val profileCache: Cache<Profile>,
   private val profilePostPaginatorProvider: MastodonProfilePostPaginator.Provider,
   private val postEntityDao: MastodonPostEntityDao,

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/pagination/MastodonPostPaginator.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/pagination/MastodonPostPaginator.kt
@@ -194,7 +194,10 @@ internal abstract class MastodonPostPaginator<T : Any>(
             } as (HostedURLBuilder.() -> URI)?
             ?: initialRouter
 
-        Pagination(page, coroutineScope.async { authenticatedRequester.get(router) })
+        Pagination(
+          page,
+          coroutineScope.async { authenticatedRequester.get(router).getValueOrThrow() }
+        )
       }
       .filterNotNull()
       .onEach(::onWillPaginate)
@@ -202,7 +205,7 @@ internal abstract class MastodonPostPaginator<T : Any>(
       .shareIn(coroutineScope + Job(), SharingStarted.Eagerly)
 
   /** [Requester] by which requests will be performed. */
-  protected abstract val requester: Requester
+  protected abstract val requester: Requester<*>
 
   /** Page from which the next pagination will start. */
   @VisibleForTesting

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/stat/comment/MastodonCommentPaginator.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/stat/comment/MastodonCommentPaginator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Orcinus
+ * Copyright © 2024–2025 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -48,7 +48,7 @@ import java.net.URI
  */
 internal class MastodonCommentPaginator(
   private val context: Context,
-  override val requester: Requester,
+  override val requester: Requester<*>,
   private val actorProvider: ActorProvider,
   private val profilePostPaginatorProvider: MastodonProfilePostPaginator.Provider,
   private val imageLoaderProvider: SomeImageLoaderProvider<URI>,

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/stat/comment/MastodonCommentStat.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/stat/comment/MastodonCommentStat.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Orcinus
+ * Copyright © 2024–2025 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -38,7 +38,7 @@ import kotlinx.coroutines.flow.flow
  * @see MastodonPost.id
  */
 internal class MastodonCommentStat(
-  private val requester: Requester,
+  private val requester: Requester<*>,
   private val paginatorProvider: MastodonCommentPaginator.Provider,
   private val id: String,
   count: Int

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/stat/toggleable/MastodonFavoriteStat.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/stat/toggleable/MastodonFavoriteStat.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Orcinus
+ * Copyright © 2024–2025 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -23,6 +23,7 @@ import br.com.orcinus.orca.core.mastodon.feed.profile.account.MastodonAccount
 import br.com.orcinus.orca.core.mastodon.feed.profile.post.MastodonPost
 import br.com.orcinus.orca.core.mastodon.instance.requester.Requester
 import br.com.orcinus.orca.core.mastodon.instance.requester.authentication.authenticated
+import br.com.orcinus.orca.std.func.monad.onEach
 import br.com.orcinus.orca.std.image.ImageLoader
 import br.com.orcinus.orca.std.image.SomeImageLoaderProvider
 import io.ktor.client.call.body
@@ -50,7 +51,7 @@ import kotlinx.coroutines.flow.flow
  */
 internal class MastodonFavoriteStat(
   private val context: Context,
-  private val requester: Requester,
+  private val requester: Requester<*>,
   private val profilePostPaginatorProvider: MastodonProfilePostPaginator.Provider,
   private val avatarLoaderProvider: SomeImageLoaderProvider<URI>,
   private val id: String,
@@ -62,10 +63,11 @@ internal class MastodonFavoriteStat(
       emit(
         requester
           .get({ path("api").path("v1").path("statuses").path(id).path("favourited_by").build() })
-          .body<List<MastodonAccount>>()
-          .map {
+          .map { it.body<List<MastodonAccount>>() }
+          .onEach {
             it.toProfile(context, requester, avatarLoaderProvider, profilePostPaginatorProvider)
           }
+          .getValueOrThrow()
       )
     }
   }

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/stat/toggleable/MastodonRepostStat.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/stat/toggleable/MastodonRepostStat.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Orcinus
+ * Copyright © 2024–2025 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -23,6 +23,7 @@ import br.com.orcinus.orca.core.mastodon.feed.profile.account.MastodonAccount
 import br.com.orcinus.orca.core.mastodon.feed.profile.post.MastodonPost
 import br.com.orcinus.orca.core.mastodon.instance.requester.Requester
 import br.com.orcinus.orca.core.mastodon.instance.requester.authentication.authenticated
+import br.com.orcinus.orca.std.func.monad.onEach
 import br.com.orcinus.orca.std.image.ImageLoader
 import br.com.orcinus.orca.std.image.SomeImageLoaderProvider
 import io.ktor.client.call.body
@@ -50,7 +51,7 @@ import kotlinx.coroutines.flow.flow
  */
 internal class MastodonRepostStat(
   private val context: Context,
-  private val requester: Requester,
+  private val requester: Requester<*>,
   private val profilePostPaginatorProvider: MastodonProfilePostPaginator.Provider,
   private val avatarLoaderProvider: SomeImageLoaderProvider<URI>,
   private val id: String,
@@ -62,10 +63,11 @@ internal class MastodonRepostStat(
       emit(
         requester
           .get({ path("api").path("v1").path("statuses").path(id).path("reblogged_by").build() })
-          .body<List<MastodonAccount>>()
-          .map {
+          .map { it.body<List<MastodonAccount>>() }
+          .onEach {
             it.toProfile(context, requester, avatarLoaderProvider, profilePostPaginatorProvider)
           }
+          .getValueOrThrow()
       )
     }
   }

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/status/MastodonStatus.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/status/MastodonStatus.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023–2024 Orcinus
+ * Copyright © 2023–2025 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -107,7 +107,7 @@ internal data class MastodonStatus(
    */
   internal fun toPost(
     context: Context,
-    requester: Requester,
+    requester: Requester<*>,
     actorProvider: ActorProvider,
     profilePostPaginatorProvider: MastodonProfilePostPaginator.Provider,
     commentPaginatorProvider: MastodonCommentPaginator.Provider,

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/type/editable/MastodonEditableProfile.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/type/editable/MastodonEditableProfile.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023–2024 Orcinus
+ * Copyright © 2023–2025 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -35,7 +35,7 @@ import java.net.URI
  *   will be provided.
  */
 internal class MastodonEditableProfile(
-  private val requester: Requester,
+  private val requester: Requester<*>,
   private val postPaginatorProvider: MastodonProfilePostPaginator.Provider,
   override val id: String,
   override val account: Account,

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/type/editable/MastodonEditor.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/type/editable/MastodonEditor.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023–2024 Orcinus
+ * Copyright © 2023–2025 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -35,7 +35,7 @@ import kotlin.io.path.name
  *
  * @property requester [Requester] by which editing requests are performed.
  */
-internal class MastodonEditor(private val requester: Requester) : Editor {
+internal class MastodonEditor(private val requester: Requester<*>) : Editor {
   /** [URI] to which requests for editing a [MastodonEditableProfile] are to be sent. */
   private val editRoute: HostedURLBuilder.() -> URI = {
     path("api").path("v1").path("accounts").path("update_credentials").build()

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/type/followable/MastodonFollowService.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/type/followable/MastodonFollowService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Orcinus
+ * Copyright © 2024–2025 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -28,7 +28,7 @@ import br.com.orcinus.orca.core.mastodon.instance.requester.authentication.authe
  * @property requester [Requester] by which the HTTP requests are sent.
  */
 class MastodonFollowService(
-  private val requester: Requester,
+  private val requester: Requester<*>,
   override val profileProvider: MastodonProfileProvider
 ) : FollowService() {
   override suspend fun <T : Follow> setFollow(profile: FollowableProfile<T>, follow: T) {

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/notification/push/PushNotificationService.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/notification/push/PushNotificationService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Orcinus
+ * Copyright © 2024–2025 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -57,7 +57,7 @@ import kotlinx.serialization.builtins.ListSerializer
 @InternalNotificationApi
 internal class PushNotificationService
 @VisibleForTesting
-constructor(private val requester: Requester, private val webPushClient: WebPushClient) :
+constructor(private val requester: Requester<*>, private val webPushClient: WebPushClient) :
   Service() {
   /** [Binder] for interprocess communication (IPC). */
   private var binder: Binder? = null

--- a/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/auth/MastodonAuthenticationLockTests.kt
+++ b/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/auth/MastodonAuthenticationLockTests.kt
@@ -47,6 +47,7 @@ internal class MastodonAuthenticationLockTests {
           actorProvider
         )
         .scheduleUnlock {}
+        .getValueOrThrow()
     }
     assertThat(hasUnlocked, name = "hasUnlocked").isTrue()
     notificationLock.close()
@@ -64,7 +65,7 @@ internal class MastodonAuthenticationLockTests {
           authenticator,
           actorProvider
         )
-        .apply { repeat(2) { scheduleUnlock {} } }
+        .apply { repeat(2) { scheduleUnlock {}.getValueOrThrow() } }
     }
     assertThat(unlockCount, name = "unlockCount").isEqualTo(1)
     notificationLock.close()

--- a/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/feed/profile/account/MastodonAccountTests.kt
+++ b/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/feed/profile/account/MastodonAccountTests.kt
@@ -18,8 +18,11 @@ package br.com.orcinus.orca.core.mastodon.feed.profile.account
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
+import assertk.assertions.isInstanceOf
 import assertk.assertions.isTrue
+import assertk.assertions.prop
 import assertk.coroutines.assertions.suspendCall
+import br.com.orcinus.orca.core.auth.AuthenticationLock
 import br.com.orcinus.orca.core.auth.actor.Actor
 import br.com.orcinus.orca.core.feed.profile.search.ProfileSearchResult
 import br.com.orcinus.orca.core.feed.profile.type.followable.Follow
@@ -33,40 +36,70 @@ import br.com.orcinus.orca.core.sample.test.image.NoOpSampleImageLoader
 import br.com.orcinus.orca.core.test.auth.AuthenticationLock
 import br.com.orcinus.orca.core.test.auth.AuthorizerBuilder
 import br.com.orcinus.orca.ext.uri.URIBuilder
-import br.com.orcinus.orca.platform.core.image.createSample
-import br.com.orcinus.orca.std.image.compose.async.AsyncImageLoader
+import br.com.orcinus.orca.platform.testing.context
+import br.com.orcinus.orca.std.func.test.monad.isFailed
+import br.com.orcinus.orca.std.func.test.monad.isSuccessful
+import br.com.orcinus.orca.std.image.android.AsyncImageLoader
+import java.lang.ref.WeakReference
 import kotlin.test.Test
 import kotlinx.coroutines.test.runTest
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
+@RunWith(RobolectricTestRunner::class)
 internal class MastodonAccountTests {
   private val authorizer = AuthorizerBuilder().build()
   private val imageLoaderProvider = NoOpSampleImageLoader.Provider
-  private val actorAvatarLoader = imageLoaderProvider.provide(AuthorImageSource.Default)
-  private val actor = Actor.Authenticated.createSample(actorAvatarLoader)
-  private val actorProvider = SampleActorProvider(actor)
+
+  @Test
+  fun ownershipCheckFailsWhenAuthenticationFails() {
+    val authenticationLock =
+      AuthenticationLock(authorizer, SampleActorProvider(Actor.Unauthenticated))
+    runTest {
+      assertThat(MastodonAccount)
+        .prop("default") { it.default }
+        .transform("isOwned") { it.isOwned(authenticationLock) }
+        .isFailed()
+        .isInstanceOf<AuthenticationLock.FailedAuthenticationException>()
+    }
+  }
 
   @Test
   fun isOwned() {
+    val actorAvatarLoader = imageLoaderProvider.provide(AuthorImageSource.Default)
+    val actor = Actor.Authenticated.createSample(actorAvatarLoader)
+    val actorProvider = SampleActorProvider(actor)
     val authenticationLock = AuthenticationLock(authorizer, actorProvider)
     runTest {
-      assertThat(MastodonAccount.default.copy(id = actor.id))
+      assertThat(MastodonAccount)
+        .prop("default") { it.default }
+        .transform("copy") { it.copy(id = actor.id) }
         .suspendCall("isOwned") { it.isOwned(authenticationLock) }
+        .isSuccessful()
         .isTrue()
     }
   }
 
   @Test
   fun isNotOwned() {
+    val actorAvatarLoader = imageLoaderProvider.provide(AuthorImageSource.Default)
+    val actor = Actor.Authenticated.createSample(actorAvatarLoader)
+    val actorProvider = SampleActorProvider(actor)
     val authenticationLock = AuthenticationLock(authorizer, actorProvider)
     runTest {
-      assertThat(MastodonAccount.default)
+      assertThat(MastodonAccount)
+        .prop("default") { it.default }
         .suspendCall("isOwned") { it.isOwned(authenticationLock) }
+        .isSuccessful()
         .isFalse()
     }
   }
 
   @Test
   fun convertsIntoProfileSearchResult() {
+    val actorAvatarLoader = imageLoaderProvider.provide(AuthorImageSource.Default)
+    val actor = Actor.Authenticated.createSample(actorAvatarLoader)
+    val actorProvider = SampleActorProvider(actor)
     val composer =
       SampleInstance.Builder.create(actorProvider, imageLoaderProvider)
         .withDefaultProfiles()
@@ -83,26 +116,29 @@ internal class MastodonAccountTests {
         .path(composer.id)
         .path("avatar")
         .build()
+    val profileSearchResultAvatarLoader = AsyncImageLoader.Provider(WeakReference(context))
     assertThat(
         MastodonAccount(
-            composer.id,
-            composer.account.username.toString(),
-            acct = "${composer.account}",
-            "${composer.uri}",
-            displayName = composer.name,
-            locked = (composer as? FollowableProfile<*>)?.follow is Follow.Private,
-            note = "${composer.bio}",
-            avatar = "$avatarURI",
-            followersCount = composer.followerCount,
-            composer.followingCount
-          )
-          .toProfileSearchResult(avatarLoaderProvider = AsyncImageLoader.Provider)
+          composer.id,
+          composer.account.username.toString(),
+          acct = "${composer.account}",
+          "${composer.uri}",
+          displayName = composer.name,
+          locked = (composer as? FollowableProfile<*>)?.follow is Follow.Private,
+          note = "${composer.bio}",
+          avatar = "$avatarURI",
+          followersCount = composer.followerCount,
+          composer.followingCount
+        )
       )
+      .transform("toProfileSearchResult") {
+        it.toProfileSearchResult(profileSearchResultAvatarLoader)
+      }
       .isEqualTo(
         ProfileSearchResult(
           composer.id,
           composer.account,
-          AsyncImageLoader.Provider.provide(avatarURI),
+          profileSearchResultAvatarLoader.provide(avatarURI),
           composer.name,
           composer.uri
         )

--- a/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/pagination/MastodonPostPaginatorScope.kt
+++ b/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/pagination/MastodonPostPaginatorScope.kt
@@ -88,7 +88,7 @@ private data class RoutesImpl(
  *   upon pagination.
  */
 private class MastodonPostPaginatorScopeImpl(
-  requesterScope: RequesterTestScope<Requester>,
+  requesterScope: RequesterTestScope<Requester<AuthenticationLock.FailedAuthenticationException>>,
   authenticationLock: SomeAuthenticationLock
 ) : MastodonPostPaginatorScope(requesterScope, authenticationLock)
 
@@ -142,7 +142,8 @@ internal sealed class Routes {
  * @see runMastodonPostPaginatorTest
  */
 internal sealed class MastodonPostPaginatorScope(
-  private val requesterScope: RequesterTestScope<Requester>,
+  private val requesterScope:
+    RequesterTestScope<Requester<AuthenticationLock.FailedAuthenticationException>>,
   authenticationLock: SomeAuthenticationLock
 ) :
   MastodonPostPaginator<Any>(authenticationLock, requesterScope),

--- a/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/instance/requester/ConfigurationBuilderTests.kt
+++ b/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/instance/requester/ConfigurationBuilderTests.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Orcinus
+ * Copyright © 2024–2025 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -16,32 +16,37 @@
 package br.com.orcinus.orca.core.mastodon.instance.requester
 
 import assertk.assertThat
-import assertk.assertions.containsAll
+import assertk.assertions.containsAtLeast
+import assertk.assertions.prop
+import assertk.coroutines.assertions.suspendCall
+import br.com.orcinus.orca.std.func.test.monad.isSuccessful
 import com.google.common.net.HttpHeaders
+import io.ktor.client.request.HttpRequest
+import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.request
+import io.ktor.http.Headers
 import io.ktor.util.flattenEntries
 import kotlin.test.Test
 
 internal class ConfigurationBuilderTests {
   @Test
-  fun appendsHeaders() {
-    runRequesterTest {
-      assertThat(
-          requester
-            .get(route) {
-              headers {
-                append(HttpHeaders.ACCEPT_LANGUAGE, "en-US")
-                append(HttpHeaders.AUTHORIZATION, "Bearer 0123")
-              }
-            }
-            .request
-            .headers
-            .flattenEntries()
-        )
-        .containsAll(
-          HttpHeaders.ACCEPT_LANGUAGE to "en-US",
-          HttpHeaders.AUTHORIZATION to "Bearer 0123"
-        )
-    }
+  fun appendsHeaders() = runRequesterTest {
+    assertThat(requester)
+      .suspendCall("get") {
+        it.get(route) {
+          headers {
+            append(HttpHeaders.ACCEPT_LANGUAGE, "en-US")
+            append(HttpHeaders.AUTHORIZATION, "Bearer 0123")
+          }
+        }
+      }
+      .isSuccessful()
+      .prop(HttpResponse::request)
+      .prop(HttpRequest::headers)
+      .prop(Headers::flattenEntries)
+      .containsAtLeast(
+        HttpHeaders.ACCEPT_LANGUAGE to "en-US",
+        HttpHeaders.AUTHORIZATION to "Bearer 0123"
+      )
   }
 }

--- a/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/instance/requester/RequesterTests.kt
+++ b/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/instance/requester/RequesterTests.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Orcinus
+ * Copyright © 2024–2025 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -16,9 +16,13 @@
 package br.com.orcinus.orca.core.mastodon.instance.requester
 
 import assertk.assertThat
+import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
+import assertk.coroutines.assertions.suspendCall
 import br.com.orcinus.orca.ext.uri.url.HostedURLBuilder
-import io.ktor.client.call.body
+import br.com.orcinus.orca.std.func.test.monad.isSuccessful
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
 import kotlin.test.Test
 
 internal class RequesterTests {
@@ -31,18 +35,25 @@ internal class RequesterTests {
   }
 
   @Test
-  fun deletes() {
-    runRequesterTest { assertThat(requester.delete(route).body<String>()).isEqualTo("") }
+  fun deletes() = runRequesterTest {
+    assertThat(requester)
+      .transform("delete") { it.delete(route) }
+      .isSuccessful()
+      .suspendCall("bodyAsText", HttpResponse::bodyAsText)
+      .isEmpty()
   }
 
   @Test
-  fun retriesDeleteTwiceAfterFailure() {
+  fun retriesDeleteTwiceAfterFailure() =
     assertThat(retryCountOf { requester.delete(route) }).isEqualTo(2)
-  }
 
   @Test
-  fun gets() {
-    runRequesterTest { assertThat(requester.get(route).body<String>()).isEqualTo("") }
+  fun gets() = runRequesterTest {
+    assertThat(requester)
+      .transform("get") { it.get(route) }
+      .isSuccessful()
+      .suspendCall("bodyAsText", HttpResponse::bodyAsText)
+      .isEmpty()
   }
 
   @Test

--- a/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/instance/requester/UrlEncodedConfigurationEmptyTests.kt
+++ b/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/instance/requester/UrlEncodedConfigurationEmptyTests.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Orcinus
+ * Copyright © 2024–2025 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -17,29 +17,34 @@ package br.com.orcinus.orca.core.mastodon.instance.requester
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import assertk.assertions.prop
+import assertk.coroutines.assertions.suspendCall
+import br.com.orcinus.orca.std.func.test.monad.isSuccessful
+import io.ktor.client.request.HttpRequest
 import io.ktor.client.request.forms.FormDataContent
+import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.request
 import io.ktor.http.parametersOf
 import kotlin.test.Test
 
 internal class UrlEncodedConfigurationEmptyTests {
   @Test
-  fun appendsParameters() {
-    runRequesterTest {
-      assertThat(
-          requester
-            .post(route) {
-              parameters {
-                append("id", "0")
-                append("name", "Jean")
-              }
-            }
-            .request
-            .content
-            .let { it as FormDataContent }
-            .formData
-        )
-        .isEqualTo(parametersOf("id" to listOf("0"), "name" to listOf("Jean")))
-    }
+  fun appendsParameters() = runRequesterTest {
+    assertThat(requester)
+      .suspendCall("post") {
+        it.post(route) {
+          parameters {
+            append("id", "0")
+            append("name", "Jean")
+          }
+        }
+      }
+      .isSuccessful()
+      .prop(HttpResponse::request)
+      .prop(HttpRequest::content)
+      .isInstanceOf<FormDataContent>()
+      .prop(FormDataContent::formData)
+      .isEqualTo(parametersOf("id" to listOf("0"), "name" to listOf("Jean")))
   }
 }

--- a/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/instance/requester/authentication/Assert.extensions.kt
+++ b/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/instance/requester/authentication/Assert.extensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023–2024 Orcinus
+ * Copyright © 2023–2025 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -17,18 +17,29 @@ package br.com.orcinus.orca.core.mastodon.instance.requester.authentication
 
 import assertk.Assert
 import assertk.assertThat
+import assertk.assertions.prop
+import br.com.orcinus.orca.core.auth.AuthenticationLock
 import br.com.orcinus.orca.core.mastodon.instance.requester.InternalRequesterApi
+import br.com.orcinus.orca.std.func.monad.Maybe
+import br.com.orcinus.orca.std.func.test.monad.isSuccessful
+import io.ktor.client.request.HttpRequest
 import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.request
 import io.ktor.http.Headers
 import io.ktor.http.HttpHeaders
 
 /**
- * Creates an [Assert] on the [response]'s authorization [Headers].
+ * Creates an [Assert] on the [responseMaybe]'s authorization [Headers].
  *
- * @param response [HttpResponse] whose header will be the basis of the [Assert].
+ * @param responseMaybe [Result] with a [HttpResponse] whose header will be the basis of the
+ *   [Assert].
  */
 @InternalRequesterApi
-internal fun assertThatRequestAuthorizationHeaderOf(response: HttpResponse): Assert<String?> {
-  return assertThat(response.request.headers[HttpHeaders.Authorization])
-}
+internal fun assertThatRequestAuthorizationHeaderOf(
+  responseMaybe: Maybe<AuthenticationLock.FailedAuthenticationException, HttpResponse>
+) =
+  assertThat(responseMaybe)
+    .isSuccessful()
+    .prop(HttpResponse::request)
+    .prop(HttpRequest::headers)
+    .transform("get") { it[HttpHeaders.Authorization] }

--- a/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/instance/requester/authentication/AuthenticatedRequesterTestScope.kt
+++ b/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/instance/requester/authentication/AuthenticatedRequesterTestScope.kt
@@ -15,6 +15,7 @@
 
 package br.com.orcinus.orca.core.mastodon.instance.requester.authentication
 
+import br.com.orcinus.orca.core.auth.AuthenticationLock
 import br.com.orcinus.orca.core.auth.SomeAuthenticationLock
 import br.com.orcinus.orca.core.auth.actor.Actor
 import br.com.orcinus.orca.core.mastodon.instance.requester.ClientResponseProvider
@@ -46,7 +47,10 @@ import kotlinx.coroutines.Job
 internal inline fun runAuthenticatedRequesterTest(
   clientResponseProvider: ClientResponseProvider = ClientResponseProvider.ok,
   context: CoroutineContext = EmptyCoroutineContext,
-  crossinline body: suspend RequesterTestScope<Requester>.(lock: SomeAuthenticationLock) -> Unit
+  crossinline body:
+    suspend RequesterTestScope<Requester<AuthenticationLock.FailedAuthenticationException>>.(
+      lock: SomeAuthenticationLock
+    ) -> Unit
 ) {
   contract { callsInPlace(body, InvocationKind.EXACTLY_ONCE) }
   val avatarLoader = NoOpSampleImageLoader.Provider.provide(AuthorImageSource.Default)

--- a/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/instance/requester/authentication/AuthenticatedRequesterTestScopeTests.kt
+++ b/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/instance/requester/authentication/AuthenticatedRequesterTestScopeTests.kt
@@ -18,7 +18,10 @@ package br.com.orcinus.orca.core.mastodon.instance.requester.authentication
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isSameInstanceAs
+import assertk.coroutines.assertions.suspendCall
+import br.com.orcinus.orca.std.func.test.monad.isSuccessful
 import io.ktor.client.engine.mock.respondOk
+import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsText
 import kotlin.test.Test
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -32,11 +35,14 @@ internal class AuthenticatedRequesterTestScopeTests {
   }
 
   @Test
-  fun requestsAreRespondedTo() {
+  fun requestsAreRespondedTo() =
     runAuthenticatedRequesterTest({ respondOk("😶") }) {
-      assertThat(requester.get(route).bodyAsText()).isEqualTo("😶")
+      assertThat(requester)
+        .suspendCall("get") { it.get(route) }
+        .isSuccessful()
+        .suspendCall("bodyAsText", HttpResponse::bodyAsText)
+        .isEqualTo("😶")
     }
-  }
 
   @Test
   fun runsBodyInSpecifiedContext() {

--- a/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/instance/requester/authentication/AuthenticatedRequesterTests.kt
+++ b/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/instance/requester/authentication/AuthenticatedRequesterTests.kt
@@ -64,7 +64,7 @@ internal class AuthenticatedRequesterTests {
 
   @Test(expected = Injector.ModuleNotRegisteredException::class)
   fun throwsWhenCreatingAnAuthenticatedRequesterWithoutHavingRegisteredACoreModule() {
-    lateinit var requester: Requester
+    lateinit var requester: Requester<*>
     runRequesterTest { requester = this.requester }
     requester.authenticated()
   }

--- a/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/instance/requester/resumption/ResumableRequesterTestScope.kt
+++ b/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/instance/requester/resumption/ResumableRequesterTestScope.kt
@@ -21,6 +21,7 @@ import br.com.orcinus.orca.core.mastodon.instance.requester.CountingClientRespon
 import br.com.orcinus.orca.core.mastodon.instance.requester.InternalRequesterApi
 import br.com.orcinus.orca.core.mastodon.instance.requester.RequesterTestScope
 import br.com.orcinus.orca.core.mastodon.instance.requester.runRequesterTest
+import br.com.orcinus.orca.std.func.monad.Maybe
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.respondOk
 import io.ktor.client.statement.HttpResponse
@@ -79,11 +80,11 @@ internal inline fun resumptionCountOf(
 @InternalRequesterApi
 @OptIn(ExperimentalContracts::class)
 internal inline fun responseCountOf(
-  crossinline request: suspend RequesterTestScope<ResumableRequester>.() -> HttpResponse
+  crossinline request: suspend RequesterTestScope<ResumableRequester>.() -> Maybe<*, HttpResponse>
 ): Int {
   contract { callsInPlace(request, InvocationKind.EXACTLY_ONCE) }
   val clientResponseProvider = CountingClientResponseProvider(ClientResponseProvider.ok)
-  runResumableRequesterTest(clientResponseProvider) { request() }
+  runResumableRequesterTest(clientResponseProvider) { request().getValueOrThrow() }
   return clientResponseProvider.count
 }
 

--- a/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/instance/requester/resumption/ResumableRequesterTests.kt
+++ b/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/instance/requester/resumption/ResumableRequesterTests.kt
@@ -43,7 +43,7 @@ internal class ResumableRequesterTests {
       val resumableRequester = requester.resumable(firstElapsedTimeProvider, requestDao)
       val anotherElapsedTimeProvider = ResumableRequester.ElapsedTimeProvider(Duration::ZERO)
       assertThat(this)
-        .prop(RequesterTestScope<Requester>::requester)
+        .prop(RequesterTestScope<Requester<*>>::requester)
         .transform("resumable") { it.resumable(anotherElapsedTimeProvider, requestDao) }
         .isNotSameInstanceAs(resumableRequester)
     }
@@ -56,7 +56,7 @@ internal class ResumableRequesterTests {
       val resumableRequester = requester.resumable(elapsedTimeProvider, firstRequestDao)
       val anotherRequestDao = InMemoryRequestDao()
       assertThat(this)
-        .prop(RequesterTestScope<Requester>::requester)
+        .prop(RequesterTestScope<Requester<*>>::requester)
         .transform("resumable") { it.resumable(elapsedTimeProvider, anotherRequestDao) }
         .isNotSameInstanceAs(resumableRequester)
     }
@@ -67,7 +67,7 @@ internal class ResumableRequesterTests {
       val elapsedTimeProvider = ResumableRequester.ElapsedTimeProvider(Duration::ZERO)
       val requestDao = InMemoryRequestDao()
       assertThat(this)
-        .prop(RequesterTestScope<Requester>::requester)
+        .prop(RequesterTestScope<Requester<*>>::requester)
         .transform("resumable") { it.resumable(elapsedTimeProvider, requestDao) }
         .all {
           given { firstRequester ->
@@ -81,7 +81,7 @@ internal class ResumableRequesterTests {
 
   @Test
   fun throwsWhenConvertingARequesterIntoAResumableOneWithoutHavingInjectedAContextGlobally() {
-    lateinit var requester: Requester
+    lateinit var requester: Requester<*>
     runRequesterTest { requester = this.requester }
     assertFailure { requester.resumable() }.isInstanceOf<Module.DependencyNotInjectedException>()
   }
@@ -110,7 +110,7 @@ internal class ResumableRequesterTests {
   fun reusesDeleteRequest() {
     assertThat(
         responseCountOf {
-          requester.delete(route)
+          requester.delete(route).getValueOrThrow()
           requester.delete(route)
         }
       )
@@ -121,7 +121,7 @@ internal class ResumableRequesterTests {
   fun reusesGetRequest() {
     assertThat(
         responseCountOf {
-          requester.get(route)
+          requester.get(route).getValueOrThrow()
           requester.get(route)
         }
       )
@@ -132,7 +132,7 @@ internal class ResumableRequesterTests {
   fun reusesPostRequest() {
     assertThat(
         responseCountOf {
-          requester.post(route)
+          requester.post(route).getValueOrThrow()
           requester.post(route)
         }
       )
@@ -143,7 +143,7 @@ internal class ResumableRequesterTests {
   fun stalesGetRequestAfterItsTimeToLiveHasPassed() {
     assertThat(
         responseCountOf {
-          requester.get(route)
+          requester.get(route).getValueOrThrow()
           delay(ResumableRequester.timeToLive + 1.nanoseconds)
           requester.get(route)
         }
@@ -155,7 +155,7 @@ internal class ResumableRequesterTests {
   fun stalesDeleteRequestAfterItsTimeToLiveHasPassed() {
     assertThat(
         responseCountOf {
-          requester.delete(route)
+          requester.delete(route).getValueOrThrow()
           delay(ResumableRequester.timeToLive + 1.nanoseconds)
           requester.delete(route)
         }
@@ -167,7 +167,7 @@ internal class ResumableRequesterTests {
   fun stalesPostRequestAfterItsTimeToLiveHasPassed() {
     assertThat(
         responseCountOf {
-          requester.post(route)
+          requester.post(route).getValueOrThrow()
           delay(ResumableRequester.timeToLive + 1.nanoseconds)
           requester.post(route)
         }

--- a/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/instance/requester/resumption/ResumableRequesters.kt
+++ b/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/instance/requester/resumption/ResumableRequesters.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.test.currentTime
  *
  * @param coroutineScope [TestScope] by which the elapsed time is provided.
  */
-internal fun Requester.resumable(coroutineScope: TestScope) =
+internal fun Requester<*>.resumable(coroutineScope: TestScope) =
   resumable(
     { @OptIn(ExperimentalCoroutinesApi::class) coroutineScope.currentTime.milliseconds },
     InMemoryRequestDao()

--- a/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/notification/push/NotificationsClientResponseProviderTests.kt
+++ b/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/notification/push/NotificationsClientResponseProviderTests.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Orcinus
+ * Copyright © 2024–2025 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -18,11 +18,13 @@ package br.com.orcinus.orca.core.mastodon.notification.push
 import assertk.assertThat
 import assertk.assertions.containsExactly
 import assertk.assertions.isEmpty
+import assertk.coroutines.assertions.suspendCall
 import br.com.orcinus.orca.core.mastodon.feed.profile.account.MastodonAccount
 import br.com.orcinus.orca.core.mastodon.feed.profile.post.status.MastodonStatus
 import br.com.orcinus.orca.core.mastodon.instance.requester.runRequesterTest
 import br.com.orcinus.orca.ext.uri.url.HostedURLBuilder
-import io.ktor.client.call.body
+import br.com.orcinus.orca.std.func.test.monad.isSuccessful
+import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsText
 import java.net.URI
 import java.time.ZonedDateTime
@@ -37,7 +39,8 @@ internal class NotificationsClientResponseProviderTests {
       baseURI = requester.baseURI
       assertThat(requester)
         .transform("get") { it.get(route) }
-        .transform("body") { it.body<String>() }
+        .isSuccessful()
+        .suspendCall("bodyAsText", HttpResponse::bodyAsText)
         .isEmpty()
     }
   }
@@ -59,7 +62,8 @@ internal class NotificationsClientResponseProviderTests {
       baseURI = requester.baseURI
       assertThat(requester)
         .transform("get") { it.get(HostedURLBuilder::buildNotificationsRoute) }
-        .transform { it.bodyAsText() }
+        .isSuccessful()
+        .suspendCall("bodyAsText", HttpResponse::bodyAsText)
         .transform("Json.decodeFromString") {
           Json.decodeFromString(PushNotificationService.dtosSerializer, it)
         }

--- a/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/notification/push/PushNotificationServiceTestScope.kt
+++ b/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/notification/push/PushNotificationServiceTestScope.kt
@@ -38,7 +38,7 @@ import org.robolectric.android.controller.ServiceController
  * Default implementation of a [PushNotificationServiceTestScope] which will be used in the tests.
  */
 private class PushNotificationServiceEnvironment(
-  override val requester: Requester,
+  override val requester: Requester<*>,
   override val clientResponseProvider: NotificationsClientResponseProvider,
   override val context: Context,
   delegate: TestScope
@@ -57,7 +57,7 @@ internal sealed class PushNotificationServiceTestScope : CoroutineScope {
   protected abstract val context: Context
 
   /** [Requester] by which subscriptions are pushed. */
-  abstract val requester: Requester
+  abstract val requester: Requester<*>
 
   /** [NotificationsClientResponseProvider] by which responses to requests are provided. */
   abstract val clientResponseProvider: NotificationsClientResponseProvider

--- a/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/notification/push/PushNotificationServiceTests.kt
+++ b/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/notification/push/PushNotificationServiceTests.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Orcinus
+ * Copyright © 2024–2025 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -64,7 +64,7 @@ internal class PushNotificationServiceTests {
   fun instantiatingFromEmptyConstructorRetrievesInjectedRequester() {
     var isRetrieved = false
     runAuthenticatedRequesterTest {
-      Injector.injectLazily<Requester> {
+      Injector.injectLazily<Requester<*>> {
         isRetrieved = true
         requester
       }

--- a/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/notification/push/PushNotificationTests.kt
+++ b/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/notification/push/PushNotificationTests.kt
@@ -32,6 +32,7 @@ import br.com.orcinus.orca.core.sample.auth.SampleAuthenticator
 import br.com.orcinus.orca.core.sample.auth.SampleAuthorizer
 import br.com.orcinus.orca.core.sample.auth.actor.SampleActorProvider
 import br.com.orcinus.orca.platform.testing.context
+import br.com.orcinus.orca.std.func.test.monad.isSuccessful
 import java.time.ZonedDateTime
 import kotlin.test.Test
 import kotlinx.coroutines.test.runTest
@@ -129,6 +130,7 @@ internal class PushNotificationTests {
             .suspendCall("toNotification") { pushNotification ->
               pushNotification.toNotification(context, authenticationLock)
             }
+            .isSuccessful()
             .prop(Notification::getChannelId)
             .isSameInstanceAs(type.channelID)
         }
@@ -152,6 +154,7 @@ internal class PushNotificationTests {
             .suspendCall("toNotification") { pushNotification ->
               pushNotification.toNotification(context, authenticationLock)
             }
+            .isSuccessful()
             .prop(Notification::flags)
             .prop("isAutoCancelled", Notification.FLAG_AUTO_CANCEL::and)
             .isNotZero()
@@ -176,15 +179,18 @@ internal class PushNotificationTests {
             .suspendCall("toNotification") { transformationDto ->
               transformationDto.toNotification(context, authenticationLock)
             }
+            .isSuccessful()
             .prop(Notification::extras)
             .prop("title") { notification -> notification.getString(Notification.EXTRA_TITLE) }
             .isEqualTo(
-              type.getContentTitle(
-                context,
-                authenticationLock,
-                pushNotification.account,
-                pushNotification.status
-              )
+              type
+                .getContentTitle(
+                  context,
+                  authenticationLock,
+                  pushNotification.account,
+                  pushNotification.status
+                )
+                .getValueOrThrow()
             )
         }
       }
@@ -207,6 +213,7 @@ internal class PushNotificationTests {
             .suspendCall("toNotification") { pushNotification ->
               pushNotification.toNotification(context, authenticationLock)
             }
+            .isSuccessful()
             .all {
               prop(Notification::extras)
                 .prop("showWhen") { it.getBoolean(Notification.EXTRA_SHOW_WHEN) }

--- a/core/sample/src/main/java/br/com/orcinus/orca/core/sample/feed/profile/SampleProfile.kt
+++ b/core/sample/src/main/java/br/com/orcinus/orca/core/sample/feed/profile/SampleProfile.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023–2024 Orcinus
+ * Copyright © 2023–2025 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -27,6 +27,7 @@ import br.com.orcinus.orca.core.sample.auth.actor.sample
 import br.com.orcinus.orca.core.sample.feed.profile.composition.Composer
 import br.com.orcinus.orca.core.sample.feed.profile.post.stat.addable.SampleAddableStat
 import br.com.orcinus.orca.ext.uri.URIBuilder
+import br.com.orcinus.orca.std.func.monad.Maybe
 import java.time.ZonedDateTime
 import java.util.UUID
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -97,9 +98,13 @@ internal abstract class SampleProfile(private val delegate: Author) : Composer {
 
   /** [OwnedPost] that can be removed from the [Composer]. */
   private inner class SampleOwnedPost(delegate: SamplePost) : OwnedPost(delegate) {
-    override suspend fun remove() {
-      postsFlow.value.find { post -> post.id == id }?.let { postsFlow.value -= it }
-    }
+    override suspend fun remove() =
+      try {
+        postsFlow.value -= postsFlow.value.single { post -> post.id == id }
+        Maybe.successful()
+      } catch (exception: Exception) {
+        Maybe.failed(exception)
+      }
   }
 
   override fun createPost(

--- a/core/sample/src/test/java/br/com/orcinus/orca/core/sample/feed/profile/composition/HardcodedComposer.kt
+++ b/core/sample/src/test/java/br/com/orcinus/orca/core/sample/feed/profile/composition/HardcodedComposer.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Orcinus
+ * Copyright © 2024–2025 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -29,6 +29,7 @@ import br.com.orcinus.orca.core.sample.feed.profile.post.stat.toggleable.SampleT
 import br.com.orcinus.orca.core.sample.image.SampleImageSource
 import br.com.orcinus.orca.core.sample.test.image.NoOpSampleImageLoader
 import br.com.orcinus.orca.ext.uri.URIBuilder
+import br.com.orcinus.orca.std.func.monad.Maybe
 import br.com.orcinus.orca.std.markdown.Markdown
 import java.time.ZonedDateTime
 import java.util.UUID
@@ -89,8 +90,9 @@ internal class HardcodedComposer : Composer {
       override suspend fun toOwnedPost(): OwnedPost {
         return let {
           object : OwnedPost(it) {
-            override suspend fun remove() {
+            override suspend fun remove(): Maybe<*, Unit> {
               postsFlow.value -= it
+              return Maybe.successful()
             }
           }
         }

--- a/core/sample/src/test/java/br/com/orcinus/orca/core/sample/feed/profile/post/SamplePostProviderTests.kt
+++ b/core/sample/src/test/java/br/com/orcinus/orca/core/sample/feed/profile/post/SamplePostProviderTests.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023–2024 Orcinus
+ * Copyright © 2023–2025 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -66,7 +66,9 @@ internal class SamplePostProviderTests {
           .build()
           .postProvider
       val deletedPost =
-        postProvider.provideOneCurrent().own().apply { (this as OwnedPost).remove() }
+        postProvider.provideOneCurrent().own().apply {
+          (this as OwnedPost).remove().getValueOrThrow()
+        }
       val posts = postProvider.provideAllCurrent()
       assertThat(posts).doesNotContain(deletedPost)
     }

--- a/core/src/main/java/br/com/orcinus/orca/core/feed/profile/post/OwnedPost.kt
+++ b/core/src/main/java/br/com/orcinus/orca/core/feed/profile/post/OwnedPost.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023–2024 Orcinus
+ * Copyright © 2023–2025 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -17,6 +17,7 @@ package br.com.orcinus.orca.core.feed.profile.post
 
 import br.com.orcinus.orca.core.InternalCoreApi
 import br.com.orcinus.orca.core.auth.actor.Actor
+import br.com.orcinus.orca.std.func.monad.Maybe
 
 /**
  * [Post] that belongs to the authenticated [Actor].
@@ -39,7 +40,7 @@ abstract class OwnedPost @InternalCoreApi constructor(private val delegate: Post
   }
 
   /** Removes this [OwnedPost]. */
-  abstract suspend fun remove()
+  abstract suspend fun remove(): Maybe<*, Unit>
 
   companion object
 }

--- a/core/src/test/java/br/com/orcinus/orca/core/feed/profile/account/reblog/RepostTests.kt
+++ b/core/src/test/java/br/com/orcinus/orca/core/feed/profile/account/reblog/RepostTests.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023–2024 Orcinus
+ * Copyright © 2023–2025 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -21,6 +21,7 @@ import br.com.orcinus.orca.core.feed.profile.post.repost.Repost
 import br.com.orcinus.orca.core.sample.auth.actor.sample
 import br.com.orcinus.orca.core.sample.instance.SampleInstance
 import br.com.orcinus.orca.core.sample.test.image.NoOpSampleImageLoader
+import br.com.orcinus.orca.std.func.monad.Maybe
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -53,7 +54,7 @@ internal class RepostTests {
         override suspend fun toOwnedPost(): OwnedPost {
           return let {
             object : OwnedPost(it) {
-              override suspend fun remove() {}
+              override suspend fun remove() = Maybe.successful()
             }
           }
         }
@@ -71,7 +72,7 @@ internal class RepostTests {
         sampleRepost.uri
       ) {
         object : OwnedPost(it) {
-          override suspend fun remove() {}
+          override suspend fun remove() = Maybe.successful()
         }
       }
     )

--- a/core/src/test/java/br/com/orcinus/orca/core/feed/profile/post/OwnedPostTests.kt
+++ b/core/src/test/java/br/com/orcinus/orca/core/feed/profile/post/OwnedPostTests.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023–2024 Orcinus
+ * Copyright © 2023–2025 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -20,6 +20,7 @@ import assertk.assertions.isTrue
 import br.com.orcinus.orca.core.sample.instance.SampleInstance
 import br.com.orcinus.orca.core.sample.test.image.NoOpSampleImageLoader
 import br.com.orcinus.orca.ext.testing.hasPropertiesEqualToThoseOf
+import br.com.orcinus.orca.std.func.monad.Maybe
 import kotlin.test.Test
 import kotlinx.coroutines.test.runTest
 
@@ -35,7 +36,7 @@ internal class OwnedPostTests {
         .provideOneCurrent()
     val ownedPost =
       object : OwnedPost(delegatePost) {
-        override suspend fun remove() {}
+        override suspend fun remove() = Maybe.successful()
       }
     assertThat(ownedPost).hasPropertiesEqualToThoseOf(delegatePost)
   }
@@ -52,12 +53,14 @@ internal class OwnedPostTests {
           .provideOneCurrent()
       var hasBeenDeleted = false
       object : OwnedPost(delegatePost) {
-          override suspend fun remove() {
+          override suspend fun remove(): Maybe<*, Unit> {
             hasBeenDeleted = true
+            return Maybe.successful()
           }
         }
         .remove()
-      assertThat(hasBeenDeleted).isTrue()
+        .getValueOrThrow()
+      assertThat(hasBeenDeleted, name = "hasBeenDeleted").isTrue()
     }
   }
 }

--- a/feature/composer/src/main/java/br/com/orcinus/orca/feature/composer/Composer.kt
+++ b/feature/composer/src/main/java/br/com/orcinus/orca/feature/composer/Composer.kt
@@ -71,10 +71,10 @@ internal fun Composer(
   onBackwardsNavigation: () -> Unit,
   modifier: Modifier = Modifier
 ) {
-  val avatarLoader by viewModel.avatarLoaderDeferred.collectAsState(initialValue = null)
+  val avatarLoaderResult by viewModel.avatarLoaderDeferredResult.collectAsState(initialValue = null)
 
   Composer(
-    avatarLoader,
+    avatarLoaderResult?.getValueOrNull(),
     onTextChange = viewModel::setText,
     onCompose = viewModel::compose,
     onBackwardsNavigation,

--- a/feature/composer/src/main/java/br/com/orcinus/orca/feature/composer/ComposerModule.kt
+++ b/feature/composer/src/main/java/br/com/orcinus/orca/feature/composer/ComposerModule.kt
@@ -15,6 +15,7 @@
 
 package br.com.orcinus.orca.feature.composer
 
+import br.com.orcinus.orca.std.func.monad.Maybe
 import br.com.orcinus.orca.std.image.android.AndroidImageLoader
 import br.com.orcinus.orca.std.injector.module.Inject
 import br.com.orcinus.orca.std.injector.module.Module
@@ -22,5 +23,6 @@ import br.com.orcinus.orca.std.injector.module.injection.Injection
 import kotlinx.coroutines.Deferred
 
 abstract class ComposerModule : Module() {
-  @Inject abstract val avatarLoaderDeferred: Injection<Deferred<AndroidImageLoader<*>>>
+  @Inject
+  abstract val avatarLoaderDeferred: Injection<out Deferred<Maybe<*, AndroidImageLoader<*>>>>
 }

--- a/feature/composer/src/main/java/br/com/orcinus/orca/feature/composer/ComposerViewModel.kt
+++ b/feature/composer/src/main/java/br/com/orcinus/orca/feature/composer/ComposerViewModel.kt
@@ -18,13 +18,15 @@ package br.com.orcinus.orca.feature.composer
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
+import br.com.orcinus.orca.std.func.monad.Maybe
 import br.com.orcinus.orca.std.image.android.AndroidImageLoader
 import br.com.orcinus.orca.std.markdown.Markdown
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.flow.MutableStateFlow
 
 internal class ComposerViewModel
-private constructor(val avatarLoaderDeferred: Deferred<AndroidImageLoader<*>>) : ViewModel() {
+private constructor(val avatarLoaderDeferredResult: Deferred<Maybe<*, AndroidImageLoader<*>>>) :
+  ViewModel() {
   private val textFlow = MutableStateFlow(Markdown.empty)
 
   fun setText(text: Markdown) {
@@ -35,8 +37,9 @@ private constructor(val avatarLoaderDeferred: Deferred<AndroidImageLoader<*>>) :
 
   companion object {
     @JvmStatic
-    fun createFactory(avatarLoaderDeferred: Deferred<AndroidImageLoader<*>>) = viewModelFactory {
-      initializer { ComposerViewModel(avatarLoaderDeferred) }
-    }
+    fun createFactory(avatarLoaderDeferred: Deferred<Maybe<*, AndroidImageLoader<*>>>) =
+      viewModelFactory {
+        initializer { ComposerViewModel(avatarLoaderDeferred) }
+      }
   }
 }

--- a/feature/composer/src/test/java/br/com/orcinus/orca/feature/composer/SampleComposerModule.kt
+++ b/feature/composer/src/test/java/br/com/orcinus/orca/feature/composer/SampleComposerModule.kt
@@ -18,6 +18,7 @@ package br.com.orcinus.orca.feature.composer
 import br.com.orcinus.orca.core.sample.image.AuthorImageSource
 import br.com.orcinus.orca.platform.core.image.createSample
 import br.com.orcinus.orca.platform.testing.context
+import br.com.orcinus.orca.std.func.monad.Maybe
 import br.com.orcinus.orca.std.image.android.AndroidImageLoader
 import br.com.orcinus.orca.std.injector.module.injection.Injection
 import br.com.orcinus.orca.std.injector.module.injection.lazyInjectionOf
@@ -25,9 +26,12 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Deferred
 
 internal object SampleComposerModule : ComposerModule() {
-  override val avatarLoaderDeferred: Injection<Deferred<AndroidImageLoader<*>>> = lazyInjectionOf {
-    CompletableDeferred(
-      AndroidImageLoader.Provider.createSample(context).provide(AuthorImageSource.Default)
-    )
-  }
+  override val avatarLoaderDeferred: Injection<Deferred<Maybe<*, AndroidImageLoader<*>>>> =
+    lazyInjectionOf {
+      CompletableDeferred(
+        Maybe.successful<Exception, _>(
+          AndroidImageLoader.Provider.createSample(context).provide(AuthorImageSource.Default)
+        )
+      )
+    }
 }

--- a/std/func-test/src/main/java/br/com/orcinus/orca/std/func/test/monad/Assertions.kt
+++ b/std/func-test/src/main/java/br/com/orcinus/orca/std/func/test/monad/Assertions.kt
@@ -28,12 +28,13 @@ import org.opentest4j.AssertionFailedError
 /**
  * Asserts that the [Maybe] holds a successful value.
  *
- * @param R The successful value.
+ * @param V The successful value.
  * @throws AssertionFailedError If the [Maybe] holds a failure.
  */
-fun <R> Assert<Maybe<*, R>>.isSuccessful() =
+@Throws(AssertionFailedError::class)
+fun <V> Assert<Maybe<*, V>>.isSuccessful() =
   try {
-    prop(Maybe<*, R>::getValueOrThrow)
+    prop(Maybe<*, V>::getValueOrThrow)
   } catch (exception: Exception) {
     expected("to be successful but was failed:${show(exception)}")
   }
@@ -41,13 +42,18 @@ fun <R> Assert<Maybe<*, R>>.isSuccessful() =
 /**
  * Asserts that the [Maybe] holds a failure.
  *
- * @param L [Exception] because of which the value cannot be obtained.
+ * @param E [Exception] because of which the value cannot be obtained.
  * @throws AssertionFailedError If the [Maybe] holds a successful value.
  */
-fun <L : Exception> Assert<Maybe<L, *>>.isFailed() =
+@Throws(AssertionFailedError::class)
+fun <E : Exception> Assert<Maybe<E, *>>.isFailed() =
   transform {
-      it.takeIf(Maybe<L, *>::isFailed)
+      it.takeIf(Maybe<E, *>::isFailed)
         ?: expected("to be failed but was successful:${show(it.getValueOrThrow())}")
     }
-    .prop(Maybe<L, *>::getExceptionOrNull)
+    .prop(Maybe<E, *>::getExceptionOrNull)
+    .transform {
+      @Suppress("UNCHECKED_CAST")
+      it as E?
+    }
     .isNotNull()

--- a/std/func/src/test/java/br/com/orcinus/orca/std/func/monad/MaybeTests.kt
+++ b/std/func/src/test/java/br/com/orcinus/orca/std/func/monad/MaybeTests.kt
@@ -15,6 +15,7 @@
 
 package br.com.orcinus.orca.std.func.monad
 
+import assertk.all
 import assertk.assertThat
 import assertk.assertions.containsExactly
 import assertk.assertions.isEqualTo
@@ -46,6 +47,32 @@ internal class MaybeTests {
   @Test
   fun isFailedIsFalseWhenMaybeIsSuccessful() =
     assertThat(Maybe).successful<Exception, _>(0).prop(Maybe<Exception, Int>::isFailed).isFalse()
+
+  @Test
+  fun onSuccessfulReturnsMaybeWhenItIsSuccessful() =
+    assertThat(Maybe).successful<Exception, _>(0).all {
+      given { transform("onSuccessful") { maybe -> maybe.onSuccessful {} }.isEqualTo(it) }
+    }
+
+  @Test
+  fun onSuccessfulReturnsMaybeWhenItIsFailed() =
+    assertThat(Maybe).failed<_, Any>(exception).all {
+      given { transform("onSuccessful") { maybe -> maybe.onSuccessful {} }.isEqualTo(it) }
+    }
+
+  @Test
+  fun doesNotCallSuccessfulCallbackWhenMaybeIsFailed() {
+    var didCallCallback = false
+    Maybe.failed<_, Any>(exception).onSuccessful { didCallCallback = true }
+    assertThat(didCallCallback, name = "didCallCallback").isFalse()
+  }
+
+  @Test
+  fun callsSuccessfulCallbackWhenMaybeIsSuccessful() {
+    var didCallCallback = false
+    Maybe.successful<Exception, _>(0).onSuccessful { didCallCallback = true }
+    assertThat(didCallCallback, name = "didCallCallback").isTrue()
+  }
 
   @Test
   fun failsWhenJoiningEachElementOfAFailedIterableIntoASingleMaybe() =


### PR DESCRIPTION
Returns monads from [`AuthenticationLock`](https://github.com/orcinusbr/orca-android/blob/3da1e11ca1e22a00bba3c12075c4326deb92d786/core/src/main/java/br/com/orcinus/orca/core/auth/AuthenticationLock.kt)-based methods instead of throwing exceptions directly.