### PR TITLE
Throw when joining two maybe monads throws unexptectedly

### DIFF
--- a/std/func/src/test/java/br/com/orcinus/orca/std/func/monad/MaybeTests.kt
+++ b/std/func/src/test/java/br/com/orcinus/orca/std/func/monad/MaybeTests.kt
@@ -93,7 +93,7 @@ internal class MaybeTests {
           error("👵🏽")
         }
       }
-      .isInstanceOf<AssertionError>()
+      .isInstanceOf<UnexpectedFailureException>()
   }
 
   @Test


### PR DESCRIPTION
[`Maybe.join`](https://github.com/orcinusbr/orca-android/blob/55d25089b2c945dce9bed5a8b67cc0fdcc711bc9/std/func/src/main/java/br/com/orcinus/orca/std/func/monad/Maybe.kt#L212) only _asserted_ that an exception, if thrown when transforming elements of a successful iterable, was of the expected type. This meant that it would not be thrown in case JVM runtime assertions were disabled, and also that the return type was `Maybe<Exception, T>` instead of `Maybe<E, T>` (with `E` being the type of the exception "inherited" from the receiver maybe).

Now, it throws an [`UnexpectedFailureException`](https://github.com/orcinusbr/orca-android/blob/55d25089b2c945dce9bed5a8b67cc0fdcc711bc9/std/func/src/main/java/br/com/orcinus/orca/std/func/monad/Maybe.kt#L37) in case such transformations throw a non-`E` exception.