### PR TITLE
Deprecate `Maybe.onEach` in favor of `Maybe.join`

### DIFF
--- a/std/func/build.gradle.kts
+++ b/std/func/build.gradle.kts
@@ -20,6 +20,8 @@ plugins {
 }
 
 dependencies {
+  implementation(libs.kotlin.reflect)
+
   testImplementation(project(":std:func-test"))
   testImplementation(libs.kotlin.test)
 }

--- a/std/func/src/test/java/br/com/orcinus/orca/std/func/monad/MaybeTests.kt
+++ b/std/func/src/test/java/br/com/orcinus/orca/std/func/monad/MaybeTests.kt
@@ -16,11 +16,13 @@
 package br.com.orcinus.orca.std.func.monad
 
 import assertk.all
+import assertk.assertFailure
 import assertk.assertThat
 import assertk.assertions.cause
 import assertk.assertions.containsExactly
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
+import assertk.assertions.isInstanceOf
 import assertk.assertions.isSameInstanceAs
 import assertk.assertions.isTrue
 import assertk.assertions.isZero
@@ -83,6 +85,16 @@ internal class MaybeTests {
       .transform("onEach") { maybe -> maybe.onEach { n -> Maybe.successful(n) } }
       .isFailed()
       .isSameInstanceAs(exception)
+
+  @Test
+  fun failsWhenJoiningEachElementOfAResultingIterableIntoASingleMaybeAndTheTransformationThrowsAnUnexpectedException() {
+    assertFailure {
+        Maybe.successful<UnsupportedOperationException, _>(listOf(1, 2, 3)).join<_, _, Int> {
+          error("👵🏽")
+        }
+      }
+      .isInstanceOf<AssertionError>()
+  }
 
   @Test
   fun failsWhenJoiningEachElementOfAResultingIterableIntoASingleMaybeAndOneOfThemIsAFailure() =


### PR DESCRIPTION
[`Maybe.onEach`](https://github.com/orcinusbr/orca-android/blob/82fdb21e658c3c309848a4157b58bbb40a6ab00e/std/func/src/main/java/br/com/orcinus/orca/std/func/monad/Maybe.kt#L180) is now named "join" and asserts that each transformation fail only with the specified exception.