### PR TITLE
Handle `ProfileProvider` errors functionally

### DIFF
--- a/app/src/main/java/br/com/orcinus/orca/app/module/feature/profiledetails/MainProfileDetailsModule.kt
+++ b/app/src/main/java/br/com/orcinus/orca/app/module/feature/profiledetails/MainProfileDetailsModule.kt
@@ -31,6 +31,7 @@ internal class MainProfileDetailsModule(context: Context) :
     lazyInjectionOf { profileProvider },
     lazyInjectionOf {
       MastodonFollowService(
+        context,
         Injector.get<Requester<AuthenticationLock.FailedAuthenticationException>>(),
         profileProvider
       )

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/MastodonProfileProvider.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/MastodonProfileProvider.kt
@@ -37,7 +37,7 @@ internal constructor(private val cache: Cache<Profile>, private val context: Con
     return true
   }
 
-  override suspend fun onProvide(id: String): Flow<Profile> {
+  override suspend fun onProvision(id: String): Flow<Profile> {
     val profile = cache.get(id)
     return flowOf(profile)
   }

--- a/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/type/followable/MastodonFollowService.kt
+++ b/core/mastodon/src/main/java/br/com/orcinus/orca/core/mastodon/feed/profile/type/followable/MastodonFollowService.kt
@@ -15,23 +15,28 @@
 
 package br.com.orcinus.orca.core.mastodon.feed.profile.type.followable
 
+import android.content.Context
 import br.com.orcinus.orca.core.feed.profile.type.followable.Follow
 import br.com.orcinus.orca.core.feed.profile.type.followable.FollowService
 import br.com.orcinus.orca.core.feed.profile.type.followable.FollowableProfile
+import br.com.orcinus.orca.core.mastodon.R
 import br.com.orcinus.orca.core.mastodon.feed.profile.MastodonProfileProvider
 import br.com.orcinus.orca.core.mastodon.instance.requester.Requester
 import br.com.orcinus.orca.core.mastodon.instance.requester.authentication.authenticated
+import br.com.orcinus.orca.platform.autos.i18n.ReadableThrowable
 
 /**
  * [FollowService] which communicates with the Mastodon API in order to toggle a [Follow] status.
  *
+ * @property context [Context] for providing the message of the cause of failures.
  * @property requester [Requester] by which the HTTP requests are sent.
  */
 class MastodonFollowService(
+  private val context: Context,
   private val requester: Requester<*>,
   override val profileProvider: MastodonProfileProvider
 ) : FollowService() {
-  override suspend fun <T : Follow> setFollow(profile: FollowableProfile<T>, follow: T) {
+  override suspend fun <T : Follow> setFollow(profile: FollowableProfile<T>, follow: T) =
     requester
       .authenticated()
       .post({
@@ -50,5 +55,10 @@ class MastodonFollowService(
           }
           .build()
       })
-  }
+      .unit()
+
+  override fun createNonFollowableProfileException(profileID: String) =
+    NonFollowableProfileException(
+      ReadableThrowable(context, R.string.core_mastodon_non_followable_profile_error, profileID)
+    )
 }

--- a/core/mastodon/src/main/res/values-pt-rBR/strings.xml
+++ b/core/mastodon/src/main/res/values-pt-rBR/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright © 2023–2024 Orcinus
+  ~ Copyright © 2023–2025 Orcinus
   ~
   ~ This program is free software: you can redistribute it and/or modify it under the terms of the
   ~ GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -33,6 +33,7 @@
     <string name="core_mastodon_feed_provisioning_error">
         O feed não pode ser carregado porque o usuário não existe.
     </string>
+    <string name="core_mastodon_non_followable_profile_error">%s não pode ser seguido.</string>
     <string name="core_mastodon_nonexistent_profile_error">Este perfil não existe.</string>
     <string name="core_mastodon_share">Compartilhar</string>
     <string name="editing_notification_channel">Edições</string>

--- a/core/mastodon/src/main/res/values/strings.xml
+++ b/core/mastodon/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright © 2023–2024 Orcinus
+  ~ Copyright © 2023–2025 Orcinus
   ~
   ~ This program is free software: you can redistribute it and/or modify it under the terms of the
   ~ GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -33,6 +33,7 @@
     <string name="core_mastodon_feed_provisioning_error">
         Feed cannot be loaded because the user doesn\'t exist.
     </string>
+    <string name="core_mastodon_non_followable_profile_error">%s cannot be followed.</string>
     <string name="core_mastodon_nonexistent_profile_error">This profile doesn\'t exist.</string>
     <string name="core_mastodon_share">Share</string>
     <string name="editing_notification_channel">Edits</string>

--- a/core/sample/src/main/java/br/com/orcinus/orca/core/sample/feed/profile/SampleProfileProvider.kt
+++ b/core/sample/src/main/java/br/com/orcinus/orca/core/sample/feed/profile/SampleProfileProvider.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023–2024 Orcinus
+ * Copyright © 2023–2025 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -20,6 +20,7 @@ import br.com.orcinus.orca.core.feed.profile.ProfileProvider
 import br.com.orcinus.orca.core.sample.feed.profile.composition.Composer
 import br.com.orcinus.orca.core.sample.feed.profile.type.editable.SampleEditableProfile
 import br.com.orcinus.orca.core.sample.feed.profile.type.editable.replacingOnceBy
+import br.com.orcinus.orca.std.func.monad.Maybe
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
@@ -76,13 +77,12 @@ class SampleProfileProvider : ProfileProvider() {
    * @see Composer.id
    */
   @PublishedApi
-  internal fun provideCurrent(id: String): Composer {
+  internal fun provideCurrent(id: String) =
     /*
      * Profiles emitted to SampleProfileProvider's onProvide(String): Flow<Composer>'s flow are
      * obtained through an in-memory, non-blocking lookup.
      */
-    return runBlocking { provide(id).first() as Composer }
-  }
+    runBlocking { provide(id).map { it.first() as Composer } }
 
   /**
    * Adds various [Composer]s.
@@ -101,13 +101,14 @@ class SampleProfileProvider : ProfileProvider() {
    * @throws ProfileProvider.NonexistentProfileException If no [Composer] with such an ID exists.
    * @see Composer.id
    */
-  internal suspend fun update(id: String, update: Composer.() -> Composer) {
+  internal suspend fun update(id: String, update: Composer.() -> Composer) =
     if (contains(id)) {
-      composersFlow.update { profiles ->
-        profiles.replacingOnceBy(update) { profile -> profile.id == id }
-      }
+      Maybe.successful<NonexistentProfileException, _>(
+        composersFlow.update { profiles ->
+          profiles.replacingOnceBy(update) { profile -> profile.id == id }
+        }
+      )
     } else {
-      throw createNonexistentProfileException()
+      Maybe.failed(createNonexistentProfileException())
     }
-  }
 }

--- a/core/sample/src/main/java/br/com/orcinus/orca/core/sample/feed/profile/SampleProfileProvider.kt
+++ b/core/sample/src/main/java/br/com/orcinus/orca/core/sample/feed/profile/SampleProfileProvider.kt
@@ -41,7 +41,7 @@ class SampleProfileProvider : ProfileProvider() {
     return NonexistentProfileException(cause = null)
   }
 
-  override suspend fun onProvide(id: String): Flow<Composer> {
+  override suspend fun onProvision(id: String): Flow<Composer> {
     return composersFlow.mapNotNull { composers ->
       composers.find { composer -> composer.id == id }
     }

--- a/core/sample/src/main/java/br/com/orcinus/orca/core/sample/feed/profile/type/followable/SampleFollowService.kt
+++ b/core/sample/src/main/java/br/com/orcinus/orca/core/sample/feed/profile/type/followable/SampleFollowService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Orcinus
+ * Copyright © 2024–2025 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -22,9 +22,11 @@ import br.com.orcinus.orca.core.sample.feed.profile.SampleProfileProvider
 
 /** [FollowService] that toggles the [Follow] status of a [SampleFollowableProfile] in memory. */
 class SampleFollowService(override val profileProvider: SampleProfileProvider) : FollowService() {
-  override suspend fun <T : Follow> setFollow(profile: FollowableProfile<T>, follow: T) {
+  override suspend fun <T : Follow> setFollow(profile: FollowableProfile<T>, follow: T) =
     profileProvider.update(profile.id) {
       @Suppress("UNCHECKED_CAST") (this as SampleFollowableProfile<Follow>).withFollow(follow)
     }
-  }
+
+  override fun createNonFollowableProfileException(profileID: String) =
+    NonFollowableProfileException(cause = null)
 }

--- a/core/sample/src/main/java/br/com/orcinus/orca/core/sample/instance/SampleInstance.kt
+++ b/core/sample/src/main/java/br/com/orcinus/orca/core/sample/instance/SampleInstance.kt
@@ -225,6 +225,7 @@ private constructor(
       init {
         profileProvider
           .provideCurrent(Actor.Authenticated.sample.id)
+          .getValueOrThrow()
           .compose(Content.sample)
           .on(ZonedDateTime.of(2_003, 10, 8, 8, 0, 0, 0, ZoneId.of("GMT-3")))
           .publish(asOwned())
@@ -269,9 +270,14 @@ private constructor(
             }
           )
           .on(ZonedDateTime.of(2023, 8, 16, 16, 48, 43, 384, ZoneId.of("GMT-3")))
-          .publish(asRepostFrom(profileProvider.provideCurrent(ramboSampleAuthorID).toAuthor()))
+          .publish(
+            asRepostFrom(
+              profileProvider.provideCurrent(ramboSampleAuthorID).getValueOrThrow().toAuthor()
+            )
+          )
         profileProvider
           .provideCurrent(christianSampleAuthorID)
+          .getValueOrThrow()
           .compose(
             Content.from(
               Domain.sample,

--- a/core/src/main/java/br/com/orcinus/orca/core/feed/profile/ProfileProvider.kt
+++ b/core/src/main/java/br/com/orcinus/orca/core/feed/profile/ProfileProvider.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023–2024 Orcinus
+ * Copyright © 2023–2025 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -16,9 +16,10 @@
 package br.com.orcinus.orca.core.feed.profile
 
 import br.com.orcinus.orca.core.InternalCoreApi
+import br.com.orcinus.orca.std.func.monad.Maybe
 import kotlinx.coroutines.flow.Flow
 
-/** Provides a [Profile] through [onProvision]. */
+/** Provides a [Profile] through [provide]. */
 abstract class ProfileProvider @InternalCoreApi constructor() {
   /**
    * [IllegalArgumentException] thrown when a [Profile] that doesn't exist is requested to be
@@ -28,15 +29,17 @@ abstract class ProfileProvider @InternalCoreApi constructor() {
     IllegalArgumentException("This profile doesn't exist.")
 
   /**
-   * Gets the [Profile] identified as [id].
+   * Provides the [Profile] identified as [id].
    *
    * @param id ID of the [Profile] to be provided.
-   * @throws NonexistentProfileException If no [Profile] with such [ID][Profile.id] exists.
    * @see Profile.id
    */
-  suspend fun provide(id: String): Flow<Profile> {
-    return if (contains(id)) onProvision(id) else throw createNonexistentProfileException()
-  }
+  suspend fun provide(id: String) =
+    if (contains(id)) {
+      Maybe.successful<NonexistentProfileException, _>(onProvision(id))
+    } else {
+      Maybe.failed(createNonexistentProfileException())
+    }
 
   /**
    * Whether a [Profile] identified as [id] exists.
@@ -46,7 +49,7 @@ abstract class ProfileProvider @InternalCoreApi constructor() {
   protected abstract suspend fun contains(id: String): Boolean
 
   /**
-   * Gets the [Profile] identified as [id].
+   * Callback called when a [Profile] is requested to be provided.
    *
    * @param id ID of the [Profile] to be provided.
    * @see Profile.id

--- a/core/src/main/java/br/com/orcinus/orca/core/feed/profile/ProfileProvider.kt
+++ b/core/src/main/java/br/com/orcinus/orca/core/feed/profile/ProfileProvider.kt
@@ -18,7 +18,7 @@ package br.com.orcinus.orca.core.feed.profile
 import br.com.orcinus.orca.core.InternalCoreApi
 import kotlinx.coroutines.flow.Flow
 
-/** Provides a [Profile] through [onProvide]. */
+/** Provides a [Profile] through [onProvision]. */
 abstract class ProfileProvider @InternalCoreApi constructor() {
   /**
    * [IllegalArgumentException] thrown when a [Profile] that doesn't exist is requested to be
@@ -35,7 +35,7 @@ abstract class ProfileProvider @InternalCoreApi constructor() {
    * @see Profile.id
    */
   suspend fun provide(id: String): Flow<Profile> {
-    return if (contains(id)) onProvide(id) else throw createNonexistentProfileException()
+    return if (contains(id)) onProvision(id) else throw createNonexistentProfileException()
   }
 
   /**
@@ -51,7 +51,7 @@ abstract class ProfileProvider @InternalCoreApi constructor() {
    * @param id ID of the [Profile] to be provided.
    * @see Profile.id
    */
-  protected abstract suspend fun onProvide(id: String): Flow<Profile>
+  protected abstract suspend fun onProvision(id: String): Flow<Profile>
 
   /** Creates a variant-specific [NonexistentProfileException]. */
   protected abstract fun createNonexistentProfileException(): NonexistentProfileException

--- a/core/src/test/java/br/com/orcinus/orca/core/feed/profile/ProfileProviderTests.kt
+++ b/core/src/test/java/br/com/orcinus/orca/core/feed/profile/ProfileProviderTests.kt
@@ -18,47 +18,43 @@ package br.com.orcinus.orca.core.feed.profile
 import app.cash.turbine.test
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import assertk.assertions.prop
+import assertk.coroutines.assertions.suspendCall
 import br.com.orcinus.orca.core.auth.actor.Actor
 import br.com.orcinus.orca.core.sample.instance.SampleInstance
 import br.com.orcinus.orca.core.sample.test.auth.actor.sample
 import br.com.orcinus.orca.core.sample.test.image.NoOpSampleImageLoader
+import br.com.orcinus.orca.std.func.test.monad.isFailed
+import br.com.orcinus.orca.std.func.test.monad.isSuccessful
 import kotlin.test.Test
-import kotlin.test.assertFailsWith
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.emptyFlow
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.test.runTest
 
 internal class ProfileProviderTests {
   @Test
-  fun `GIVEN a nonexistent profile WHEN requesting it to be provided THEN it throws`() {
-    val provider =
-      object : ProfileProvider() {
-        override suspend fun contains(id: String): Boolean {
-          return false
-        }
-
-        override suspend fun onProvision(id: String): Flow<Profile> {
-          return emptyFlow()
-        }
-
-        override fun createNonexistentProfileException(): NonexistentProfileException {
-          return NonexistentProfileException(cause = null)
-        }
-      }
-    assertFailsWith<ProfileProvider.NonexistentProfileException> {
-      runTest { provider.provide("🫥") }
-    }
+  fun failsWhenANonexistentProfileIsRequestedToBeProvided() = runTest {
+    assertThat(SampleInstance.Builder)
+      .transform("create") { it.create(NoOpSampleImageLoader.Provider) }
+      .prop(SampleInstance.Builder.Empty::build)
+      .prop(SampleInstance::profileProvider)
+      .suspendCall("provide") { it.provide("🫥") }
+      .isFailed()
+      .isInstanceOf<ProfileProvider.NonexistentProfileException>()
   }
 
   @Test
-  fun `GIVEN a profile WHEN requesting it to be provided THEN it's provided`() {
-    val id = Actor.Authenticated.sample.id
-    val provider =
-      SampleInstance.Builder.create(NoOpSampleImageLoader.Provider)
-        .withDefaultProfiles()
-        .build()
-        .profileProvider
-    runTest { provider.provide(id).map { it.id }.test { assertThat(awaitItem()).isEqualTo(id) } }
+  fun provides() = runTest {
+    assertThat(SampleInstance.Builder)
+      .transform("create") { it.create(NoOpSampleImageLoader.Provider) }
+      .prop(SampleInstance.Builder.Empty::withDefaultProfiles)
+      .prop(SampleInstance.Builder.DefaultProfiles::build)
+      .prop(SampleInstance::profileProvider)
+      .suspendCall("provide") { it.provide(Actor.Authenticated.sample.id) }
+      .isSuccessful()
+      .transform("test") {
+        it.test {
+          assertThat(awaitItem()).prop(Profile::id).isEqualTo(Actor.Authenticated.sample.id)
+        }
+      }
   }
 }

--- a/core/src/test/java/br/com/orcinus/orca/core/feed/profile/ProfileProviderTests.kt
+++ b/core/src/test/java/br/com/orcinus/orca/core/feed/profile/ProfileProviderTests.kt
@@ -38,7 +38,7 @@ internal class ProfileProviderTests {
           return false
         }
 
-        override suspend fun onProvide(id: String): Flow<Profile> {
+        override suspend fun onProvision(id: String): Flow<Profile> {
           return emptyFlow()
         }
 

--- a/core/src/test/java/br/com/orcinus/orca/core/feed/profile/type/followable/FollowServiceTests.kt
+++ b/core/src/test/java/br/com/orcinus/orca/core/feed/profile/type/followable/FollowServiceTests.kt
@@ -1,10 +1,29 @@
+/*
+ * Copyright © 2024–2025 Orcinus
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
 package br.com.orcinus.orca.core.feed.profile.type.followable
 
 import assertk.assertThat
 import assertk.assertions.isSameAs
+import assertk.assertions.isSameInstanceAs
+import assertk.coroutines.assertions.suspendCall
 import br.com.orcinus.orca.core.sample.feed.profile.type.followable.SampleFollowableProfile
 import br.com.orcinus.orca.core.sample.instance.SampleInstance
 import br.com.orcinus.orca.core.sample.test.image.NoOpSampleImageLoader
+import br.com.orcinus.orca.std.func.monad.Maybe
+import br.com.orcinus.orca.std.func.test.monad.isFailed
 import kotlin.test.Test
 import kotlinx.coroutines.test.runTest
 
@@ -22,12 +41,46 @@ internal class FollowServiceTests {
       object : FollowService() {
         override val profileProvider = profileProvider
 
-        override suspend fun <T : Follow> setFollow(profile: FollowableProfile<T>, follow: T) {
+        override suspend fun <T : Follow> setFollow(
+          profile: FollowableProfile<T>,
+          follow: T
+        ): Maybe<*, Unit> {
           setFollow = follow
+          return Maybe.successful()
         }
+
+        override fun createNonFollowableProfileException(profileID: String) =
+          NonFollowableProfileException(cause = null)
       }
     runTest { followService.toggle(composer.id) }
     assertThat(setFollow).isSameAs(composer.follow.toggled())
+  }
+
+  @Test
+  fun failsWhenSettingNextStatusAndSettingTheFollowStatusFails() {
+    val profileProvider =
+      SampleInstance.Builder.create(NoOpSampleImageLoader.Provider)
+        .withDefaultProfiles()
+        .build()
+        .profileProvider
+    val profileID = profileProvider.provideCurrent<SampleFollowableProfile<*>>().id
+    val exception = Exception()
+    val followService =
+      object : FollowService() {
+        override val profileProvider = profileProvider
+
+        override suspend fun <T : Follow> setFollow(profile: FollowableProfile<T>, follow: T) =
+          Maybe.failed<_, Unit>(exception)
+
+        override fun createNonFollowableProfileException(profileID: String) =
+          NonFollowableProfileException(cause = null)
+      }
+    runTest {
+      assertThat(followService)
+        .suspendCall("next") { it.next(profileID) }
+        .isFailed()
+        .isSameInstanceAs(exception)
+    }
   }
 
   @Test
@@ -43,9 +96,16 @@ internal class FollowServiceTests {
       object : FollowService() {
         override val profileProvider = profileProvider
 
-        override suspend fun <T : Follow> setFollow(profile: FollowableProfile<T>, follow: T) {
+        override suspend fun <T : Follow> setFollow(
+          profile: FollowableProfile<T>,
+          follow: T
+        ): Maybe<*, Unit> {
           setFollow = follow
+          return Maybe.successful()
         }
+
+        override fun createNonFollowableProfileException(profileID: String) =
+          NonFollowableProfileException(cause = null)
       }
     runTest { followService.next(composer.id) }
     assertThat(setFollow).isSameAs(composer.follow.next())

--- a/feature/profile-details/src/main/java/br/com/orcinus/orca/feature/profiledetails/ProfileDetailsViewModel.kt
+++ b/feature/profile-details/src/main/java/br/com/orcinus/orca/feature/profiledetails/ProfileDetailsViewModel.kt
@@ -66,7 +66,9 @@ private constructor(
 
   @OptIn(ExperimentalCoroutinesApi::class)
   private val profileFlow =
-    profileNotifierFlow.flatMapLatest { profileProvider.provide(id).filterNotNull() }
+    profileNotifierFlow.flatMapLatest {
+      profileProvider.provide(id).getValueOrThrow().filterNotNull()
+    }
 
   private val postsIndexFlow = MutableStateFlow(0)
 

--- a/platform/autos/src/main/java/br/com/orcinus/orca/platform/autos/i18n/ReadableThrowable.kt
+++ b/platform/autos/src/main/java/br/com/orcinus/orca/platform/autos/i18n/ReadableThrowable.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Orcinus
+ * Copyright © 2024–2025 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -47,20 +47,23 @@ import java.util.Locale
  *   If this identifier isn't that of a [String] resource, a [Resources.NotFoundException] will be
  *   thrown when either the default or the localized message is retrieved.
  *
+ * @property formatArgs Format arguments by which placeholders in the obtained [String] are
+ *   replaced.
  * @see message
  * @see getLocalizedMessage
  */
 class ReadableThrowable(
   private val context: Context,
-  @StringRes private val messageResourceID: Int
+  @StringRes private val messageResourceID: Int,
+  private vararg val formatArgs: Any?
 ) : Throwable() {
   override val message
     @Throws(IllegalStateException::class, Resources.NotFoundException::class)
-    get() = context.getDefaultString(messageResourceID)
+    get() = context.getDefaultString(messageResourceID, *formatArgs)
 
   @Throws(Resources.NotFoundException::class)
   override fun getLocalizedMessage(): String {
-    return context.getString(messageResourceID)
+    return context.getString(messageResourceID, *formatArgs)
   }
 
   companion object {
@@ -91,6 +94,7 @@ class ReadableThrowable(
  * Obtains a [String] in the default [Locale].
  *
  * @param resourceID Resource ID of the [String] to be obtained.
+ * @param formatArgs The format arguments that will be used for substitution.
  * @throws IllegalStateException If either creating the [Context] with the default [Locale] returns
  *   `null` or such [Context]'s [Resources] are `null`.
  * @throws Resources.NotFoundException If a [String] identified with the [resourceID] isn't found.
@@ -98,7 +102,7 @@ class ReadableThrowable(
  * @see Context.getResources
  */
 @Throws(IllegalStateException::class, Resources.NotFoundException::class)
-private fun Context.getDefaultString(@StringRes resourceID: Int): String {
+private fun Context.getDefaultString(@StringRes resourceID: Int, vararg formatArgs: Any?): String {
   val locale = Locale.getDefault()
-  return at(locale).getString(resourceID)
+  return at(locale).getString(resourceID, *formatArgs)
 }

--- a/std/func/src/main/java/br/com/orcinus/orca/std/func/monad/Maybe.kt
+++ b/std/func/src/main/java/br/com/orcinus/orca/std/func/monad/Maybe.kt
@@ -18,13 +18,13 @@
 package br.com.orcinus.orca.std.func.monad
 
 /**
- * Class private to the machinery of [Maybe] that allows for distinguishing between a successful
- * value (whose type is whichever _but_ this one) and a failed value (whose type is _exclusively_
- * this one).
+ * Class internal to the machinery of [Maybe] which allows for distinguishing between a successful
+ * value (whose type is whichever _but_ that of this class) and a failed value (whose type is
+ * _exclusively_ that of this class).
  *
  * @property exception [Exception] resulted from trying to obtain a successful value.
  */
-@JvmInline private value class Failure(val exception: Exception)
+@JvmInline @PublishedApi internal value class Failure(val exception: Exception)
 
 /**
  * Monad that holds either a successful value or an [Exception] because of which such value failed
@@ -58,6 +58,17 @@ class Maybe<out E : Exception, out V> private constructor(@PublishedApi internal
    * consumers, functionally indicating to them only that obtaining the value _may_ throw.
    */
   @Suppress("UNCHECKED_CAST") fun unit() = if (value is Unit) this as Maybe<E, Unit> else map {}
+
+  /**
+   * Produces a [Maybe] whose [Exception] is the result of applying the given transformation to that
+   * of this one. Essentially, acts as a [map] for failures instead of successful values.
+   *
+   * @param T Result of the transformation.
+   * @param transform Transformation to be performed on the [Exception] of this [Maybe].
+   */
+  @Suppress("UNCHECKED_CAST")
+  inline fun <T : Exception> failWith(transform: (E) -> T) =
+    if (isFailed) failed(transform((value as Failure).exception as E)) else this as Maybe<T, V>
 
   /**
    * Produces a [Maybe] whose value is the result of applying the given transformation to that of

--- a/std/func/src/test/java/br/com/orcinus/orca/std/func/monad/MaybeTests.kt
+++ b/std/func/src/test/java/br/com/orcinus/orca/std/func/monad/MaybeTests.kt
@@ -17,11 +17,13 @@ package br.com.orcinus.orca.std.func.monad
 
 import assertk.all
 import assertk.assertThat
+import assertk.assertions.cause
 import assertk.assertions.containsExactly
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
 import assertk.assertions.isSameInstanceAs
 import assertk.assertions.isTrue
+import assertk.assertions.isZero
 import assertk.assertions.prop
 import br.com.orcinus.orca.std.func.test.monad.failed
 import br.com.orcinus.orca.std.func.test.monad.isFailed
@@ -171,4 +173,37 @@ internal class MaybeTests {
       .transform("combine") { it.combine(Maybe.successful(2), Int::times) }
       .isSuccessful()
       .isEqualTo(4)
+
+  @Test
+  fun failsWhenMappingAFailedValueToAnotherOne() =
+    assertThat(Maybe)
+      .failed<_, Any>(exception)
+      .transform("map") { it.map { 0 } }
+      .isFailed()
+      .isSameInstanceAs(exception)
+
+  @Test
+  fun mapsASuccessfulValueToAnotherOne() =
+    assertThat(Maybe)
+      .successful<Exception, _>(2)
+      .transform("map") { it.map(2::times) }
+      .isSuccessful()
+      .isEqualTo(4)
+
+  @Test
+  fun failsWithTheTransformedExceptionWhenCallingFailWithOnAFailedValue() =
+    assertThat(Maybe)
+      .failed<_, Any>(exception)
+      .transform("failWith") { it.failWith(::RuntimeException) }
+      .isFailed()
+      .cause()
+      .isSameInstanceAs(exception)
+
+  @Test
+  fun returnsTheSuccessfulValueWhenCallingFailWithOnIt() =
+    assertThat(Maybe)
+      .successful<Exception, _>(0)
+      .transform("failWith") { it.failWith(::RuntimeException) }
+      .isSuccessful()
+      .isZero()
 }


### PR DESCRIPTION
Returns a monad instead of throwing from the [provide](https://github.com/orcinusbr/orca-android/blob/0f0aa03e8fae6d92850b91b8b8d211147d172e21/core/src/main/java/br/com/orcinus/orca/core/feed/profile/ProfileProvider.kt#L37) method.