### PR TITLE
Parse out Java version from catalog

### DIFF
--- a/build-src/build.gradle.kts
+++ b/build-src/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023–2024 Orcinus
+ * Copyright © 2023–2025 Orcinus
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -13,16 +13,10 @@
  * not, see https://www.gnu.org/licenses.
  */
 
+import kotlin.io.path.listDirectoryEntries
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-
-/** Key of this TOML-"`key = value`"-formatted [String]. * */
-private val String.tomlKey
-  get() = replace(" ", "").split('=').first()
-
-/** Value of this TOML-"`key = value`"-formatted [String]. * */
-private val String.tomlValue
-  get() = split('=').last().replace('"', ' ').trim()
+import org.tomlj.Toml
 
 plugins {
   alias(libs.plugins.kotlin.jvm) apply false
@@ -34,71 +28,32 @@ plugins {
 allprojects {
   repositories.mavenCentral()
 
-  withJavaVersionString {
-    tasks.withType<KotlinCompile> {
-      compilerOptions.jvmTarget.set(JvmTarget.fromTarget(this@withJavaVersionString))
+  rootDir.parentFile
+    .toPath()
+    .listDirectoryEntries("gradle")
+    .getOrNull(0)
+    ?.resolve("libs.versions.toml")
+    ?.let(Toml::parse)
+    ?.getTable("versions")
+    ?.getString("java")
+    ?.let { javaVersionAsString ->
+      tasks.withType<KotlinCompile> {
+        compilerOptions.jvmTarget.set(JvmTarget.fromTarget(javaVersionAsString))
 
-      java {
-        sourceCompatibility = JavaVersion.toVersion(this@withJavaVersionString)
-        targetCompatibility = JavaVersion.toVersion(this@withJavaVersionString)
+        java {
+          val version = JavaVersion.toVersion(javaVersionAsString)
+          sourceCompatibility = version
+          targetCompatibility = version
+        }
       }
     }
-  }
 }
+
+buildscript { dependencies.classpath(libs.tomlJ) }
 
 gradlePlugin {
   plugins.register(name) {
     id = name
     implementationClass = "br.com.orcinus.orca.plugin.BuildSrcPlugin"
-  }
-}
-
-/**
- * Extracts the Java version [String] from the `libs.versions.toml` [File] and runs the [action]
- * with it.
- *
- * @param action Operation to be performed with the extracted version.
- */
-fun withJavaVersionString(action: String.() -> Unit) {
-  rootDir.parentFile
-    .listFiles { file, name -> file.isDirectory && name == "gradle" }
-    ?.first()
-    ?.listFiles { _, name -> name == "libs.versions.toml" }
-    ?.first()
-    ?.reader()
-    ?.useLines { lines ->
-      lines
-        .dropUntil { it.isTomlTableHeader("versions") }
-        .first { it.tomlKey == "java" }
-        .tomlValue
-        .run(action)
-    }
-}
-
-/**
- * Drops all elements until the [predicate] is satisfied.
- *
- * @param predicate Condition to be met for a given element to not be dropped.
- */
-fun <T> Sequence<T>.dropUntil(predicate: (T) -> Boolean): Sequence<T> {
-  var toDrop = 0
-  filter { element ->
-    predicate(element).also { isMatch ->
-      if (!isMatch) {
-        ++toDrop
-      }
-    }
-  }
-  return drop(toDrop)
-}
-
-/**
- * Returns whether this [String] is a [TOML table header](https://toml.io/en/v1.0.0#table).
- *
- * @param tableName Name of the table to be checked if it's defined in the header.
- */
-fun String.isTomlTableHeader(tableName: String): Boolean {
-  return with(trim()) {
-    startsWith('[') && endsWith(']') && substringAfter('[').substringBefore(']').trim() == tableName
   }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -85,6 +85,7 @@ robolectric = { group = "org.robolectric", name = "robolectric", version = "4.14
 slf4j = { group = "org.slf4j", name = "slf4j-api", version = "2.0.7" }
 spotless = { group = "com.diffplug.spotless", name = "spotless-plugin-gradle", version.ref = "spotless" }
 time4j = { group = "net.time4j", name = "time4j-android", version = "4.8-2021a" }
+tomlJ = { group = "org.tomlj", name = "tomlj", version = "1.1.1" }
 turbine = { group = "app.cash.turbine", name = "turbine", version = "1.2.0" }
 zoomable = { group = "net.engawapg.lib", name = "zoomable", version = "1.6.0-beta2" }
 


### PR DESCRIPTION
Parses the version catalog TOML file with [TomlJ](https://github.com/tomlj/tomlj) instead of extracting the declared Java version manually.