### PR TITLE
Handle `FeedProvider` errors functionally

### DIFF
--- a/app/src/main/java/br/com/orcinus/orca/app/activity/BottomNavigationFragmentProvider.kt
+++ b/app/src/main/java/br/com/orcinus/orca/app/activity/BottomNavigationFragmentProvider.kt
@@ -40,7 +40,7 @@ internal enum class BottomNavigationFragmentProvider {
     override val id = R.id.feed
 
     override suspend fun provide(backStack: BackStack, authenticationLock: SomeAuthenticationLock) =
-      authenticationLock.scheduleUnlock { FeedFragment(backStack, it.id) }
+      Maybe.successful<AuthenticationLock.FailedAuthenticationException, _>(FeedFragment(backStack))
   },
 
   /** Provider of a [Fragment] with the details of the profile of the authenticated [Actor]. */

--- a/app/src/main/java/br/com/orcinus/orca/app/activity/BottomNavigationFragmentProvider.kt
+++ b/app/src/main/java/br/com/orcinus/orca/app/activity/BottomNavigationFragmentProvider.kt
@@ -40,7 +40,7 @@ internal enum class BottomNavigationFragmentProvider {
     override val id = R.id.feed
 
     override suspend fun provide(backStack: BackStack, authenticationLock: SomeAuthenticationLock) =
-      Maybe.successful<AuthenticationLock.FailedAuthenticationException, _>(FeedFragment(backStack))
+      authenticationLock.scheduleUnlock { FeedFragment(backStack) }
   },
 
   /** Provider of a [Fragment] with the details of the profile of the authenticated [Actor]. */

--- a/composite/timeline-test/src/main/java/br/com/orcinus/orca/composite/timeline/test/post/SemanticsNodeInteraction.extensions.kt
+++ b/composite/timeline-test/src/main/java/br/com/orcinus/orca/composite/timeline/test/post/SemanticsNodeInteraction.extensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Orcinus
+ * Copyright © 2024–2025 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -24,12 +24,10 @@ import br.com.orcinus.orca.composite.timeline.post.PostPreview
 import br.com.orcinus.orca.composite.timeline.post.figure.gallery.GalleryPreview
 import br.com.orcinus.orca.composite.timeline.post.figure.link.LinkCard
 import br.com.orcinus.orca.composite.timeline.test.isTimeline
-import br.com.orcinus.orca.core.auth.actor.Actor
 import br.com.orcinus.orca.core.feed.profile.post.Post
 import br.com.orcinus.orca.core.sample.feed.SampleFeedProvider
 import br.com.orcinus.orca.core.sample.feed.profile.composition.Composer
 import br.com.orcinus.orca.core.sample.instance.SampleInstance
-import br.com.orcinus.orca.platform.core.sample
 
 /**
  * Scrolls to the first [PostPreview] containing a [GalleryPreview].
@@ -117,7 +115,8 @@ private fun findIndexedPost(
   predicate: (inPagePosts: List<Post>, foundPost: Post) -> Boolean
 ): IndexedValue<Post> {
   return feedProvider
-    .provideCurrent(Actor.Authenticated.sample.id, page)
+    .provideCurrent(page)
+    .getValueOrThrow()
     .ifEmpty { throw NoSuchElementException("No post matching the given predicate was found.") }
     .let { inPagePosts ->
       inPagePosts

--- a/composite/timeline/src/test/java/br/com/orcinus/orca/composite/timeline/post/conversion/PostToPostPreviewConversionScope.kt
+++ b/composite/timeline/src/test/java/br/com/orcinus/orca/composite/timeline/post/conversion/PostToPostPreviewConversionScope.kt
@@ -126,6 +126,7 @@ constructor(delegate: TestScope) : CoroutineScope by delegate {
         authenticator,
         authenticationLock,
         feedProvider,
+        SampleTermMuter(),
         profileProvider,
         profileSearcher,
         postProvider,

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/MastodonFeedProvider.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/MastodonFeedProvider.kt
@@ -35,5 +35,6 @@ internal constructor(
   override val termMuter: TermMuter,
   private val postPaginator: MastodonFeedPaginator
 ) : FeedProvider() {
-  override suspend fun onProvide(@Page page: Int) = postPaginator.paginateTo(page).getValueOrThrow()
+  override suspend fun onProvision(@Page page: Int) =
+    postPaginator.paginateTo(page).getValueOrThrow()
 }

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/MastodonFeedProvider.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/MastodonFeedProvider.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023–2024 Orcinus
+ * Copyright © 2023–2025 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -15,15 +15,12 @@
 
 package br.com.orcinus.orca.core.mastodon.feed
 
-import android.content.Context
 import br.com.orcinus.orca.core.auth.actor.Actor
 import br.com.orcinus.orca.core.auth.actor.ActorProvider
 import br.com.orcinus.orca.core.feed.FeedProvider
 import br.com.orcinus.orca.core.feed.profile.post.Post
 import br.com.orcinus.orca.core.feed.profile.post.content.TermMuter
-import br.com.orcinus.orca.core.mastodon.R
-import br.com.orcinus.orca.platform.autos.i18n.ReadableThrowable
-import kotlinx.coroutines.flow.Flow
+import br.com.orcinus.orca.core.mastodon.feed.profile.post.pagination.page.Page
 
 /**
  * [FeedProvider] that requests the feed's [Post]s to the API.
@@ -34,25 +31,9 @@ import kotlinx.coroutines.flow.Flow
  */
 class MastodonFeedProvider
 internal constructor(
-  private val context: Context,
   private val actorProvider: ActorProvider,
   override val termMuter: TermMuter,
   private val postPaginator: MastodonFeedPaginator
 ) : FeedProvider() {
-  override suspend fun containsUser(userID: String): Boolean {
-    return when (actorProvider.provide()) {
-      is Actor.Unauthenticated -> false
-      is Actor.Authenticated -> true
-    }
-  }
-
-  override fun createNonexistentUserException(): NonexistentUserException {
-    return NonexistentUserException(
-      cause = ReadableThrowable(context, R.string.core_mastodon_feed_provisioning_error)
-    )
-  }
-
-  override suspend fun onProvide(userID: String, page: Int): Flow<List<Post>> {
-    return postPaginator.paginateTo(page)
-  }
+  override suspend fun onProvide(@Page page: Int) = postPaginator.paginateTo(page).getValueOrThrow()
 }

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/MastodonProfile.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/MastodonProfile.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023–2024 Orcinus
+ * Copyright © 2023–2025 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -42,10 +42,10 @@ internal data class MastodonProfile(
 ) : Profile {
   private lateinit var postPaginator: MastodonProfilePostPaginator
 
-  override suspend fun getPosts(page: Int): Flow<List<Post>> {
+  override suspend fun onPostsObtainance(page: Int): Flow<List<Post>> {
     if (!::postPaginator.isInitialized) {
       postPaginator = postPaginatorProvider.provide(id)
     }
-    return postPaginator.paginateTo(page)
+    return postPaginator.paginateTo(page).getValueOrThrow()
   }
 }

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/pagination/Pagination.java
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/pagination/Pagination.java
@@ -16,9 +16,9 @@
 package br.com.orcinus.orca.core.mastodon.feed.profile.post.pagination;
 
 import androidx.annotation.NonNull;
+import br.com.orcinus.orca.core.feed.Pages;
 import br.com.orcinus.orca.core.feed.profile.post.Post;
 import br.com.orcinus.orca.core.mastodon.feed.profile.post.pagination.page.Page;
-import br.com.orcinus.orca.core.mastodon.feed.profile.post.pagination.page.Pages;
 import io.ktor.client.statement.HttpResponse;
 import kotlinx.coroutines.Deferred;
 

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/stat/comment/MastodonCommentStat.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/stat/comment/MastodonCommentStat.kt
@@ -21,9 +21,6 @@ import br.com.orcinus.orca.core.feed.profile.post.stat.addable.AddableStat
 import br.com.orcinus.orca.core.mastodon.feed.profile.post.MastodonPost
 import br.com.orcinus.orca.core.mastodon.instance.requester.Requester
 import br.com.orcinus.orca.core.mastodon.instance.requester.authentication.authenticated
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.emitAll
-import kotlinx.coroutines.flow.flow
 
 /**
  * [AddableStat] for adding comments to and removing them from a [MastodonPost]. Both the obtainance
@@ -43,9 +40,10 @@ internal class MastodonCommentStat(
   private val id: String,
   count: Int
 ) : AddableStat<Post>(count) {
-  override fun get(page: Int): Flow<List<Post>> {
-    return flow { emitAll(paginatorProvider.provide(id).paginateTo(page)) }
-  }
+  /** [MastodonCommentPaginator] for the specified [Post]. */
+  private val paginator = paginatorProvider.provide(id)
+
+  override fun get(page: Int) = paginator.paginateTo(page).getValueOrThrow()
 
   override suspend fun onAddition(element: Post) {
     requester.authenticated().post({ path("api").path("v1").path("statuses").build() }) {

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/instance/ContextualMastodonInstance.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/instance/ContextualMastodonInstance.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023–2024 Orcinus
+ * Copyright © 2023–2025 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -195,8 +195,7 @@ internal class ContextualMastodonInstance(
   /** [Cache] that decides how to obtain [MastodonPost]s. */
   private val postCache = Cache.of(context, name = "post-cache", postFetcher, postStorage)
 
-  override val feedProvider =
-    MastodonFeedProvider(context, actorProvider, termMuter, feedPostPaginator)
+  override val feedProvider = MastodonFeedProvider(actorProvider, termMuter, feedPostPaginator)
   override val profileProvider = MastodonProfileProvider(profileCache, context)
   override val profileSearcher = MastodonProfileSearcher(profileSearchResultsCache)
   override val postProvider = MastodonPostProvider(postCache)

--- a/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/pagination/Flows.kt
+++ b/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/pagination/Flows.kt
@@ -31,5 +31,5 @@ internal suspend fun <T> TurbineTestContext<T>.awaitItemOrThrowCause() =
   try {
     awaitItem()
   } catch (error: AssertionError) {
-    throw checkNotNull(error.cause)
+    throw error.cause ?: error
   }

--- a/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/pagination/MastodonPostPaginatorTests.kt
+++ b/core/mastodon/src/test/java/br/com/orcinus/orca/core/mastodon/feed/profile/post/pagination/MastodonPostPaginatorTests.kt
@@ -16,6 +16,7 @@
 package br.com.orcinus.orca.core.mastodon.feed.profile.post.pagination
 
 import app.cash.turbine.test
+import assertk.all
 import assertk.assertFailure
 import assertk.assertThat
 import assertk.assertions.cause
@@ -23,8 +24,9 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.isInstanceOf
 import assertk.assertions.isNotNull
 import assertk.assertions.prop
+import assertk.coroutines.assertions.suspendCall
+import br.com.orcinus.orca.core.feed.Pages
 import br.com.orcinus.orca.core.feed.profile.post.Post
-import br.com.orcinus.orca.core.mastodon.feed.profile.post.pagination.page.Pages
 import br.com.orcinus.orca.core.mastodon.feed.profile.post.pagination.type.KTypeCreator
 import br.com.orcinus.orca.core.mastodon.feed.profile.post.pagination.type.kTypeCreatorOf
 import br.com.orcinus.orca.core.mastodon.instance.requester.authentication.runAuthenticatedRequesterTest
@@ -33,6 +35,8 @@ import br.com.orcinus.orca.core.sample.feed.profile.post.content.SampleTermMuter
 import br.com.orcinus.orca.core.sample.instance.SampleInstanceProvider
 import br.com.orcinus.orca.core.sample.test.image.NoOpSampleImageLoader
 import br.com.orcinus.orca.ext.uri.url.HostedURLBuilder
+import br.com.orcinus.orca.std.func.test.monad.isFailed
+import br.com.orcinus.orca.std.func.test.monad.isSuccessful
 import br.com.orcinus.orca.std.injector.Injector
 import br.com.orcinus.orca.std.injector.module.injection.lazyInjectionOf
 import io.ktor.http.HttpMethod
@@ -40,79 +44,114 @@ import java.net.URI
 import kotlin.test.Test
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.launch
 
 internal class MastodonPostPaginatorTests {
   @Test
-  fun throwsWhenCountingPagesFromInvalidPage() = runMastodonPostPaginatorTest {
-    assertFailure { countPagesOrThrow(Pages.NONE, 0) }.isInstanceOf<Pages.InvalidException>()
+  fun failsWhenCountingPagesFromInvalidPage() = runMastodonPostPaginatorTest {
+    assertThat(this)
+      .transform("countPagesSafely") { it.countPagesSafely(Pages.NONE, 0) }
+      .isFailed()
+      .isInstanceOf<Pages.InvalidException>()
   }
 
   @Test
-  fun throwsWhenCountingPagesToInvalidPage() = runMastodonPostPaginatorTest {
-    assertFailure { countPagesOrThrow(Pages.NONE) }.isInstanceOf<Pages.InvalidException>()
+  fun failsWhenCountingPagesToInvalidPage() = runMastodonPostPaginatorTest {
+    assertThat(this)
+      .transform("countPagesSafely") { it.countPagesSafely(Pages.NONE) }
+      .isFailed()
+      .isInstanceOf<Pages.InvalidException>()
   }
 
   @Test
   fun countsPages() = runMastodonPostPaginatorTest {
-    assertThat(this).transform("countPages") { it.countPagesOrThrow(2) }.isEqualTo(3)
+    assertThat(this)
+      .transform("countPagesSafely") { it.countPagesSafely(2) }
+      .isSuccessful()
+      .isEqualTo(3)
   }
 
   @Test
-  fun throwsWhenPaginatingToInvalidPage() = runMastodonPostPaginatorTest {
-    assertFailure { paginateTo(Pages.NONE) }.isInstanceOf<Pages.InvalidException>()
+  fun failsWhenPaginatingToInvalidPage() = runMastodonPostPaginatorTest {
+    assertThat(this)
+      .suspendCall("paginateTo") { it.paginateTo(Pages.NONE) }
+      .isFailed()
+      .isInstanceOf<Pages.InvalidException>()
   }
 
   @Test
   fun sendsAGetRequestUponPagination() =
     runMastodonPostPaginatorTest({ method, _, _ -> assertThat(method).isEqualTo(HttpMethod.Get) }) {
-      paginateToAndAwait(0)
+      assertThat(this).suspendCall("paginateToAndAwait") { paginateToAndAwait(0) }.isSuccessful()
     }
 
   @Test
   fun paginatesToInitialRoute() {
     lateinit var requestRoute: URI
     runMastodonPostPaginatorTest({ _, _, route -> requestRoute = route }) {
-      paginateToAndAwait(0)
+      assertThat(this).suspendCall("paginateToAndAwait") { paginateToAndAwait(0) }.isSuccessful()
       assertThat(::routes).prop(Routes::initial).transform("matches") { it matches requestRoute }
     }
   }
 
   @Test
   fun refreshesInInitialRoute() = runMastodonPostPaginatorTest {
-    repeat(2) { paginateToAndAwait(0) }
+    repeat(2) {
+      assertThat(this).suspendCall("paginateToAndAwait") { paginateToAndAwait(0) }.isSuccessful()
+    }
     assertThat(::routes).prop(Routes::initial).prop(RouteSpec::hitCount).isEqualTo(2)
   }
 
   @Test
   fun refreshesInPreviousRoute() = runMastodonPostPaginatorTest {
-    paginateToAndAwait(1)
-    repeat(2) { paginateToAndAwait(0) }
+    assertThat(this).suspendCall("paginateToAndAwait") { paginateToAndAwait(1) }.isSuccessful()
+    repeat(2) {
+      assertThat(this).suspendCall("paginateToAndAwait") { paginateToAndAwait(0) }.isSuccessful()
+    }
     assertThat(::routes).prop(Routes::current).isNotNull().prop(RouteSpec::hitCount).isEqualTo(3)
   }
 
   @Test
   fun refreshesInNextRoute() = runMastodonPostPaginatorTest {
-    repeat(2) { paginateToAndAwait(1) }
+    repeat(2) {
+      assertThat(this).suspendCall("paginateToAndAwait") { it.paginateToAndAwait(1) }.isSuccessful()
+    }
     assertThat(::routes).prop(Routes::current).isNotNull().prop(RouteSpec::hitCount).isEqualTo(2)
   }
 
   @Test
   fun doesNotPaginateBackwardsWhenPreviousRouteIsNotLinked() =
     runMastodonPostPaginatorTest(previous = { page -> if (page < 1) previous else null }) {
-      paginateToAndAwait(1)
-      paginateTo(0).test {
-        awaitItem()
-        assertFailure { awaitItem() }.cause().isNotNull().isInstanceOf<CancellationException>()
+      assertThat(this).all {
+        launch {
+          suspendCall("paginateToAndAwait") { paginateToAndAwait(1) }.isSuccessful()
+          suspendCall("paginateTo") { it.paginateTo(0) }
+            .isSuccessful()
+            .suspendCall("test") {
+              it.test {
+                awaitItem()
+                assertFailure { awaitItem() }
+                  .cause()
+                  .isNotNull()
+                  .isInstanceOf<CancellationException>()
+              }
+            }
+        }
       }
     }
 
   @Test
   fun doesNotPaginateForwardsWhenNextRouteIsNotLinked() =
     runMastodonPostPaginatorTest(next = { null }) {
-      paginateTo(1).test {
-        awaitItem()
-        assertFailure { awaitItem() }.cause().isNotNull().isInstanceOf<CancellationException>()
-      }
+      assertThat(this)
+        .suspendCall("paginateTo") { it.paginateTo(1) }
+        .isSuccessful()
+        .suspendCall("test") {
+          it.test {
+            awaitItem()
+            assertFailure { awaitItem() }.cause().isNotNull().isInstanceOf<CancellationException>()
+          }
+        }
     }
 
   @Test
@@ -124,21 +163,24 @@ internal class MastodonPostPaginatorTests {
         lazyInjectionOf { SampleTermMuter() }
       )
     )
+    assertThat(
+        @OptIn(DelicateCoroutinesApi::class) @Suppress("DEPRECATION")
+        object : MastodonPostPaginator<Any>(), KTypeCreator<Any> by kTypeCreatorOf() {
+          override val requester = this@runAuthenticatedRequesterTest.requester
 
-    @OptIn(DelicateCoroutinesApi::class) @Suppress("DEPRECATION")
-    object : MastodonPostPaginator<Any>(), KTypeCreator<Any> by kTypeCreatorOf() {
-        override val requester = this@runAuthenticatedRequesterTest.requester
+          override fun HostedURLBuilder.buildInitialRoute() = build()
 
-        override fun HostedURLBuilder.buildInitialRoute() = build()
-
-        override fun Any.toPosts() = emptyList<Post>()
+          override fun Any.toPosts() = emptyList<Post>()
+        }
+      )
+      .suspendCall("paginateTo") { it.paginateTo(0) }
+      .isSuccessful()
+      .suspendCall("test") {
+        it.test {
+          awaitItem()
+          awaitComplete()
+        }
       }
-      .paginateTo(0)
-      .test {
-        awaitItem()
-        awaitComplete()
-      }
-
     Injector.unregister<CoreModule>()
   }
 }

--- a/core/sample/build.gradle.kts
+++ b/core/sample/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023–2024 Orcinus
+ * Copyright © 2023–2025 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -37,6 +37,7 @@ dependencies {
 
   testImplementation(project(":core:sample-test"))
   testImplementation(project(":ext:testing"))
+  testImplementation(project(":std:func-test"))
   testImplementation(libs.kotlin.coroutines.test)
   testImplementation(libs.kotlin.test)
   testImplementation(libs.turbine)

--- a/core/sample/src/main/java/br/com/orcinus/orca/core/sample/feed/SampleFeedProvider.kt
+++ b/core/sample/src/main/java/br/com/orcinus/orca/core/sample/feed/SampleFeedProvider.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023–2024 Orcinus
+ * Copyright © 2023–2025 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -25,7 +25,6 @@ import br.com.orcinus.orca.core.sample.feed.profile.post.SamplePostProvider
 import br.com.orcinus.orca.core.sample.image.SampleImageSource
 import br.com.orcinus.orca.std.image.ImageLoader
 import br.com.orcinus.orca.std.image.SomeImageLoaderProvider
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.runBlocking
@@ -44,31 +43,20 @@ class SampleFeedProvider(
   override val termMuter: TermMuter,
   private val imageLoaderProvider: SomeImageLoaderProvider<SampleImageSource>
 ) : FeedProvider() {
-  override fun createNonexistentUserException(): NonexistentUserException {
-    return NonexistentUserException(cause = null)
-  }
-
-  override suspend fun containsUser(userID: String): Boolean {
-    return profileProvider.contains(userID)
-  }
-
-  override suspend fun onProvide(userID: String, page: Int): Flow<List<Post>> {
-    return postProvider.postsFlow.map { posts ->
-      posts.chunked(Composer.MAX_POST_COUNT_PER_PAGE).getOrElse(page) { emptyList() }
+  override suspend fun onProvide(page: Int) =
+    postProvider.postsFlow.map {
+      it.chunked(Composer.MAX_POST_COUNT_PER_PAGE).getOrElse(page) { emptyList() }
     }
-  }
 
   /**
    * Provides the feed as it currently is.
    *
-   * @param userID ID of the user whose feed will be provided.
    * @param page Index of the [Post]s that compose the feed.
    */
-  fun provideCurrent(userID: String, page: Int): List<Post> {
+  fun provideCurrent(page: Int) =
     /*
      * SampleFeedProvider's provide(userID, page): Flow<List<Post>>'s flow is composed on top of a
      * state flow; given that the only operation
      */
-    return runBlocking { provide(userID, page).first() }
-  }
+    runBlocking { provide(page).map { it.first() } }
 }

--- a/core/sample/src/main/java/br/com/orcinus/orca/core/sample/feed/SampleFeedProvider.kt
+++ b/core/sample/src/main/java/br/com/orcinus/orca/core/sample/feed/SampleFeedProvider.kt
@@ -43,7 +43,7 @@ class SampleFeedProvider(
   override val termMuter: TermMuter,
   private val imageLoaderProvider: SomeImageLoaderProvider<SampleImageSource>
 ) : FeedProvider() {
-  override suspend fun onProvide(page: Int) =
+  override suspend fun onProvision(page: Int) =
     postProvider.postsFlow.map {
       it.chunked(Composer.MAX_POST_COUNT_PER_PAGE).getOrElse(page) { emptyList() }
     }

--- a/core/sample/src/main/java/br/com/orcinus/orca/core/sample/feed/profile/composition/Composer.kt
+++ b/core/sample/src/main/java/br/com/orcinus/orca/core/sample/feed/profile/composition/Composer.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Orcinus
+ * Copyright © 2024–2025 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -18,6 +18,7 @@
 package br.com.orcinus.orca.core.sample.feed.profile.composition
 
 import br.com.orcinus.orca.core.feed.profile.Profile
+import br.com.orcinus.orca.core.feed.profile.getPosts
 import br.com.orcinus.orca.core.feed.profile.post.Author
 import br.com.orcinus.orca.core.feed.profile.post.Post
 import br.com.orcinus.orca.core.feed.profile.post.content.Content
@@ -33,13 +34,12 @@ interface Composer : Profile {
   val postsFlow: MutableStateFlow<List<Post>>
     @InternalSampleApi get
 
-  override suspend fun getPosts(page: Int): Flow<List<Post>> {
-    return postsFlow.map {
+  override suspend fun onPostsObtainance(page: Int) =
+    postsFlow.map {
       it.windowed(MAX_POST_COUNT_PER_PAGE, partialWindows = true).getOrElse(page) { _ ->
         emptyList()
       }
     }
-  }
 
   /**
    * Creates a [Post].
@@ -48,7 +48,6 @@ interface Composer : Profile {
    * @param content [Content] that's been composed by the [Author].
    * @param publicationDateTime Zoned moment in time in which the [Post] was published.
    */
-  @InternalSampleApi
   fun createPost(author: Author, content: Content, publicationDateTime: ZonedDateTime): Post
 
   companion object {

--- a/core/sample/src/main/java/br/com/orcinus/orca/core/sample/instance/SampleInstance.kt
+++ b/core/sample/src/main/java/br/com/orcinus/orca/core/sample/instance/SampleInstance.kt
@@ -66,7 +66,11 @@ import br.com.orcinus.orca.std.markdown.buildMarkdown
 import java.time.ZoneId
 import java.time.ZonedDateTime
 
-/** [Instance] made out of sample underlying core structures. */
+/**
+ * [Instance] made out of sample underlying core structures.
+ *
+ * @property termMuter [SampleTermMuter] for muting terms in [Post]s from the feed.
+ */
 class SampleInstance
 private constructor(
   override val authenticator: SampleAuthenticator,
@@ -74,7 +78,8 @@ private constructor(
   override val feedProvider: SampleFeedProvider,
   override val profileProvider: SampleProfileProvider,
   override val profileSearcher: SampleProfileSearcher,
-  override val postProvider: SamplePostProvider
+  override val postProvider: SamplePostProvider,
+  val termMuter: SampleTermMuter
 ) : Instance<SampleAuthenticator>() {
   override val domain = Domain.sample
 
@@ -99,6 +104,9 @@ private constructor(
     /** [Instance]-specific [FeedProvider] that provides the [Post]s in the timeline. */
     protected abstract val feedProvider: SampleFeedProvider
 
+    /** [SampleTermMuter] for muting terms in [Post]s from the feed. */
+    protected abstract val termMuter: SampleTermMuter
+
     /** [Instance]-specific [ProfileProvider] for providing [Profile]s. */
     protected abstract val profileProvider: SampleProfileProvider
 
@@ -117,6 +125,7 @@ private constructor(
       override val authenticator: SampleAuthenticator,
       override val authenticationLock: SampleAuthenticationLock,
       override val feedProvider: SampleFeedProvider,
+      override val termMuter: SampleTermMuter,
       override val profileProvider: SampleProfileProvider,
       override val profileSearcher: SampleProfileSearcher,
       override val postProvider: SamplePostProvider,
@@ -128,6 +137,7 @@ private constructor(
           authenticator,
           authenticationLock,
           feedProvider,
+          termMuter,
           profileSearcher,
           profileProvider,
           postProvider,
@@ -148,6 +158,7 @@ private constructor(
       override val authenticator: SampleAuthenticator,
       override val authenticationLock: SampleAuthenticationLock,
       override val feedProvider: SampleFeedProvider,
+      override val termMuter: SampleTermMuter,
       override val profileSearcher: SampleProfileSearcher,
       override val profileProvider: SampleProfileProvider,
       override val postProvider: SamplePostProvider,
@@ -190,6 +201,7 @@ private constructor(
           authenticator,
           authenticationLock,
           feedProvider,
+          termMuter,
           profileSearcher,
           profileProvider,
           postProvider,
@@ -204,6 +216,7 @@ private constructor(
       override val authenticator: SampleAuthenticator,
       override val authenticationLock: SampleAuthenticationLock,
       override val feedProvider: SampleFeedProvider,
+      override val termMuter: SampleTermMuter,
       override val profileSearcher: SampleProfileSearcher,
       override val profileProvider: SampleProfileProvider,
       override val postProvider: SamplePostProvider,
@@ -286,7 +299,8 @@ private constructor(
         feedProvider,
         profileProvider,
         profileSearcher,
-        postProvider
+        postProvider,
+        termMuter
       )
     }
 
@@ -314,6 +328,7 @@ private constructor(
           authenticator,
           authenticationLock,
           feedProvider,
+          termMuter,
           profileProvider,
           profileSearcher,
           postProvider,
@@ -345,6 +360,7 @@ private constructor(
           authenticator,
           authenticationLock,
           feedProvider,
+          termMuter,
           profileProvider,
           profileSearcher,
           postProvider,
@@ -361,6 +377,7 @@ private constructor(
        *   locked or unlocked by an authentication "wall".
        * @param feedProvider [Instance]-specific [FeedProvider] that provides the [Post]s in the
        *   timeline.
+       * @param termMuter [SampleTermMuter] for muting terms in [Post]s from the feed.
        * @param profileProvider [Instance]-specific [ProfileProvider] for providing [Profile]s.
        * @param profileSearcher [Instance]-specific [ProfileSearcher] by which search for [Profile]s
        *   can be made.
@@ -372,21 +389,22 @@ private constructor(
         authenticator: SampleAuthenticator,
         authenticationLock: SampleAuthenticationLock,
         feedProvider: SampleFeedProvider,
+        termMuter: SampleTermMuter,
         profileProvider: SampleProfileProvider,
         profileSearcher: SampleProfileSearcher,
         postProvider: SamplePostProvider,
         imageLoaderProvider: SomeImageLoaderProvider<SampleImageSource>
-      ): Empty {
-        return Empty(
+      ) =
+        Empty(
           authenticator,
           authenticationLock,
           feedProvider,
+          termMuter,
           profileProvider,
           profileSearcher,
           postProvider,
-          imageLoaderProvider
+          imageLoaderProvider,
         )
-      }
     }
   }
 }

--- a/core/sample/src/test/java/br/com/orcinus/orca/core/sample/feed/profile/composition/HardcodedComposer.kt
+++ b/core/sample/src/test/java/br/com/orcinus/orca/core/sample/feed/profile/composition/HardcodedComposer.kt
@@ -33,7 +33,6 @@ import br.com.orcinus.orca.std.func.monad.Maybe
 import br.com.orcinus.orca.std.markdown.Markdown
 import java.time.ZonedDateTime
 import java.util.UUID
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.map
 
@@ -56,13 +55,12 @@ internal class HardcodedComposer : Composer {
       .build()
   override val postsFlow = MutableStateFlow(emptyList<Post>())
 
-  override suspend fun getPosts(page: Int): Flow<List<Post>> {
-    return postsFlow.map {
+  override suspend fun onPostsObtainance(page: Int) =
+    postsFlow.map {
       it.windowed(Composer.MAX_POST_COUNT_PER_PAGE, partialWindows = true).getOrElse(page) {
         emptyList()
       }
     }
-  }
 
   override fun createPost(
     author: Author,

--- a/core/sample/src/test/java/br/com/orcinus/orca/core/sample/instance/SampleInstanceBuilderTests.kt
+++ b/core/sample/src/test/java/br/com/orcinus/orca/core/sample/instance/SampleInstanceBuilderTests.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Orcinus
+ * Copyright © 2024–2025 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -15,45 +15,55 @@
 
 package br.com.orcinus.orca.core.sample.instance
 
+import assertk.all
 import assertk.assertThat
 import assertk.assertions.isEmpty
 import assertk.assertions.isNotEmpty
-import br.com.orcinus.orca.core.auth.actor.Actor
-import br.com.orcinus.orca.core.sample.auth.actor.sample
+import assertk.assertions.prop
 import br.com.orcinus.orca.core.sample.test.image.NoOpSampleImageLoader
+import br.com.orcinus.orca.std.func.test.monad.isSuccessful
 import kotlin.test.Test
 
 internal class SampleInstanceBuilderTests {
   @Test
-  fun buildsSampleInstanceWithoutDefaultProfilesAndPosts() {
-    val profiles =
-      SampleInstance.Builder.create(NoOpSampleImageLoader.Provider)
-        .build()
-        .profileProvider
-        .provideCurrent()
-    assertThat(profiles).isEmpty()
-  }
+  fun buildsSampleInstanceWithoutDefaultProfilesAndPosts() =
+    assertThat(SampleInstance.Builder)
+      .transform("create") { it.create(NoOpSampleImageLoader.Provider) }
+      .prop(SampleInstance.Builder.Empty::build)
+      .prop(SampleInstance::profileProvider)
+      .transform("provideCurrent") { it.provideCurrent() }
+      .isEmpty()
 
   @Test
-  fun buildsSampleInstanceWithDefaultProfilesAndWithoutDefaultPosts() {
-    val instance =
-      SampleInstance.Builder.create(NoOpSampleImageLoader.Provider).withDefaultProfiles().build()
-    val profiles = instance.profileProvider.provideCurrent()
-    val feed = instance.feedProvider.provideCurrent(Actor.Authenticated.sample.id, page = 0)
-    assertThat(profiles).isNotEmpty()
-    assertThat(feed).isEmpty()
-  }
+  fun buildsSampleInstanceWithDefaultProfilesAndWithoutDefaultPosts() =
+    assertThat(SampleInstance.Builder)
+      .transform("create") { it.create(NoOpSampleImageLoader.Provider) }
+      .prop(SampleInstance.Builder.Empty::withDefaultProfiles)
+      .prop(SampleInstance.Builder.DefaultProfiles::build)
+      .all {
+        prop(SampleInstance::profileProvider)
+          .transform("provideCurrent") { it.provideCurrent() }
+          .isNotEmpty()
+        prop(SampleInstance::feedProvider)
+          .transform("provideCurrent") { it.provideCurrent(page = 0) }
+          .isSuccessful()
+          .isEmpty()
+      }
 
   @Test
-  fun buildsSampleInstanceWithDefaultProfilesAndPosts() {
-    val instance =
-      SampleInstance.Builder.create(NoOpSampleImageLoader.Provider)
-        .withDefaultProfiles()
-        .withDefaultPosts()
-        .build()
-    val profiles = instance.profileProvider.provideCurrent()
-    val feed = instance.feedProvider.provideCurrent(Actor.Authenticated.sample.id, page = 0)
-    assertThat(profiles).isNotEmpty()
-    assertThat(feed).isNotEmpty()
-  }
+  fun buildsSampleInstanceWithDefaultProfilesAndPosts() =
+    assertThat(SampleInstance.Builder)
+      .transform("create") { it.create(NoOpSampleImageLoader.Provider) }
+      .prop(SampleInstance.Builder.Empty::withDefaultProfiles)
+      .prop(SampleInstance.Builder.DefaultProfiles::withDefaultPosts)
+      .prop(SampleInstance.Builder.DefaultPosts::build)
+      .all {
+        prop(SampleInstance::profileProvider)
+          .transform("provideCurrent") { it.provideCurrent() }
+          .isNotEmpty()
+        prop(SampleInstance::feedProvider)
+          .transform("provideCurrent") { it.provideCurrent(page = 0) }
+          .isSuccessful()
+          .isNotEmpty()
+      }
 }

--- a/core/sample/src/test/java/br/com/orcinus/orca/core/sample/instance/SampleInstanceProviderFactoryTests.kt
+++ b/core/sample/src/test/java/br/com/orcinus/orca/core/sample/instance/SampleInstanceProviderFactoryTests.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Orcinus
+ * Copyright © 2024–2025 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -15,21 +15,26 @@
 
 package br.com.orcinus.orca.core.sample.instance
 
+import assertk.all
 import assertk.assertThat
 import assertk.assertions.isNotEmpty
-import br.com.orcinus.orca.core.auth.actor.Actor
-import br.com.orcinus.orca.core.sample.auth.actor.sample
+import assertk.assertions.prop
 import br.com.orcinus.orca.core.sample.test.image.NoOpSampleImageLoader
+import br.com.orcinus.orca.std.func.test.monad.isSuccessful
 import kotlin.test.Test
 
 internal class SampleInstanceProviderFactoryTests {
   @Test
-  fun createsASampleInstanceProviderThatProvidesASampleInstanceWithDefaultProfilesAndPostsByDefault() {
-    val imageLoaderProvider = NoOpSampleImageLoader.Provider
-    val providedInstance = SampleInstanceProvider(imageLoaderProvider).provide()
-    val providedProfiles = providedInstance.profileProvider.provideCurrent()
-    val feed = providedInstance.feedProvider.provideCurrent(Actor.Authenticated.sample.id, page = 0)
-    assertThat(providedProfiles).isNotEmpty()
-    assertThat(feed).isNotEmpty()
-  }
+  fun createsASampleInstanceProviderThatProvidesASampleInstanceWithDefaultProfilesAndPostsByDefault() =
+    assertThat(SampleInstanceProvider(NoOpSampleImageLoader.Provider))
+      .prop(SampleInstanceProvider::provide)
+      .all {
+        prop(SampleInstance::profileProvider)
+          .transform("provideCurrent") { it.provideCurrent() }
+          .isNotEmpty()
+        prop(SampleInstance::feedProvider)
+          .transform("provideCurrent") { it.provideCurrent(page = 0) }
+          .isSuccessful()
+          .isNotEmpty()
+      }
 }

--- a/core/src/main/java/br/com/orcinus/orca/core/feed/FeedProvider.kt
+++ b/core/src/main/java/br/com/orcinus/orca/core/feed/FeedProvider.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023–2024 Orcinus
+ * Copyright © 2023–2025 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -16,6 +16,7 @@
 package br.com.orcinus.orca.core.feed
 
 import br.com.orcinus.orca.core.InternalCoreApi
+import br.com.orcinus.orca.core.auth.actor.Actor
 import br.com.orcinus.orca.core.feed.profile.post.Post
 import br.com.orcinus.orca.core.feed.profile.post.content.TermMuter
 import kotlinx.coroutines.flow.Flow
@@ -28,65 +29,19 @@ abstract class FeedProvider @InternalCoreApi constructor() {
   protected abstract val termMuter: TermMuter
 
   /**
-   * [IllegalArgumentException] thrown when a user that doesn't exist is requested to be provided.
-   */
-  class NonexistentUserException @InternalCoreApi constructor(override val cause: Throwable?) :
-    IllegalArgumentException("Feed cannot be loaded because the user doesn't exist.")
-
-  /**
-   * Provides the feed of the user identified as [userID].
+   * Provides the feed of the current [Actor].
    *
-   * @param userID ID of the user whose feed will be provided.
-   * @param page Index of the [Post]s that compose the feed.
-   * @throws NonexistentUserException If no user with such [userID] exists.
-   * @throws IndexOutOfBoundsException If the page is invalid.
-   * @see ensurePageValidity
+   * @param page Page at which the emitted [Post]s are in the feed.
    */
-  suspend fun provide(userID: String, page: Int): Flow<List<Post>> {
-    ensureContainsUser(userID)
-    ensurePageValidity(page)
-    return onProvide(userID, page).filterEach { !termMuter.isMuted(it.content) }
-  }
-
-  /**
-   * Whether a user identified as [userID] exists.
-   *
-   * @param userID ID of the user whose existence will be checked.
-   */
-  protected abstract suspend fun containsUser(userID: String): Boolean
-
-  /** Creates a variant-specific [NonexistentUserException]. */
-  protected abstract fun createNonexistentUserException(): NonexistentUserException
-
-  /**
-   * Provides the feed of the user identified as [userID].
-   *
-   * @param userID ID of the user whose feed will be provided.
-   * @param page Index of the [Post]s that compose the feed.
-   */
-  protected abstract suspend fun onProvide(userID: String, page: Int): Flow<List<Post>>
-
-  /**
-   * Ensures that a user identified as [userID] exists.
-   *
-   * @param userID ID of the user whose existence will be ensured.
-   * @throws NonexistentUserException If no user with such [userID] exists.
-   */
-  private suspend fun ensureContainsUser(userID: String) {
-    if (!containsUser(userID)) {
-      throw createNonexistentUserException()
+  suspend fun provide(page: Int) =
+    Pages.validate(page).map { validPage ->
+      onProvide(validPage).filterEach { post -> !termMuter.isMuted(post.content) }
     }
-  }
 
   /**
-   * Ensures that the [page] is valid; that is, if it is a positive [Int].
+   * Callback called whenever the feed of the current [Actor] is requested to be provided.
    *
-   * @param page Page whose validity will be ensured.
-   * @throws IndexOutOfBoundsException If the page is invalid.
+   * @param page Valid page at which the emitted [Post]s are in the feed.
    */
-  private fun ensurePageValidity(page: Int) {
-    if (page < 0) {
-      throw IndexOutOfBoundsException("Page out of range: $page.")
-    }
-  }
+  protected abstract suspend fun onProvide(page: Int): Flow<List<Post>>
 }

--- a/core/src/main/java/br/com/orcinus/orca/core/feed/FeedProvider.kt
+++ b/core/src/main/java/br/com/orcinus/orca/core/feed/FeedProvider.kt
@@ -22,7 +22,8 @@ import br.com.orcinus.orca.core.feed.profile.post.content.TermMuter
 import kotlinx.coroutines.flow.Flow
 
 /**
- * Provides a user's feed (the [Post]s shown to them based on who they follow) through [onProvide].
+ * Provides a user's feed (the [Post]s shown to them based on who they follow) through
+ * [onProvision].
  */
 abstract class FeedProvider @InternalCoreApi constructor() {
   /** [TermMuter] by which [Post]s with muted terms will be filtered out. */
@@ -35,7 +36,7 @@ abstract class FeedProvider @InternalCoreApi constructor() {
    */
   suspend fun provide(page: Int) =
     Pages.validate(page).map { validPage ->
-      onProvide(validPage).filterEach { post -> !termMuter.isMuted(post.content) }
+      onProvision(validPage).filterEach { post -> !termMuter.isMuted(post.content) }
     }
 
   /**
@@ -43,5 +44,5 @@ abstract class FeedProvider @InternalCoreApi constructor() {
    *
    * @param page Valid page at which the emitted [Post]s are in the feed.
    */
-  protected abstract suspend fun onProvide(page: Int): Flow<List<Post>>
+  protected abstract suspend fun onProvision(page: Int): Flow<List<Post>>
 }

--- a/core/src/main/java/br/com/orcinus/orca/core/feed/Pages.java
+++ b/core/src/main/java/br/com/orcinus/orca/core/feed/Pages.java
@@ -13,14 +13,17 @@
  * not, see https://www.gnu.org/licenses.
  */
 
-package br.com.orcinus.orca.core.mastodon.feed.profile.post.pagination.page;
+package br.com.orcinus.orca.core.feed;
+
+import br.com.orcinus.orca.std.func.monad.Maybe;
+import org.jetbrains.annotations.NotNull;
 
 /** Utilities for pages. */
 public class Pages {
   /**
    * Marker that denotes an unset page. It is not a valid page itself — passing it as a parameter to
-   * {@link #validate(int)} throws an {@link InvalidException}; rather, it merely indicates that a
-   * page has not yet been defined.
+   * {@link #validate(int)} results in a failure; rather, it merely indicates that a page has not
+   * yet been defined.
    */
   public static final int NONE = -1;
 
@@ -59,12 +62,13 @@ public class Pages {
    * Ensures that the given integer is a valid page.
    *
    * @param page Page whose validity will be checked.
-   * @throws NegativeException If the page is negative.
    */
-  public static void validate(final int page) throws NegativeException {
+  @NotNull
+  public static Maybe<@NotNull InvalidException, @NotNull Integer> validate(final int page) {
     if (page < 0) {
-      throw new NegativeException(page);
+      return Maybe.failed(new NegativeException(page));
     }
+    return Maybe.successful(page);
   }
 
   /**
@@ -72,10 +76,9 @@ public class Pages {
    * otherwise, returns its {@link String} representation.
    */
   private static String name(final int page) {
-    String name = String.valueOf(page);
     if (page == NONE) {
-      name = "NONE";
+      return "NONE";
     }
-    return name;
+    return String.valueOf(page);
   }
 }

--- a/core/src/main/java/br/com/orcinus/orca/core/feed/profile/Profile.kt
+++ b/core/src/main/java/br/com/orcinus/orca/core/feed/profile/Profile.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023–2024 Orcinus
+ * Copyright © 2023–2025 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -15,6 +15,8 @@
 
 package br.com.orcinus.orca.core.feed.profile
 
+import br.com.orcinus.orca.core.InternalCoreApi
+import br.com.orcinus.orca.core.feed.Pages
 import br.com.orcinus.orca.core.feed.profile.account.Account
 import br.com.orcinus.orca.core.feed.profile.post.Post
 import br.com.orcinus.orca.std.image.ImageLoader
@@ -53,11 +55,19 @@ interface Profile : Serializable {
   val uri: URI
 
   /**
-   * Gets the [Post]s that have been published by the owner of this [Profile].
+   * Callback called whenever the [Post]s published by the owner of this [Profile] are requested to
+   * be obtained.
    *
-   * @param page Page in which the [Post]s to be obtained are.
+   * @param page Valid page in which the [Post]s to be obtained are.
    */
-  suspend fun getPosts(page: Int): Flow<List<Post>>
+  @InternalCoreApi suspend fun onPostsObtainance(page: Int): Flow<List<Post>>
 
   companion object
 }
+
+/**
+ * Obtains the [Post]s that have been published by the owner of this [Profile].
+ *
+ * @param page Page in which the [Post]s to be obtained are.
+ */
+suspend fun Profile.getPosts(page: Int) = Pages.validate(page).map { onPostsObtainance(it) }

--- a/core/src/test/java/br/com/orcinus/orca/core/feed/FeedProviderTests.kt
+++ b/core/src/test/java/br/com/orcinus/orca/core/feed/FeedProviderTests.kt
@@ -42,7 +42,7 @@ internal class FeedProviderTests {
         object : FeedProvider() {
           override val termMuter = SampleTermMuter()
 
-          override suspend fun onProvide(page: Int) = emptyFlow<List<Post>>()
+          override suspend fun onProvision(page: Int) = emptyFlow<List<Post>>()
         }
       )
       .suspendCall("provide") { it.provide(page = -1) }

--- a/core/src/test/java/br/com/orcinus/orca/core/feed/PagesTests.kt
+++ b/core/src/test/java/br/com/orcinus/orca/core/feed/PagesTests.kt
@@ -13,29 +13,33 @@
  * not, see https://www.gnu.org/licenses.
  */
 
-package br.com.orcinus.orca.core.mastodon.feed.profile.post.pagination.page
+package br.com.orcinus.orca.core.feed
 
-import assertk.assertFailure
+import assertk.assertThat
+import assertk.assertions.isEqualTo
 import assertk.assertions.isInstanceOf
+import assertk.assertions.isZero
 import assertk.assertions.messageContains
+import br.com.orcinus.orca.std.func.test.monad.isFailed
+import br.com.orcinus.orca.std.func.test.monad.isSuccessful
 import kotlin.test.Test
 
 internal class PagesTests {
   @Test
   fun negativePageIsInvalid() {
-    assertFailure { Pages.validate(-2) }.isInstanceOf<Pages.NegativeException>()
+    assertThat(Pages.validate(-2)).isFailed().isInstanceOf<Pages.NegativeException>()
   }
 
   @Test
   fun noneMarkerIsInvalid() {
-    assertFailure { Pages.validate(Pages.NONE) }.isInstanceOf<Pages.InvalidException>()
+    assertThat(Pages.validate(Pages.NONE)).isFailed().isInstanceOf<Pages.InvalidException>()
   }
 
   @Test
   fun throwsMentioningNoneMarkerWhenValidatingIt() =
-    assertFailure { Pages.validate(Pages.NONE) }.messageContains(Pages::NONE.name)
+    assertThat(Pages.validate(Pages.NONE)).isFailed().messageContains(Pages::NONE.name)
 
-  @Test fun pageZeroIsValid() = Pages.validate(0)
+  @Test fun pageZeroIsValid() = assertThat(Pages.validate(0)).isSuccessful().isZero()
 
-  @Test fun positivePageIsValid() = Pages.validate(1)
+  @Test fun positivePageIsValid() = assertThat(Pages.validate(1)).isSuccessful().isEqualTo(1)
 }

--- a/ext/testing/src/main/java/br/com/orcinus/orca/ext/testing/Assert.extensions.kt
+++ b/ext/testing/src/main/java/br/com/orcinus/orca/ext/testing/Assert.extensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023–2024 Orcinus
+ * Copyright © 2023–2025 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -29,6 +29,17 @@ import org.opentest4j.AssertionFailedError
  * @param T Object on whose [KClass] assertions are to be performed.
  */
 inline fun <reified T : Any> assertThat() = assertk.assertThat(T::class)
+
+/**
+ * Obtains the value on which the assertion is being performed.
+ *
+ * @param T Value to be obtained.
+ */
+fun <T> Assert<T>.get(): T {
+  var value: T? = null
+  given { value = it }
+  @Suppress("UNCHECKED_CAST") return value as T
+}
 
 /**
  * Asserts that the value's properties have the same name and hold data equal to [other]'s. It will

--- a/ext/testing/src/test/java/br/com/orcinus/orca/ext/testing/AssertExtensionsTests.kt
+++ b/ext/testing/src/test/java/br/com/orcinus/orca/ext/testing/AssertExtensionsTests.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023–2024 Orcinus
+ * Copyright © 2023–2025 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -15,13 +15,18 @@
 
 package br.com.orcinus.orca.ext.testing
 
+import assertk.Assert
 import assertk.assertThat
 import assertk.assertions.isSameInstanceAs
+import assertk.assertions.isZero
+import assertk.assertions.prop
 import kotlin.test.Test
 import org.opentest4j.AssertionFailedError
 
 internal class AssertExtensionsTests {
   @Test fun createsAssertWithKClass() = assertThat<Any>().isSameInstanceAs(Any::class)
+
+  @Test fun gets() = assertThat(assertThat(0)).prop(Assert<Int>::get).isZero()
 
   @Test
   fun passesWhenAssertingThatAnObjectHasPropertiesEqualToThoseOfAnotherOneWhenItDoes() {

--- a/feature/feed/src/main/java/br/com/orcinus/orca/feature/feed/FeedFragment.kt
+++ b/feature/feed/src/main/java/br/com/orcinus/orca/feature/feed/FeedFragment.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023–2024 Orcinus
+ * Copyright © 2023–2025 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -22,13 +22,11 @@ import br.com.orcinus.orca.composite.composable.ComposableFragment
 import br.com.orcinus.orca.platform.navigation.BackStack
 import br.com.orcinus.orca.platform.navigation.Navigator
 import br.com.orcinus.orca.platform.navigation.application
-import br.com.orcinus.orca.platform.navigation.argument
 import br.com.orcinus.orca.std.injector.Injector
 
 class FeedFragment internal constructor() : ComposableFragment() {
   private val module by lazy { Injector.from<FeedModule>() }
   private val backStack by BackStack.from(this)
-  private val userID by argument<String>(USER_ID_KEY)
   private val navigator by lazy { Navigator.create(this, backStack) }
   private val viewModel by
     viewModels<FeedViewModel> {
@@ -37,7 +35,6 @@ class FeedFragment internal constructor() : ComposableFragment() {
         module.profileSearcher(),
         module.feedProvider(),
         module.postProvider(),
-        userID,
         onLinkClick = boundary::navigateTo,
         onThumbnailClickListener = { postID, entrypointIndex, secondary, entrypoint ->
           boundary.navigateToGallery(postID, entrypointIndex, secondary, entrypoint)
@@ -48,8 +45,8 @@ class FeedFragment internal constructor() : ComposableFragment() {
   private val boundary
     get() = module.boundary()
 
-  constructor(backStack: BackStack, userID: String) : this() {
-    arguments = bundleOf(BackStack.KEY to backStack, USER_ID_KEY to userID)
+  constructor(backStack: BackStack) : this() {
+    arguments = bundleOf(BackStack.KEY to backStack)
   }
 
   @Composable
@@ -59,9 +56,5 @@ class FeedFragment internal constructor() : ComposableFragment() {
       onPostClick = { boundary.navigateToPostDetails(navigator, backStack, it) },
       onComposition = { boundary.navigateToComposer() }
     )
-  }
-
-  companion object {
-    private const val USER_ID_KEY = "user-id"
   }
 }

--- a/feature/feed/src/main/java/br/com/orcinus/orca/feature/feed/FeedViewModel.kt
+++ b/feature/feed/src/main/java/br/com/orcinus/orca/feature/feed/FeedViewModel.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023–2024 Orcinus
+ * Copyright © 2023–2025 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -59,7 +59,6 @@ constructor(
   private val profileSearcher: ProfileSearcher,
   private val feedProvider: FeedProvider,
   private val postProvider: PostProvider,
-  private val userID: String,
   private val onLinkClick: (URI) -> Unit,
   private val onThumbnailClickListener: Disposition.OnThumbnailClickListener
 ) : AndroidViewModel(application) {
@@ -86,7 +85,7 @@ constructor(
   val postPreviewsLoadableFlow = listLoadableFlow {
     indexFlow
       .combine(postPreviewsLoadableNotifierFlow) { index, _ -> index }
-      .paginate { feedProvider.provide(userID, page = it) }
+      .paginate { feedProvider.provide(page = it).getValueOrThrow() }
       .flatMapEach(selector = PostPreview::id) {
         it.toPostPreviewFlow(colors, onLinkClick, onThumbnailClickListener)
       }
@@ -99,7 +98,6 @@ constructor(
     profileSearcher: ProfileSearcher,
     feedProvider: FeedProvider,
     postProvider: PostProvider,
-    userID: String,
     onLinkClick: (URI) -> Unit,
     onThumbnailClickListener: Disposition.OnThumbnailClickListener
   ) : this(
@@ -108,7 +106,6 @@ constructor(
     profileSearcher,
     feedProvider,
     postProvider,
-    userID,
     onLinkClick,
     onThumbnailClickListener
   )
@@ -147,7 +144,6 @@ constructor(
       profileSearcher: ProfileSearcher,
       feedProvider: FeedProvider,
       postProvider: PostProvider,
-      userID: String,
       onLinkClick: (URI) -> Unit,
       onThumbnailClickListener: Disposition.OnThumbnailClickListener
     ): ViewModelProvider.Factory {
@@ -158,7 +154,6 @@ constructor(
             profileSearcher,
             feedProvider,
             postProvider,
-            userID,
             onLinkClick,
             onThumbnailClickListener
           )

--- a/feature/feed/src/test/java/br/com/orcinus/orca/feature/feed/FeedFragmentTests.kt
+++ b/feature/feed/src/test/java/br/com/orcinus/orca/feature/feed/FeedFragmentTests.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023–2024 Orcinus
+ * Copyright © 2023–2025 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -25,10 +25,8 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import br.com.orcinus.orca.composite.timeline.stat.activateable.favorite.FavoriteStatTag
 import br.com.orcinus.orca.composite.timeline.test.post.onPostPreviews
-import br.com.orcinus.orca.core.auth.actor.Actor
 import br.com.orcinus.orca.core.sample.instance.SampleInstance
 import br.com.orcinus.orca.platform.core.image.sample
-import br.com.orcinus.orca.platform.core.sample
 import br.com.orcinus.orca.platform.navigation.BackStack
 import br.com.orcinus.orca.platform.navigation.test.fragment.launchFragmentInNavigationContainer
 import br.com.orcinus.orca.std.image.compose.ComposableImageLoader
@@ -59,15 +57,10 @@ internal class FeedFragmentTests {
   @Test
   fun favoritesPost() {
     runTest {
-      instance.feedProvider
-        .provide(Actor.Authenticated.sample.id, page = 0)
-        .first()
-        .first()
-        .favorite
-        .disable()
+      instance.feedProvider.provide(page = 0).getValueOrThrow().first().first().favorite.disable()
     }
     launchFragmentInNavigationContainer {
-        FeedFragment(BackStack.named(FeedFragment::class.java.name), Actor.Authenticated.sample.id)
+        FeedFragment(BackStack.named(FeedFragment::class.java.name))
       }
       .use {
         composeRule

--- a/feature/feed/src/test/java/br/com/orcinus/orca/feature/feed/FeedViewModelScope.kt
+++ b/feature/feed/src/test/java/br/com/orcinus/orca/feature/feed/FeedViewModelScope.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Orcinus
+ * Copyright © 2024–2025 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -20,11 +20,9 @@ import androidx.lifecycle.viewModelScope
 import androidx.test.core.app.ApplicationProvider
 import br.com.orcinus.orca.composite.timeline.post.PostPreview
 import br.com.orcinus.orca.composite.timeline.post.figure.gallery.disposition.Disposition
-import br.com.orcinus.orca.core.auth.actor.Actor
 import br.com.orcinus.orca.core.feed.profile.post.Post
 import br.com.orcinus.orca.core.sample.instance.SampleInstance
 import br.com.orcinus.orca.platform.core.image.sample
-import br.com.orcinus.orca.platform.core.sample
 import br.com.orcinus.orca.std.image.compose.ComposableImageLoader
 import com.jeanbarrossilva.loadable.list.ListLoadable
 import kotlin.contracts.ExperimentalContracts
@@ -71,8 +69,7 @@ internal inline fun runFeedViewModelTest(crossinline body: suspend FeedViewModel
         .withDefaultPosts()
         .build()
     val feedProvider = instance.feedProvider
-    val userID = Actor.Authenticated.sample.id
-    val postID = feedProvider.provide(userID, page = 0).first().first().id
+    val postID = feedProvider.provide(page = 0).getValueOrThrow().first().first().id
     val viewModel =
       FeedViewModel(
         application,
@@ -80,7 +77,6 @@ internal inline fun runFeedViewModelTest(crossinline body: suspend FeedViewModel
         instance.profileSearcher,
         feedProvider,
         instance.postProvider,
-        userID,
         onLinkClick = {},
         Disposition.OnThumbnailClickListener.empty
       )

--- a/feature/post-details/src/test/java/br/com/orcinus/orca/feature/postdetails/conversion/TestScope.extensions.kt
+++ b/feature/post-details/src/test/java/br/com/orcinus/orca/feature/postdetails/conversion/TestScope.extensions.kt
@@ -211,6 +211,7 @@ internal class PostDetailsConversionScope(delegate: TestScope) : CoroutineScope 
         authenticator,
         authenticationLock,
         feedProvider,
+        termMuter,
         profileProvider,
         profileSearcher,
         postProvider,

--- a/feature/profile-details/src/main/java/br/com/orcinus/orca/feature/profiledetails/ProfileDetailsViewModel.kt
+++ b/feature/profile-details/src/main/java/br/com/orcinus/orca/feature/profiledetails/ProfileDetailsViewModel.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023–2024 Orcinus
+ * Copyright © 2023–2025 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -24,6 +24,7 @@ import br.com.orcinus.orca.composite.timeline.post.PostPreview
 import br.com.orcinus.orca.composite.timeline.post.figure.gallery.disposition.Disposition
 import br.com.orcinus.orca.composite.timeline.post.toPostPreviewFlow
 import br.com.orcinus.orca.core.feed.profile.ProfileProvider
+import br.com.orcinus.orca.core.feed.profile.getPosts
 import br.com.orcinus.orca.core.feed.profile.post.PostProvider
 import br.com.orcinus.orca.core.feed.profile.type.followable.FollowService
 import br.com.orcinus.orca.ext.coroutines.await
@@ -114,7 +115,7 @@ private constructor(
   @OptIn(ExperimentalCoroutinesApi::class)
   private fun getPostPreviewsAt(index: Int): Flow<List<PostPreview>> {
     return profileFlow.filterNotNull().flatMapConcat { profile ->
-      profile.getPosts(index).flatMapEach(selector = PostPreview::id) { post ->
+      profile.getPosts(index).getValueOrThrow().flatMapEach(selector = PostPreview::id) { post ->
         post.toPostPreviewFlow(colors, onLinkClick, onThumbnailClickListener)
       }
     }

--- a/feature/profile-details/src/test/java/br/com/orcinus/orca/feature/profiledetails/ProfileDetails.Default.extensions.kt
+++ b/feature/profile-details/src/test/java/br/com/orcinus/orca/feature/profiledetails/ProfileDetails.Default.extensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023–2024 Orcinus
+ * Copyright © 2023–2025 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -18,10 +18,9 @@ package br.com.orcinus.orca.feature.profiledetails
 import br.com.orcinus.orca.autos.colors.Colors
 import br.com.orcinus.orca.composite.timeline.text.annotated.toAnnotatedString
 import br.com.orcinus.orca.core.feed.profile.Profile
-import br.com.orcinus.orca.core.feed.profile.post.Post
+import br.com.orcinus.orca.core.feed.profile.getPosts
 import br.com.orcinus.orca.core.sample.feed.profile.SampleProfileProvider
 import br.com.orcinus.orca.core.sample.feed.profile.type.editable.SampleEditableProfile
-import kotlinx.coroutines.flow.Flow
 
 /**
  * Creates a sample [ProfileDetails.Default].
@@ -51,8 +50,8 @@ internal fun ProfileDetails.Default.Companion.createSample(
  */
 internal fun ProfileDetails.Default.Companion.getSampleDelegateProfile(
   profileProvider: SampleProfileProvider
-): Profile {
-  return object : Profile {
+) =
+  object : Profile {
     /**
      * [Profile] to which this one's characteristics (expect for its [id]) and behavior is
      * delegated.
@@ -68,8 +67,5 @@ internal fun ProfileDetails.Default.Companion.getSampleDelegateProfile(
     override val followingCount = delegate.followingCount
     override val uri = delegate.uri
 
-    override suspend fun getPosts(page: Int): Flow<List<Post>> {
-      return delegate.getPosts(page)
-    }
+    override suspend fun onPostsObtainance(page: Int) = delegate.getPosts(page).getValueOrThrow()
   }
-}

--- a/std/func/src/main/java/br/com/orcinus/orca/std/func/monad/Maybe.kt
+++ b/std/func/src/main/java/br/com/orcinus/orca/std/func/monad/Maybe.kt
@@ -36,9 +36,7 @@ package br.com.orcinus.orca.std.func.monad
  * @property value Either a [V] (when successful) or a [Failure] by which the [Exception] is wrapped
  *   (when failed).
  */
-@JvmInline
-value class Maybe<out E : Exception, out V>
-private constructor(@PublishedApi internal val value: Any?) {
+class Maybe<out E : Exception, out V> private constructor(@PublishedApi internal val value: Any?) {
   /** Whether the value has been obtained successfully. */
   val isSuccessful
     get() = !isFailed
@@ -136,6 +134,21 @@ private constructor(@PublishedApi internal val value: Any?) {
 }
 
 /**
+ * Produces a [Maybe] from the successful value of this one and that which has been given.
+ *
+ * @param E [Exception] because of which the value cannot be obtained.
+ * @param V Value resulted from this [Maybe].
+ * @param T Successful value of the given [Maybe].
+ * @param R Successful, combined value.
+ * @param other [Maybe] whose value is transformed into another alongside that of this one.
+ * @param transform Transformation to be applied to both successful values.
+ */
+inline fun <E : Exception, V, T, R> Maybe<E, V>.combine(
+  other: Maybe<E, T>,
+  transform: (V, T) -> R
+) = flatMap { thisValue -> other.map { otherValue -> transform(thisValue, otherValue) } }
+
+/**
  * Transforms each element in the [Iterable] of this [Maybe] and combines the produced [Maybe]s into
  * a single one. That which is returned by this method holds either all successful transformations
  * or the [Exception] thrown by the first failing one.
@@ -157,7 +170,7 @@ inline fun <reified E : Exception, V, T> Maybe<E, Iterable<V>>.onEach(
 
 /**
  * Returns the [Maybe] resulted from the transformation in case it is not a failure; otherwise, the
- * receiver one is cast to `Maybe<E, R>` and returned (which is safe because its successful value is
+ * receiver one is cast to `Maybe<E, T>` and returned (which is safe because its successful value is
  * nonexistent and, thus, unobtainable).
  *
  * @param E [Exception] because of which the value cannot be obtained.
@@ -170,7 +183,7 @@ inline fun <E : Exception, V, T> Maybe<E, V>.flatMap(transform: (V) -> Maybe<E, 
 
 /**
  * Returns the [Maybe] resulted from this one in case this one is not a failure; otherwise, this one
- * is cast to `Maybe<E, R>` and returned (which is safe because its successful value is nonexistent
+ * is cast to `Maybe<E, V>` and returned (which is safe because its successful value is nonexistent
  * and, thus, unobtainable).
  *
  * @param E [Exception] because of which the value cannot be obtained.

--- a/std/func/src/test/java/br/com/orcinus/orca/std/func/monad/MaybeTests.kt
+++ b/std/func/src/test/java/br/com/orcinus/orca/std/func/monad/MaybeTests.kt
@@ -147,4 +147,28 @@ internal class MaybeTests {
       .prop(Maybe<Exception, Int>::unit)
       .isSuccessful()
       .isSameInstanceAs(Unit)
+
+  @Test
+  fun failsWhenCombiningAFailedValueAndASuccessfulOne() =
+    assertThat(Maybe)
+      .failed<_, Any>(exception)
+      .transform("combine") { it.combine(Maybe.successful(0)) { _, _ -> "👩🏻‍💻⛓️‍💥" } }
+      .isFailed()
+      .isSameInstanceAs(exception)
+
+  @Test
+  fun failsWhenCombiningTwoFailedValues() =
+    assertThat(Maybe)
+      .failed<_, Any>(exception)
+      .transform("combine") { it.combine(Maybe.failed<_, Any>(Exception())) { _, _ -> "👤🧱" } }
+      .isFailed()
+      .isSameInstanceAs(exception)
+
+  @Test
+  fun combinesTwoSuccessfulValues() =
+    assertThat(Maybe)
+      .successful<Exception, _>(2)
+      .transform("combine") { it.combine(Maybe.successful(2), Int::times) }
+      .isSuccessful()
+      .isEqualTo(4)
 }


### PR DESCRIPTION
Returns a monad instead of throwing from the [`provide`](https://github.com/orcinusbr/orca-android/blob/d1111712a231f74cf6e4892f474acdb1721c7a47/core/src/main/java/br/com/orcinus/orca/core/feed/FeedProvider.kt#L37) method.